### PR TITLE
more Safearray support

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8159,7 +8159,7 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		{
 			bif = BIF_ComObjArray;
 			min_params = 2;
-			max_params = 9; // up to 8 dimensions
+			max_params = 10000; // no realistic limit, as with Array() function
 		}
 		else if (!_tcsicmp(suffix, _T("Query")))
 		{

--- a/source/script_com.cpp
+++ b/source/script_com.cpp
@@ -431,6 +431,7 @@ BIF_DECL(BIF_ComObjArray)
 		bound[i].lLbound = 0;
 	}
 	SAFEARRAY *psa = SafeArrayCreate(vt, dims, bound);
+	delete[] bound;
 	if (!SafeSetTokenObject(aResultToken, psa ? new ComObject((__int64)psa, VT_ARRAY | vt, ComObject::F_OWNVALUE) : NULL) && psa)
 		SafeArrayDestroy(psa);
 }
@@ -1147,6 +1148,7 @@ ResultType ComObject::SafeArrayInvoke(ExprTokenType &aResultToken, int aFlags, E
 	SafeArrayLock(psa);
 
 	hr = SafeArrayPtrOfIndex(psa, index, &item);
+	delete[] index;
 	if (SUCCEEDED(hr))
 	{
 		if (IS_INVOKE_GET)

--- a/source/script_com.cpp
+++ b/source/script_com.cpp
@@ -1092,6 +1092,23 @@ ResultType ComObject::SafeArrayInvoke(ExprTokenType &aResultToken, int aFlags, E
 				hr = SafeArrayGetUBound(psa, aParamCount > 1 ? (UINT)TokenToInt64(*aParam[1]) : 1, &retval);
 			else if (!_tcsicmp(name, _T("MinIndex")))
 				hr = SafeArrayGetLBound(psa, aParamCount > 1 ? (UINT)TokenToInt64(*aParam[1]) : 1, &retval);
+			else if (!_tcsicmp(name, _T("Count")))
+			{
+				if (aParamCount > 1)
+				{
+					LONG upper, lower;
+					UINT dim = (UINT)TokenToInt64(*aParam[1]);
+					hr = SafeArrayGetUBound(psa, dim, &upper);
+					if (SUCCEEDED(hr))
+					{
+						hr = SafeArrayGetLBound(psa, dim, &lower);
+						if (SUCCEEDED(hr))
+							retval = upper - lower + 1;
+					}
+				}
+				else
+					retval = SafeArrayGetDim(psa);
+			}
 			else
 				hr = DISP_E_UNKNOWNNAME; // Seems slightly better than ignoring the call.
 			if (SUCCEEDED(hr))

--- a/source/script_com.cpp
+++ b/source/script_com.cpp
@@ -423,9 +423,8 @@ BIF_DECL(BIF_ComObjFlags)
 BIF_DECL(BIF_ComObjArray)
 {
 	VARTYPE vt = (VARTYPE)TokenToInt64(*aParam[0]);
-	SAFEARRAYBOUND bound[8]; // Same limit as ComObject::SafeArrayInvoke().
 	int dims = aParamCount - 1;
-	ASSERT(dims <= _countof(bound)); // Prior validation should ensure aParamCount-1 never exceeds 8.
+	SAFEARRAYBOUND* bound = new SAFEARRAYBOUND[dims];
 	for (int i = 0; i < dims; ++i)
 	{
 		bound[i].cElements = (ULONG)TokenToInt64(*aParam[i + 1]);
@@ -1124,9 +1123,9 @@ ResultType ComObject::SafeArrayInvoke(ExprTokenType &aResultToken, int aFlags, E
 	}
 
 	UINT dims = SafeArrayGetDim(psa);
-	LONG index[8];
+	LONG* index = new LONG[dims];
 	// Verify correct number of parameters/dimensions (maximum 8).
-	if (dims > _countof(index) || dims != (IS_INVOKE_SET ? aParamCount - 1 : aParamCount))
+	if (dims != (IS_INVOKE_SET ? aParamCount - 1 : aParamCount))
 	{
 		g->LastError = DISP_E_BADPARAMCOUNT;
 		return OK;

--- a/source/script_com.cpp
+++ b/source/script_com.cpp
@@ -424,14 +424,13 @@ BIF_DECL(BIF_ComObjArray)
 {
 	VARTYPE vt = (VARTYPE)TokenToInt64(*aParam[0]);
 	int dims = aParamCount - 1;
-	SAFEARRAYBOUND* bound = new SAFEARRAYBOUND[dims];
+	SAFEARRAYBOUND* bound = (SAFEARRAYBOUND*)_alloca(dims * sizeof(SAFEARRAYBOUND));
 	for (int i = 0; i < dims; ++i)
 	{
 		bound[i].cElements = (ULONG)TokenToInt64(*aParam[i + 1]);
 		bound[i].lLbound = 0;
 	}
 	SAFEARRAY *psa = SafeArrayCreate(vt, dims, bound);
-	delete[] bound;
 	if (!SafeSetTokenObject(aResultToken, psa ? new ComObject((__int64)psa, VT_ARRAY | vt, ComObject::F_OWNVALUE) : NULL) && psa)
 		SafeArrayDestroy(psa);
 }
@@ -1124,7 +1123,7 @@ ResultType ComObject::SafeArrayInvoke(ExprTokenType &aResultToken, int aFlags, E
 	}
 
 	UINT dims = SafeArrayGetDim(psa);
-	LONG* index = new LONG[dims];
+	LONG* index = (LONG*)_alloca(dims * sizeof(LONG));
 	// Verify correct number of parameters/dimensions (maximum 8).
 	if (dims != (IS_INVOKE_SET ? aParamCount - 1 : aParamCount))
 	{
@@ -1148,7 +1147,6 @@ ResultType ComObject::SafeArrayInvoke(ExprTokenType &aResultToken, int aFlags, E
 	SafeArrayLock(psa);
 
 	hr = SafeArrayPtrOfIndex(psa, index, &item);
-	delete[] index;
 	if (SUCCEEDED(hr))
 	{
 		if (IS_INVOKE_GET)


### PR DESCRIPTION
Hi,

here's another _suggestion_ for extended SAFEARRAY support:
- remove the 8 dimension limit (is there a reason for this that I'm missing?)
- add a `Count()` method which returns either the number of dimensions or the element count in the specified dimension

If both this and #10 would be merged, the later would possibly need to be adjusted.

Regards
maul.esel
