### PR TITLE
Changing BIF_Integer to handle scientific notation (string).

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -14166,8 +14166,10 @@ BIF_DECL(BIF_FloorCeil)
 
 BIF_DECL(BIF_Integer)
 {
-	Throw_if_Param_NaN(0);
-	_f_return_i(ParamIndexToInt64(0));
+	ExprTokenType token;
+	if (ParamIndexToNumber(0, token))
+		_f_return_i(token.symbol == SYM_INTEGER ? token.value_int64 : token.value_double);
+	_f_throw(ERR_TYPE_MISMATCH);
 }
 
 


### PR DESCRIPTION
Hello :wave: .

Issue example,
```autohotkey
Value := "1234e-2"
msgbox integer(Value)

Value := "12.34e2"
msgbox integer(Value)
```

Note, from the documentation,
>Any fractional part of Value is dropped, equivalent to `Value < 0 ? Ceil(Value) : Floor(Value)`

It is currently not true, example

```autohotkey
Value := "9223372036854775807.0"
msgbox Value < 0 ? Ceil(Value) : Floor(Value)
msgbox integer(Value)
```

It is true in this branch, however, if it is desired that
```autohotkey
integer("9223372036854775807.0") == 9223372036854775807
```
be true, another fix is needed, then also consider that eg integer(`"922337203685477580.7e1")` should probably work the same, which implies more work, I guess.