### PR TITLE
Adding CaseSensitive parameter to StrReplace.

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -227,7 +227,7 @@ FuncEntry g_BIF[] =
 	BIF1(StrLen, 1, 1),
 	BIFn(StrLower, 1, 2, BIF_StrCase),
 	BIFn(StrPut, 1, 4, BIF_StrGetPut),
-	BIF1(StrReplace, 2, 5, {4}),
+	BIF1(StrReplace, 2, 6, {5}),
 	BIF1(StrSplit, 1, 4),
 	BIFn(StrUpper, 1, 2, BIF_StrCase),
 	BIF1(SubStr, 2, 3),


### PR DESCRIPTION
Hello :wave: 

New:

```autohotkey
ReplacedStr := StrReplace(Haystack, SearchText [, ReplaceText, CaseSensitive := false, OutputVarCount, Limit := -1])
```

Implementation is copied from `BIF_InStr`.

Reason for change: convenience.