### PR TITLE
Adding option to BIF_Format, enabling placeholders to be used for more than one index.

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -13144,7 +13144,7 @@ BIF_DECL(BIF_Format)
 	int recursive_iteration;		// Zero-based iteration counter, ensures parameter x+y*recursive_iteration*sign is used. If x is not specified, last_param + 1 is used as x. 
 	int step_size;					// Temporarily hold the value of "y"
 	bool placeholder_is_recursive;	// Temporarily indicates if considering a recursive placeholder.
-	bool param_out_of_bounds;		// Indicates x+y*recursive_iteration*sign > aParamCount or less than 1, also catches {0:fmt}.
+	bool param_out_of_bounds;		// Indicates x+y*recursive_iteration*sign > aParamCount or less than 1.
 	
 	for (;;)
 	{
@@ -13167,8 +13167,6 @@ BIF_DECL(BIF_Format)
 			{
 				if (recurse) // fmt has placeholders on the form: {+y},{x+y},{x+y:...}
 				{
-					if (param_out_of_bounds) // breaks on the first valid recursive placeholder which causes a param value outside of 1...aParamCount.
-						break;
 					recursive_iteration++;
 					lit = cp = fmt;	// repeat the parsing of the format string, fmt.
 					continue;
@@ -13216,9 +13214,9 @@ BIF_DECL(BIF_Format)
 				placeholder_is_recursive = true; // Does not need to be set to false below if placeholder is found to be literal. Setting it to false as above is sufficient.
 				++recurse; // this is decremented below if placeholder is found to not be valid.
 			}
-			
+
 			param_out_of_bounds = false;
-			if (param >= aParamCount || param < 1) // Invalid parameter index.
+			if (param >= aParamCount || param < 1) // Invalid parameter index. I.e, "{0}" or something like "{" 0x80000000+0 "}" or "{x-y}"
 			{
 				if (placeholder_is_recursive)
 					param_out_of_bounds = true; // need to continue parsing to ensure the placeholder is not a literal, eg, {x+y:john}


### PR DESCRIPTION
Hello :wave:

Adding option to `BIF_Format`, enabling placeholders to be used for more than one index.

New (optional) syntax for placeholders: `{x+y:fmt}`, `{x-y:fmt}`, uses the placeholder for indices `x+y*k`, where `k = 0,1,...`. For example, `{1+1:fmt} ` formats each one of the input values, according to `fmt`.

# Examples
```autohotkey
; Simple example
msgbox format("{3-1} ", "a", "b", "c") ; c b a

; Table manipulation.
table := "
(
1	2	ab
4	5	cd
7	8	ef
10	11	gh
)"
arr := strsplit(table,["`t","`n"])

text := "View the array.`n`n"
msgbox text . format("{1+1}`n", arr*)

text := "Remove second column, swap first and third column.`n`n"
msgbox text . format("{3+3}`t{1+3}`n", arr*)

text := "Remove first column, swap second and third column. Turn up-side-down.`n`n"
l := arr.length()
msgbox text . format("{" l "-3}`t{" l-1 "-3}`n", arr*)		; Equivalent to: "{12-3}`t{11-3}`n"

; Random example

text := "Print the array backwards, swapping every other item.`n`n"
msgbox text . format("{11-2} {12-2}`t",arr*)
``` 

_Formatting_ is stopped on the first placeholder which causes `x+y*k` to be outside the range `1...aParamCount`, this avoids printing a literal placeholder containing a `+` or `-`, this is assumed to never be wanted. So you cannot print `{10+1}` even if less than `10` values were passed, in contrast to `{10}`. Limitation or feature, I consider it a feature, example, `format("{1} {10+1} {2}",1,2)` compare to `format("{1} {10} {2}",1,2)`.  Partial _work around_ `format("{1} {{}10+1} {2}",1,2)`.

Note: omitting _index_, eg, `{+y}`, is permitted but might not be generally useful or intuitive. However, detecting it as literal doesn't seem worth the bother, it does no harm as is.

Side effect: Specifying _index_ `0`, eg, `format("{0:U}a")` no longer formats the format string.

# Pros and cons.

Enables versatile and easy to use '`strJoin`' functionality, while still keeping the function simple and with small amount of added code. The repeated parsing is inefficient. `arr.format(opt)` would be more efficient than `format(...,arr*)`.

Thanks for reading.
