### PR TITLE
Adding check to avoid instr returning 1 for blank or object needle.

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -11566,7 +11566,8 @@ BIF_DECL(BIF_InStr)
 	LPTSTR haystack = ParamIndexToString(0, _f_number_buf, (size_t *)&haystack_length);
 	size_t needle_length;
 	LPTSTR needle = ParamIndexToString(1, needle_buf, &needle_length);
-	
+	if (*needle == NULL)  // avoid instr(str, "") and (eg) instr(str, []) returning 1.
+		_f_return_i(0);
 	// v1.0.43.03: Rather than adding a third value to the CaseSensitive parameter, it seems better to
 	// obey StringCaseSense because:
 	// 1) It matches the behavior of the equal operator (=) in expressions.

--- a/source/util.cpp
+++ b/source/util.cpp
@@ -566,10 +566,12 @@ LPTSTR tcsrstr(LPTSTR aStr, size_t aStr_length, LPCTSTR aPattern, StringCaseSens
 {
 	if (aOccurrence < 1)
 		return NULL;
-	if (!*aPattern)
-		// The empty string is found in every string, and since we're searching from the right, return
-		// the position of the zero terminator to indicate the situation:
-		return aStr + aStr_length;
+	// Currently the only calling function is already doing the below check, hence it is redundant.
+	// Future callers should consider how to handle the case where (!*aPattern) == true.
+	//if (!*aPattern)
+	//	// The empty string is found in every string, and since we're searching from the right, return
+	//	// the position of the zero terminator to indicate the situation:
+	//	return aStr + aStr_length;
 
 	size_t aPattern_length = _tcslen(aPattern);
 	TCHAR aPattern_last_char = aPattern[aPattern_length - 1];


### PR DESCRIPTION
Currently `instr(str,"")` and (eg) `instr(str,[])` returns `1`.