### PR TITLE
Changing details of scientific notation handling.

### DIFF
--- a/source/util.cpp
+++ b/source/util.cpp
@@ -963,7 +963,7 @@ __int64 tcstoi64_o(LPCTSTR buf, LPCTSTR *endptr, int base)
 		// Check for scientific notation and float.
 		// Doing it here because, presumably, most often *p == 0, and the calls to _tcschr are avoided.
 		LPCTSTR e_char = 0;
-		if (*p && *p == '.' || ((e_char = _tcschr(p, 'e')) || (e_char = _tcschr(p, 'E'))))
+		if ( *p && ( *p == '.' || (e_char = _tcschr(p, 'e')) || (e_char = _tcschr(p, 'E')) ) )
 		{
 			BOOL is_float = TRUE;
 			if (e_char) // implies no '.', so it is an integer in sci. notation, eg, 1e3 or a float like 1e-3.


### PR DESCRIPTION
Hello :wave: 

This supersedes #100 .

### New

Numbers written in scientific notation produces the same result as the AHK expression `x*10**y`, where `y` is an integer. Consequently, if

* `x` is an integer and `y` is greater or equal to zero, the result is an integer. (`-0` equals `0`)
* `x` is a float, the result is float.

Further, any _float string_ converted to an integer produces the same number as if the float was written as a _pure float_ in the script source code and converted, eg,

```autohotkey
integer("9223372036854775807.0") == integer(9223372036854775807.0)
```
is `true`.

__Known limitation:__ If a positive exponenent (`y`) is so large that it _wraps around_ (__int64) to become negative that is not detected and it is considered an integer, but the corresponding ahk expression `x*10**y` will produce a float. Similarily, if a negative exponent _wraps around_ to become positive, the number in scinentific notation produces a float and the AHK expression an integer. That is scientific notation has the same limitation as the expression `x*10**y` but they are _swapped_.

The problem can only be seen if `y > 9223372036854775807` (in `xEy` or `x*10**y`). Maybe integers written as `>9223372036854775807` should be detected as errors? For example,
```autohotkey
a:=9999999999999999999999999999999999999999999999999999999999999999
```
is valid but is unlikely to be written for the purpose of producing `-1`.

Cheers.