### PR TITLE
PriorKey variable

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -9034,7 +9034,7 @@ void *Script::GetVarType(LPTSTR aVarName)
 		|| !_tcscmp(lower, _T("tab"))) return BIV_Space_Tab;
 	if (!_tcscmp(lower, _T("ahkversion"))) return BIV_AhkVersion;
 	if (!_tcscmp(lower, _T("ahkpath"))) return BIV_AhkPath;
-	if (!_tcscmp(lower, _T("priorkeyevent"))) return BIV_PriorKeyEvent;
+	if (!_tcscmp(lower, _T("priorkey"))) return BIV_PriorKey;
 
 	// Since above didn't return:
 	return (void *)VAR_NORMAL;

--- a/source/script.h
+++ b/source/script.h
@@ -2804,7 +2804,7 @@ VarSizeType BIV_TimeIdlePhysical(LPTSTR aBuf, LPTSTR aVarName);
 VarSizeType BIV_IPAddress(LPTSTR aBuf, LPTSTR aVarName);
 VarSizeType BIV_IsAdmin(LPTSTR aBuf, LPTSTR aVarName);
 VarSizeType BIV_PtrSize(LPTSTR aBuf, LPTSTR aVarName);
-VarSizeType BIV_PriorKeyEvent(LPTSTR aBuf, LPTSTR aVarName);
+VarSizeType BIV_PriorKey(LPTSTR aBuf, LPTSTR aVarName);
 
 
 

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -10859,7 +10859,7 @@ VarSizeType BIV_IconNumber(LPTSTR aBuf, LPTSTR aVarName)
 	return (VarSizeType)_tcslen(UTOA(g_script.mCustomIconNumber, target_buf));
 }
 
-VarSizeType BIV_PriorKeyEvent(LPTSTR aBuf, LPTSTR aVarName)
+VarSizeType BIV_PriorKey(LPTSTR aBuf, LPTSTR aVarName)
 {
 	const int bufSize = 32;
 	if (!aBuf)


### PR DESCRIPTION
Provide access to the prior key event through a new variable A_PriorKey. This allows hotkeys to change their behavior depending on whether another key was pressed inbetween a keydown and a keyup.

For example, the following remaps the AppsKey to the RWin key for use as a modifier, but still sends the AppsKey when it is pressed by itself:

```
AppsKey::Send {Blind}{RWin down}
AppsKey Up::
  if (A_PriorKey = "AppsKey")
    Send {Blind}{Ctrl}{RWin Up}{AppsKey}
  else
    Send {Blind}{RWin Up}
return
```
