### PR TITLE
ComObjArray - add support for specifying lower bounds

### DIFF
--- a/source/script_com.cpp
+++ b/source/script_com.cpp
@@ -441,7 +441,7 @@ BIF_DECL(BIF_ComObjArray)
 			if (upperBound < lLbound)
 				cElements = 0;
 			else
-				cElements = upperBound - lLbound;
+				cElements = upperBound - lLbound + 1;
 		}
 		else
 		{

--- a/source/script_com.cpp
+++ b/source/script_com.cpp
@@ -428,8 +428,28 @@ BIF_DECL(BIF_ComObjArray)
 	ASSERT(dims <= _countof(bound)); // Prior validation should ensure aParamCount-1 never exceeds 8.
 	for (int i = 0; i < dims; ++i)
 	{
-		bound[i].cElements = (ULONG)TokenToInt64(*aParam[i + 1]);
-		bound[i].lLbound = 0;
+		LONG lLbound = 0;
+		ULONG cElements;
+
+		LPTSTR param = TokenToString(*aParam[i + 1]);
+		TCHAR* delimiter = _tcsstr(param, _T(".."));
+		if (delimiter)
+		{
+			*delimiter = '\0';
+			lLbound = ATOI(param);
+			LONG upperBound = ATOI(delimiter + 2);
+			if (upperBound < lLbound)
+				cElements = 0;
+			else
+				cElements = upperBound - lLbound;
+		}
+		else
+		{
+			cElements = (ULONG)TokenToInt64(*aParam[i + 1]);
+		}
+
+		bound[i].cElements = cElements;
+		bound[i].lLbound = lLbound;
 	}
 	SAFEARRAY *psa = SafeArrayCreate(vt, dims, bound);
 	if (psa && !SafeSetTokenObject(aResultToken, new ComObject((__int64)psa, VT_ARRAY | vt, ComObject::F_OWNVALUE)))

--- a/source/script_com.cpp
+++ b/source/script_com.cpp
@@ -438,10 +438,7 @@ BIF_DECL(BIF_ComObjArray)
 			*delimiter = '\0';
 			lLbound = ATOI(param);
 			LONG upperBound = ATOI(delimiter + 2);
-			if (upperBound < lLbound)
-				cElements = 0;
-			else
-				cElements = upperBound - lLbound + 1;
+			cElements = upperBound - lLbound + 1;
 		}
 		else
 		{


### PR DESCRIPTION
Hi,

I just added a small piece of code which allows to specify lower bounds for SAFEARRAYs created with `ComObjArray()`. Syntax is quite easy and intuitive:

``` ahk
arr := ComObjArray(0xC, "1..5", "4..6", 5, "2..8")
```

As in the example, it might be mixed with the traditional method (specifying element count only). I hope the code is not too bad :)
If the upper bound is lower or equal to the lower bound, right now it silently falls back to 0. Should that be changed? Should an error be thrown?
The methods (`maxIndex()` and `minIndex()`) seem to work pretty fine, setting an element works too. Are there other things to be considered / that would need to be updated?

Regards
maul.esel
