### PR TITLE
Fix bug in ListVars for alias variable containing an object

### DIFF
--- a/source/Debugger.cpp
+++ b/source/Debugger.cpp
@@ -2644,10 +2644,10 @@ void Debugger::PropertyWriter::EndProperty(DebugCookie aCookie)
 
 // Helper for Var::ToText().
 
-LPTSTR Var::ObjectToText(LPTSTR aBuf, int aBufSize)
+LPTSTR Var::ObjectToText(LPTSTR aName, LPTSTR aBuf, int aBufSize)
 {
 	LPTSTR aBuf_orig = aBuf;
-	aBuf += sntprintf(aBuf, aBufSize, _T("%s: %s object"), mName, mObject->Type());
+	aBuf += sntprintf(aBuf, aBufSize, _T("%s: %s object"), aName, mObject->Type());
 	if (ComObject *cobj = dynamic_cast<ComObject *>(mObject))
 		aBuf += sntprintf(aBuf, BUF_SPACE_REMAINING, _T(" {wrapper: 0x%IX, vt: 0x%04hX, value: 0x%I64X}"), cobj, cobj->mVarType, cobj->mVal64);
 	else

--- a/source/var.h
+++ b/source/var.h
@@ -531,7 +531,7 @@ public:
 	#define DISPLAY_FUNC_ERROR 2
 	static ResultType ValidateName(LPCTSTR aName, int aDisplayError = DISPLAY_VAR_ERROR);
 
-	LPTSTR ObjectToText(LPTSTR aBuf, int aBufSize);
+	LPTSTR ObjectToText(LPTSTR aName, LPTSTR aBuf, int aBufSize);
 	LPTSTR ToText(LPTSTR aBuf, int aBufSize, bool aAppendNewline)
 	// Caller must ensure that Type() == VAR_NORMAL.
 	// aBufSize is an int so that any negative values passed in from caller are not lost.
@@ -546,7 +546,7 @@ public:
 		var.UpdateContents(); // Update mContents and mLength for use below.
 		LPTSTR aBuf_orig = aBuf;
 		if (var.IsObject())
-			aBuf = ObjectToText(aBuf, aBufSize);
+			aBuf = var.ObjectToText(this->mName, aBuf, aBufSize);
 		else
 			aBuf += sntprintf(aBuf, BUF_SPACE_REMAINING, _T("%s[%Iu of %Iu]: %-1.60s%s"), mName // mName not var.mName (see comment above).
 				, var._CharLength(), var._CharCapacity() ? (var._CharCapacity() - 1) : 0  // Use -1 since it makes more sense to exclude the terminator.


### PR DESCRIPTION
Example:
fun(var:=[])
fun(ByRef v){
ListVars
}