### PR TITLE
Add a new #InputGroup directive for controlling which generated inputs get ignored

### DIFF
--- a/source/hook.cpp
+++ b/source/hook.cpp
@@ -147,7 +147,8 @@ inline bool IsIgnored(ULONG_PTR aExtraInfo)
 // such events as true physical events might cause infinite loops or other side-effects in
 // the instance that generated the event.  More review of this is needed if KEY_PHYS_IGNORE
 // events ever need to be treated as true physical events by the instances of the hook that
-// didn't originate them:
+// didn't originate them. UPDATE: The foregoing can now be accomplished using the #InputGroup
+// directive.
 {
 	return aExtraInfo == KEY_IGNORE || aExtraInfo == KEY_PHYS_IGNORE || aExtraInfo == KEY_IGNORE_ALL_EXCEPT_MODIFIER;
 }

--- a/source/keyboard_mouse.cpp
+++ b/source/keyboard_mouse.cpp
@@ -22,6 +22,7 @@ GNU General Public License for more details.
 #include "window.h" // for IsWindowHung()
 
 
+DWORD g_KeyIgnoreSentinel = KEY_IGNORE_DEFAULT;
 
 // Added for v1.0.25.  Search on sPrevEventType for more comments:
 static KeyEventTypes sPrevEventType;

--- a/source/keyboard_mouse.h
+++ b/source/keyboard_mouse.h
@@ -234,10 +234,14 @@ LRESULT CALLBACK PlaybackProc(int aCode, WPARAM wParam, LPARAM lParam);
 // Below uses a pseudo-random value.  It's best that this be constant so that if multiple instances
 // of the app are running, they will all ignore each other's keyboard & mouse events.  Also, a value
 // close to UINT_MAX might be a little better since it's might be less likely to be used as a pointer
-// value by any apps that send keybd events whose ExtraInfo is really a pointer value:
-#define KEY_IGNORE 0xFFC3D44F
+// value by any apps that send keybd events whose ExtraInfo is really a pointer value.
+// See the comments for the #InputGroup directive for details on why KEY_IGNORE is no longer a constant.
+extern DWORD g_KeyIgnoreSentinel;
+#define KEY_IGNORE_DEFAULT 0xFFC3D44F
+#define KEY_IGNORE g_KeyIgnoreSentinel
 #define KEY_PHYS_IGNORE (KEY_IGNORE - 1)  // Same as above but marked as physical for other instances of the hook.
 #define KEY_IGNORE_ALL_EXCEPT_MODIFIER (KEY_IGNORE - 2)  // Non-physical and ignored only if it's not a modifier.
+#define KEY_IGNORE_GROUP_SIZE 3 // Number of values defined above using offsets from KEY_IGNORE
 
 // The default in the below is KEY_IGNORE_ALL_EXCEPT_MODIFIER, which causes standard calls to
 // KeyEvent() to update g_modifiersLR_logical_non_ignored the same way it updates g_modifiersLR_logical.

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -3314,7 +3314,6 @@ inline ResultType Script::IsDirective(LPTSTR aBuf)
 		}
 		return CONDITION_TRUE;
 	}
-
 	if (IS_DIRECTIVE_MATCH(_T("#MenuMaskKey")))
 	{
 		// L38: Allow scripts to specify an alternate "masking" key in place of VK_CONTROL.
@@ -3323,7 +3322,32 @@ inline ResultType Script::IsDirective(LPTSTR aBuf)
 		else
 			return ScriptError(parameter ? ERR_PARAM1_INVALID : ERR_PARAM1_REQUIRED, aBuf);
 	}
+	if (IS_DIRECTIVE_MATCH(_T("#InputGroup")))
+	{
+		// To avoid infinite loops and other side effects, AHK ignores self-generated input events.
+		// It does this by setting a sentinel value in the ExtraInfo field when sending input. In
+		// previous versions, a single sentinel value was used for all scripts, making it impossible
+		// for a script to send input that triggers a hotkey in another script.
+		//
+		// The #InputGroup directive provides a way to change the sentinel, so that each script only
+		// ignores input from the other scripts in the same input group.
+		//
+		// A common use case for this is global key remapping. If script A remaps keys 1, 2, and 3
+		// to X, script B can specify a different #InputGroup and set a hotkey for X that is
+		// triggered by any of the keys remapped by script A.
+		//
+		// The group can be any number from 0 to 65535. The default value is 0.
 
+		if (!parameter)
+			return ScriptError(ERR_PARAM1_REQUIRED, aBuf);
+		
+		int group = ATOI(parameter);
+		if (group < 0 || group > 65535)
+			return ScriptError(ERR_PARAM1_INVALID, aBuf);
+
+		g_KeyIgnoreSentinel = KEY_IGNORE_DEFAULT + (group * KEY_IGNORE_GROUP_SIZE);
+		return CONDITION_TRUE;
+	}
 	if (IS_DIRECTIVE_MATCH(_T("#Warn")))
 	{
 		if (!parameter)


### PR DESCRIPTION
To avoid infinite loops and other side effects, AHK ignores self-generated input events.
It does this by setting a sentinel value in the ExtraInfo field when sending input. In
previous versions, a single sentinel value was used for all scripts, making it impossible
for a script to send input that triggers a hotkey in another script.

The #InputGroup directive provides a way to change the sentinel, so that each script only
ignores input from the other scripts in the same input group.

A common use case for this is global key remapping. If script A remaps keys 1, 2, and 3
to X, script B can specify a different #InputGroup and set a hotkey for X that is
triggered by any of the keys remapped by script A.
