### PR TITLE
Math functions Min/Max

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8354,6 +8354,11 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 2;
 		max_params = 2;
 	}
+	else if (!_tcsicmp(func_name, _T("Min")) || !_tcsicmp(func_name, _T("Max")))
+	{
+		bif = BIF_MinMax;
+		max_params = 10000; // An arbitrarily high limit that will never realistically be reached.
+	}
 	else if (!_tcsicmp(func_name, _T("Abs")))
 		bif = BIF_Abs;
 	else if (!_tcsicmp(func_name, _T("Sin")))

--- a/source/script.h
+++ b/source/script.h
@@ -3235,6 +3235,7 @@ BIF_DECL(BIF_ASinACos);
 BIF_DECL(BIF_ATan);
 BIF_DECL(BIF_Exp);
 BIF_DECL(BIF_SqrtLogLn);
+BIF_DECL(BIF_MinMax);
 
 BIF_DECL(BIF_OnMessage);
 BIF_DECL(BIF_OnExitOrClipboard);


### PR DESCRIPTION
These functions ~~and their Transform counterparts~~ are used to determine the lowest or highest value of several numeric input values. ~~While Transform only supports two input values,~~ the functions accept ~~more than two~~ one or more input values (up to 10000 if all parameters are explicitly specified, or quasi-infinite if an array is passed as a variadic parameter). If one the input values is non-numeric, a blank value is returned. The return value inherits the number type (integer or float) of the highest/lowest input value.

To the best of my knowledge, I have tried to keep the code performant and small. Perhaps it can still be improved. There should be no breaking changes, since already existing functions of the same name overwrite the built-in ones.

I think it is a great convenience for the user to use these functions instead of using the ternary operator (or a loop for more than two values).

If you are interested in merging, I will write the corresponding documentation.

Examples:
```autohotkey
MsgBox, % Min(-2, 2.11) ; -2
MsgBox, % Max([1, 2, 3]*) ; 3
MsgBox, % Max("abc", 1) ; blank value
; Transform, test, Min, 1.324, 100
; MsgBox, % test ; 1.324000
; Transform, test, Max, -43, % False
; MsgBox, % test ; 0
```