### PR TITLE
ControlFocus resets hotstring buffer

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -2648,6 +2648,11 @@ ResultType Line::ControlFocus(LPTSTR aControl, LPTSTR aTitle, LPTSTR aText
 
 	if (SetFocus(control_window))
 	{
+		// Reset hotstring buffer, so that a hotkey bound to ControlFocus
+		// works the same as pressing TAB or Shift-TAB
+		*g_HSBuf = '\0';
+		g_HSBufLength = 0;
+		
 		g_ErrorLevel->Assign(ERRORLEVEL_NONE); // Indicate success.
 		DoControlDelay;
 	}


### PR DESCRIPTION
### Summary

Fixed hotstring issue when using hotkeys to set keyboard focus to another control.
### Description

Consider a hotkey that focuses a certain control, and some hostring **::aa::Foo**

If user presses "a", then uses the hotkey to move focus to an input field and types "A ", the hotstring is triggered because the first "a" was unintendedly left in the buffer.

The default case should be (IMO) that hotstring buffer is cleared on every focus change, to match the behavior when pressing tab or clicking on another control.
