### PR TITLE
Add /RunStdIn

### DIFF
--- a/source/AutoHotkey.cpp
+++ b/source/AutoHotkey.cpp
@@ -88,6 +88,8 @@ int WINAPI _tWinMain (HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmd
 			g_ForceLaunch = true;
 		else if (!_tcsicmp(param, _T("/ErrorStdOut")))
 			g_script.mErrorStdOut = true;
+		else if (!_tcsicmp(param, _T("/RunStdIn")))
+			g_RunStdIn = true;
 #ifndef AUTOHOTKEYSC // i.e. the following switch is recognized only by AutoHotkey.exe (especially since recognizing new switches in compiled scripts can break them, unlike AutoHotkey.exe).
 		else if (!_tcsicmp(param, _T("/iLib"))) // v1.0.47: Build an include-file so that ahk2exe can include library functions called by the script.
 		{
@@ -137,11 +139,12 @@ int WINAPI _tWinMain (HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmd
 		else // since this is not a recognized switch, the end of the [Switches] section has been reached (by design).
 		{
 			switch_processing_is_complete = true;  // No more switches allowed after this point.
-#ifdef AUTOHOTKEYSC
-			--i; // Make the loop process this item again so that it will be treated as a script param.
-#else
-			script_filespec = param;  // The first unrecognized switch must be the script filespec, by design.
+#ifndef AUTOHOTKEYSC
+			if (!g_RunStdIn)
+				script_filespec = param;  // The first unrecognized switch must be the script filespec, by design.
+			else
 #endif
+				--i; // Make the loop process this item again so that it will be treated as a script param.
 		}
 	}
 

--- a/source/globaldata.cpp
+++ b/source/globaldata.cpp
@@ -74,6 +74,7 @@ HHOOK g_MouseHook = NULL;
 HHOOK g_PlaybackHook = NULL;
 bool g_ForceLaunch = false;
 bool g_WinActivateForce = false;
+bool g_RunStdIn = false;
 WarnMode g_Warn_UseUnsetLocal = WARNMODE_OFF;		// Used by #Warn directive.
 WarnMode g_Warn_UseUnsetGlobal = WARNMODE_OFF;		//
 WarnMode g_Warn_UseEnv = WARNMODE_OFF;				//

--- a/source/globaldata.h
+++ b/source/globaldata.h
@@ -70,6 +70,7 @@ extern HHOOK g_MouseHook;
 extern HHOOK g_PlaybackHook;
 extern bool g_ForceLaunch;
 extern bool g_WinActivateForce;
+extern bool g_RunStdIn;
 extern WarnMode g_Warn_UseUnsetLocal;
 extern WarnMode g_Warn_UseUnsetGlobal;
 extern WarnMode g_Warn_UseEnv;


### PR DESCRIPTION
I accepted your invitation.
- New switch: `/RunStdIn`, which loads the script from stdin.
- stdin scripts default to `#SingleInstance Off` and `#NoEnv` (since it makes no sense to limit the number of simultaneous dynamic scripts to 1 and `#NoEnv` is boilerplate present in almost all scripts which would hinder dynamic execution of one-line scripts).
- FileOpen() now supports opening stdin/out/err (actually a side-effect of implementing stdin support in TextIO.cpp but which I expanded anyway due to convenience):
  - `FileOpen("*",  "r")` for stdin
  - `FileOpen("*",  "w")` for stdout
  - `FileOpen("**", "w")` for stderr
- Doubt: Currently BOMs are handled for the standard streams too. Maybe this should be changed (i.e. ignore automatic BOM writing for `FileOpen("*", "w", "UTF-8")`).

As always, I may have broken something. Please let me know in that case.
