### PR TITLE
Throw error when property is called

### DIFF
--- a/source/script.h
+++ b/source/script.h
@@ -221,6 +221,7 @@ enum CommandIDs {CONTROL_ID_FIRST = IDCANCEL + 1
 #define ERR_NO_OBJECT _T("No object to invoke.")
 #define ERR_UNKNOWN_PROPERTY _T("Unknown property.")
 #define ERR_UNKNOWN_METHOD _T("Unknown method.")
+#define ERR_PROPERTY_CALL _T("Cannot call a property")
 #define ERR_NO_GUI _T("No default GUI.")
 #define ERR_NO_STATUSBAR _T("No StatusBar.")
 #define ERR_NO_LISTVIEW _T("No ListView.")

--- a/source/script_object.cpp
+++ b/source/script_object.cpp
@@ -417,6 +417,12 @@ ResultType STDMETHODCALLTYPE Object::Invoke(
 			// about 25% and typeid()== by about 20%.  We can safely assume that the vtable pointer is
 			// stored at the beginning of the object even though it isn't guaranteed by the C++ standard,
 			// since COM fundamentally requires it:  http://msdn.microsoft.com/en-us/library/dd757710
+
+			if (IS_INVOKE_CALL)
+			{
+				_o_throw(ERR_PROPERTY_CALL);
+			}
+
 			prop = (Property *)field->object;
 			prop_field = field;
 			if (IS_INVOKE_SET ? prop->CanSet() : prop->CanGet())


### PR DESCRIPTION
From what I have seen in the source obj.property() leads to the properties get code being called.
However I think that it should rather throw an error.
Also I want to ask if this coding style is the correct way to do this.