### PR TITLE
Removing the <> operator.

### DIFF
--- a/source/defines.h
+++ b/source/defines.h
@@ -180,7 +180,7 @@ enum SymbolType // For use with ExpandExpression() and IsNumeric().
 #define IS_SHORT_CIRCUIT_OPERATOR(symbol) ((symbol) <= SYM_AND && (symbol) >= SYM_IFF_THEN) // Excludes SYM_IFF_ELSE, which acts as a simple jump after the THEN branch is evaluated.
 #define SYM_USES_CIRCUIT_TOKEN(symbol) ((symbol) <= SYM_AND && (symbol) >= SYM_IFF_ELSE)
 	, SYM_IS, SYM_IN, SYM_CONTAINS
-	, SYM_EQUAL, SYM_EQUALCASE, SYM_NOTEQUAL // =, ==, <> ... Keep this in sync with IS_RELATIONAL_OPERATOR() below.
+	, SYM_EQUAL, SYM_EQUALCASE, SYM_NOTEQUAL // =, ==, ... Keep this in sync with IS_RELATIONAL_OPERATOR() below.
 	, SYM_GT, SYM_LT, SYM_GTOE, SYM_LTOE  // >, <, >=, <= ... Keep this in sync with IS_RELATIONAL_OPERATOR() below.
 #define IS_RELATIONAL_OPERATOR(symbol) (symbol >= SYM_EQUAL && symbol <= SYM_LTOE)
 	, SYM_REGEXMATCH // ~=, equivalent to a RegExMatch call in two-parameter mode.

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8211,7 +8211,7 @@ ResultType Line::ExpressionToPostfix(ArgStruct &aArg)
 					}
 					break;
 				case '!':
-					if (cp1 == '=') // i.e. != is synonymous with <>, which is also already supported by legacy.
+					if (cp1 == '=') // i.e. !=
 					{
 						++cp; // An additional increment to have loop skip over the '=' too.
 						this_infix_item.symbol = SYM_NOTEQUAL;
@@ -8331,10 +8331,6 @@ ResultType Line::ExpressionToPostfix(ArgStruct &aArg)
 					case '=':
 						++cp; // An additional increment to have loop skip over the '=' too.
 						this_infix_item.symbol = SYM_LTOE;
-						break;
-					case '>':
-						++cp; // An additional increment to have loop skip over the '>' too.
-						this_infix_item.symbol = SYM_NOTEQUAL;
 						break;
 					case '<':
 						if (cp[2] == '=')


### PR DESCRIPTION
Hello :wave:.
Example,
```autohotkey
(0<>0) ; Load-time error
```

Reason:
There is no obvious reason why both `!=` and `<>` are needed, keeping `!=` because it seems prefered by most. 

If it wasn't available, we wouldn't add it for the same reasons we wouldn't add, eg, `!<` meaning `>=`

Cheers.