### PR TITLE
Fixing "Image Has Safe Exception Handlers: No (/SAFESEH:NO)"

### DIFF
--- a/AutoHotkeyx.vcxproj
+++ b/AutoHotkeyx.vcxproj
@@ -282,6 +282,9 @@
     <ClCompile>
       <TreatWarningAsError Condition="!$(ConfigDebug)">true</TreatWarningAsError>
     </ClCompile>
+    <Link>
+      <ImageHasSafeExceptionHandlers Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ImageHasSafeExceptionHandlers>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <CustomBuild Include="source\lib\win2kcompat.asm">


### PR DESCRIPTION
Project -> properties -> Configuration Properties -> Linker -> Advanced "Image Has Safe Exception Handlers: No (/SAFESEH:NO) because opening the solution fresh and building it with vs 2013 update 5 gave me the output "Unable to generate SAFESEH image".