### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/source/WinGroup.cpp
+++ b/source/WinGroup.cpp
@@ -111,7 +111,7 @@ ResultType WinGroup::CloseAndGoToNext(bool aStartWithMostRecent)
 	// Even if it's NULL, don't return since the legacy behavior is to continue on to the final part below.
 
 	WindowSpec *win_spec = IsMember(fore_win, *g);
-	if (   (mIsModeActivate && win_spec) || (!mIsModeActivate && !win_spec)   )
+	if (   mIsModeActivate && win_spec!=nullptr)
 	{
 		// If the user is using a GroupActivate hotkey, we don't want to close
 		// the foreground window if it's not a member of the group.  Conversely,

--- a/source/keyboard_mouse.cpp
+++ b/source/keyboard_mouse.cpp
@@ -2708,8 +2708,10 @@ ResultType ExpandEventArray()
 		memcpy(new_mem, sEventSI, sEventCount * event_size);
 	if (sMaxEvents > (sSendMode == SM_INPUT ? MAX_INITIAL_EVENTS_SI : MAX_INITIAL_EVENTS_PB))
 		free(sEventSI); // Previous block was malloc'd vs. _alloc'd, so free it.
-	if (sAbortArraySend)
+	if (sAbortArraySend) {
+		free(new_mem);
 		return FAIL;
+	}
 	sEventSI = (LPINPUT)new_mem; // Note that sEventSI and sEventPB are different views of the same variable.
 	sMaxEvents *= EVENT_EXPANSION_MULTIPLIER;
 	return OK;

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -12297,6 +12297,7 @@ ResultType Line::ExecUntil(ExecUntilMode aMode, ExprTokenType *aResultToken, Lin
 				if ( !(sDerefBuf = tmalloc(sDerefBufSize)) )
 				{
 					sDerefBufSize = 0;
+					delete token;
 					return line->LineError(ERR_OUTOFMEM);
 				}
 			}

--- a/source/script.h
+++ b/source/script.h
@@ -1984,7 +1984,7 @@ public:
 		// OK: Both are absent, which is the signal to use the current position.
 		// OK: Both are present (that they are numeric is validated elsewhere).
 		// FAIL: One is absent but the other is present.
-		return (!*aX && !*aY) || (*aX && *aY) ? OK : FAIL;
+		return (*aX == *aY) ? OK : FAIL;
 	}
 
 	bool IsExemptFromSuspend()


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V728](https://www.viva64.com/en/w/v728/) An excessive check can be simplified. The '(A && B) || (!A && !B)' expression is equivalent to the 'bool(A) == bool(B)' expression. wingroup.cpp 114
[V773](https://www.viva64.com/en/w/v773/) The function was exited without releasing the 'new_mem' pointer. A memory leak is possible. keyboard_mouse.cpp 2712
[V773](https://www.viva64.com/en/w/v773/) The function was exited without releasing the 'token' pointer. A memory leak is possible. script.cpp 12300
[V728](https://www.viva64.com/en/w/v728/) An excessive check can be simplified. The '(A && B) || (!A && !B)' expression is equivalent to the 'bool(A) == bool(B)' expression. script.h 1987