### PR TITLE
Changing Line::PerformLoopFor to throw exceptions

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -10710,8 +10710,10 @@ ResultType Line::PerformLoopFor(ResultToken *aResultToken, bool &aContinueMainLo
 		// The following would need to be checked if the "non-expression" optimization
 		// was enabled for ACT_FOR (currently it does not improve performance):
 		//if (  !(ARGVARRAW3 && (param_tokens[2].object = ARGVARRAW3->ToObject()))  )
-			// The expression didn't resolve to an object, so no enumerator is available.
-			return OK;
+		
+		// The expression didn't resolve to an object, so no enumerator is available, throw to indicate the problem..
+		LineError(ERR_NO_OBJECT);
+		return FAIL;
 		// Arg was a simple var ref, so not evaluated as an expression, but it contained an object.
 		//param_tokens[2].symbol = SYM_OBJECT;
 		//param_tokens[2].object->AddRef();
@@ -10743,9 +10745,11 @@ ResultType Line::PerformLoopFor(ResultToken *aResultToken, bool &aContinueMainLo
 	if (result == FAIL || result == EARLY_EXIT)
 		return result;
 
-	if (enum_token.symbol != SYM_OBJECT)
-		// The object didn't return an enumerator, so nothing more we can do.
-		return OK;
+	if (enum_token.symbol != SYM_OBJECT) {
+		// The object didn't return an enumerator, throw to indicate the problem.
+		LineError(ERR_NO_MEMBER, FAIL, _T("Object has no enumerator.")); // Extra info added for clarity.
+		return FAIL;
+	}
 
 	// "Localize" the loop variables.
 	VarBkp var_bkp[2];


### PR DESCRIPTION
Changing `Line::PerformLoopFor` to throw exceptions when `expression` doesn't resolve to an object or when the object doesn't have an enumerator.

Example,
```autohotkey
for k in func("abs") 
```
causes,

> Error:  Unknown property or method.
>
>Specifically: Object has no enumerator.

and

```autohotkey
for k in "str"
```

causes,

> Error:  No object to invoke.

The previous behaviour can be replicated using `try`. I will attempt to match the change in the documentation.