### PR TITLE
Adding function StrCompare and disabling string compairsion of operators: < <= > >=

### DIFF
--- a/source/defines.h
+++ b/source/defines.h
@@ -180,7 +180,7 @@ enum SymbolType // For use with ExpandExpression() and IsNumeric().
 #define IS_SHORT_CIRCUIT_OPERATOR(symbol) ((symbol) <= SYM_AND && (symbol) >= SYM_IFF_THEN) // Excludes SYM_IFF_ELSE, which acts as a simple jump after the THEN branch is evaluated.
 #define SYM_USES_CIRCUIT_TOKEN(symbol) ((symbol) <= SYM_AND && (symbol) >= SYM_IFF_ELSE)
 	, SYM_IS, SYM_IN, SYM_CONTAINS
-	, SYM_EQUAL, SYM_EQUALCASE, SYM_NOTEQUAL // =, ==, <> ... Keep this in sync with IS_RELATIONAL_OPERATOR() below.
+	, SYM_EQUAL, SYM_EQUALCASE, SYM_NOTEQUAL, SYM_NOTEQUALCASE // =, ==, <> and !=, !==... Keep this in sync with IS_RELATIONAL_OPERATOR() below.
 	, SYM_GT, SYM_LT, SYM_GTOE, SYM_LTOE  // >, <, >=, <= ... Keep this in sync with IS_RELATIONAL_OPERATOR() below.
 #define IS_RELATIONAL_OPERATOR(symbol) (symbol >= SYM_EQUAL && symbol <= SYM_LTOE)
 	, SYM_REGEXMATCH // ~=, equivalent to a RegExMatch call in two-parameter mode.

--- a/source/defines.h
+++ b/source/defines.h
@@ -141,7 +141,6 @@ enum ToggleValueType {TOGGLE_INVALID = 0, TOGGLED_ON, TOGGLED_OFF, ALWAYS_ON, AL
 	, TOGGLE_MOUSEMOVE, TOGGLE_MOUSEMOVEOFF};
 
 // Some things (such as ListView sorting) rely on SCS_INSENSITIVE being zero.
-// In addition, BIF_InStr relies on SCS_SENSITIVE being 1:
 enum StringCaseSenseType {SCS_INSENSITIVE, SCS_SENSITIVE, SCS_INSENSITIVE_LOCALE, SCS_INSENSITIVE_LOGICAL, SCS_INVALID};
 
 enum SymbolType // For use with ExpandExpression() and IsNumeric().
@@ -181,6 +180,7 @@ enum SymbolType // For use with ExpandExpression() and IsNumeric().
 #define SYM_USES_CIRCUIT_TOKEN(symbol) ((symbol) <= SYM_AND && (symbol) >= SYM_IFF_ELSE)
 	, SYM_IS, SYM_IN, SYM_CONTAINS
 	, SYM_EQUAL, SYM_EQUALCASE, SYM_NOTEQUAL, SYM_NOTEQUALCASE // =, ==, <> and !=, !==... Keep this in sync with IS_RELATIONAL_OPERATOR() below.
+#define IS_EQUALITY_OPERATOR(symbol) (symbol >= SYM_EQUAL && symbol <= SYM_NOTEQUALCASE)
 	, SYM_GT, SYM_LT, SYM_GTOE, SYM_LTOE  // >, <, >=, <= ... Keep this in sync with IS_RELATIONAL_OPERATOR() below.
 #define IS_RELATIONAL_OPERATOR(symbol) (symbol >= SYM_EQUAL && symbol <= SYM_LTOE)
 	, SYM_REGEXMATCH // ~=, equivalent to a RegExMatch call in two-parameter mode.

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -227,6 +227,7 @@ FuncEntry g_BIF[] =
 	BIFn(SoundSet, 1, 4, BIF_Sound),
 	BIFn(Sqrt, 1, 1, BIF_SqrtLogLn),
 	BIF1(StatusBarGetText, 0, 5),
+	BIF1(StrCompare, 2, 3),
 	BIFn(StrGet, 1, 3, BIF_StrGetPut),
 	BIF1(String, 1, 1),
 	BIF1(StrLen, 1, 1),

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -7960,7 +7960,7 @@ ResultType Line::ExpressionToPostfix(ArgStruct &aArg)
 //		, 25             // Reserved for SYM_LOWNOT.
 //		, 26             // THIS VALUE MUST BE LEFT UNUSED so that the one above can be promoted to it by the infix-to-postfix routine.
 		, 28, 28, 28	 // SYM_IS, SYM_IN, SYM_CONTAINS
-		, 30, 30, 30     // SYM_EQUAL, SYM_EQUALCASE, SYM_NOTEQUAL (lower prec. than the below so that "x < 5 = var" means "result of comparison is the boolean value in var".
+		, 30, 30, 30, 30 // SYM_EQUAL, SYM_EQUALCASE, SYM_NOTEQUAL, SYM_NOTEQUALCASE (lower prec. than the below so that "x < 5 = var" means "result of comparison is the boolean value in var".
 		, 34, 34, 34, 34 // SYM_GT, SYM_LT, SYM_GTOE, SYM_LTOE
 		, 36             // SYM_REGEXMATCH
 		, 38             // SYM_CONCAT
@@ -8211,11 +8211,11 @@ ResultType Line::ExpressionToPostfix(ArgStruct &aArg)
 					}
 					break;
 				case '!':
-					if (cp1 == '=') // i.e. != is synonymous with <>, which is also already supported by legacy.
-					{
-						++cp; // An additional increment to have loop skip over the '=' too.
-						this_infix_item.symbol = SYM_NOTEQUAL;
-					}
+					if (cp1 == '=') // i.e. != is synonymous with <>, which is also already supported by legacy, or !==.
+						// An additional increment for each '=' to have loop skip over the '=' too.
+						++cp, this_infix_item.symbol	= cp[1] == '=' // note, cp[1] is not equal to cp1 here due to ++cp
+														? (++cp, SYM_NOTEQUALCASE)	// !==
+														: SYM_NOTEQUAL;				// != 
 					else
 						// If what lies to its left is a CPARAN or OPERAND, SYM_CONCAT is not auto-inserted because:
 						// 1) Allows ! and ~ to potentially be overloaded to become binary and unary operators in the future.

--- a/source/script.h
+++ b/source/script.h
@@ -3045,6 +3045,7 @@ void *GetDllProcAddress(LPCTSTR aDllFileFunc, HMODULE *hmodule_to_free = NULL);
 BIF_DECL(BIF_DllCall);
 #endif
 
+BIF_DECL(BIF_StrCompare);
 BIF_DECL(BIF_String);
 BIF_DECL(BIF_StrLen);
 BIF_DECL(BIF_SubStr);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -11601,6 +11601,37 @@ void ObjectToString(ResultToken &aResultToken, ExprTokenType &aThisToken, IObjec
 	}
 }
 
+BIF_DECL(BIF_StrCompare)
+{
+	// In script:
+	// Result := StrCompare(str1, str2 [, CaseSensitive := false])
+	// str1, str2, the strings to compare, can be be pure numbers, such numbers are converted to strings before the comparison.
+	// CaseSensitive, the case sensitive setting to use.
+	// Result, the result of the comparison:
+	//	< 0,	if str1 is less than str2.
+	//	0,		if str1 is identical to str2.
+	//	> 0,	if str1 is greater than str2.
+
+	// Param 1 and 2, str1 and str2
+	TCHAR str1_buf[MAX_NUMBER_SIZE];	// numeric input is converted to string.
+	TCHAR str2_buf[MAX_NUMBER_SIZE];
+	LPTSTR str1 = ParamIndexToString(0, str1_buf);
+	LPTSTR str2 = ParamIndexToString(1, str2_buf);
+	// Could return 0 here if str1 == str2, but it is probably rare to call StrCompare(str_var, str_var)
+	// so for most cases that would just be an unnecessary cost, albeit low.
+	// Param 3 - CaseSensitive
+	StringCaseSenseType string_case_sense = ParamIndexToCaseSense(2);
+
+	int result;
+	switch (string_case_sense)		// Compare the strings according to the string_case_sense setting.
+	{
+	case SCS_SENSITIVE:				result = _tcscmp(str1, str2); break;
+	case SCS_INSENSITIVE:			result = _tcsicmp(str1, str2); break;
+	case SCS_INSENSITIVE_LOCALE:	result = lstrcmpi(str1, str2); break;
+	}
+	_f_return_i(result);			// Return 
+}
+
 
 BIF_DECL(BIF_String)
 {
@@ -11719,20 +11750,9 @@ BIF_DECL(BIF_InStr)
 	LPTSTR haystack = ParamIndexToString(0, _f_number_buf, (size_t *)&haystack_length);
 	size_t needle_length;
 	LPTSTR needle = ParamIndexToString(1, needle_buf, &needle_length);
-	
-	// v1.0.43.03: Rather than adding a third value to the CaseSensitive parameter, it seems better to
-	// obey StringCaseSense because:
-	// 1) It matches the behavior of the equal operator (=) in expressions.
-	// 2) It's more friendly for typical international uses because it avoids having to specify that special/third value
-	//    for every call of InStr.  It's nice to be able to omit the CaseSensitive parameter every time and know that
-	//    the behavior of both InStr and its counterpart the equals operator are always consistent with each other.
-	// 3) Avoids breaking existing scripts that may pass something other than true/false for the CaseSense parameter.
-	StringCaseSenseType string_case_sense = (StringCaseSenseType)(!ParamIndexIsOmitted(2) && ParamIndexToBOOL(2));
-	// Above has assigned SCS_INSENSITIVE (0) or SCS_SENSITIVE (1).  If it's insensitive, resolve it to
-	// be Locale-mode if the StringCaseSense mode is either case-sensitive or Locale-insensitive.
-	if (g->StringCaseSense != SCS_INSENSITIVE && string_case_sense == SCS_INSENSITIVE) // Ordered for short-circuit performance.
-		string_case_sense = SCS_INSENSITIVE_LOCALE;
 
+	StringCaseSenseType string_case_sense = ParamIndexToCaseSense(2);
+	
 	LPTSTR found_pos;
 	INT_PTR offset = 0; // Set default.
 	int occurrence_number = ParamIndexToOptionalInt(4, 1);

--- a/source/script_expression.cpp
+++ b/source/script_expression.cpp
@@ -884,25 +884,26 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
 			if (  !(right_is_number && left_is_number)  // i.e. they're not both numeric (or this is SYM_CONCAT).
 				|| IS_RELATIONAL_OPERATOR(this_token.symbol) && !right_is_pure_number && !left_is_pure_number  ) // i.e. if both are strings, compare them alphabetically.
 			{
-				// L31: Handle binary ops supported by objects (= == !=).
+				// L31: Handle binary ops supported by objects (= == != !==).
 				switch (this_token.symbol)
 				{
 				case SYM_EQUAL:
 				case SYM_EQUALCASE:
 				case SYM_NOTEQUAL:
+				case SYM_NOTEQUALCASE:
 					IObject *right_obj = TokenToObject(right);
 					IObject *left_obj = TokenToObject(left);
 					// To support a future "implicit default value" feature, both operands must be objects.
 					// Otherwise, an object operand will be treated as its default value, currently always "".
 					// This is also consistent with unsupported operands such as < and > - i.e. because obj<""
 					// and obj>"" are always false and obj<="" and obj>="" are always true, obj must be "".
-					// When the default value feature is implemented all operators (excluding =, == and !=
+					// When the default value feature is implemented all operators (excluding =, ==, !== and !=
 					// if both operands are objects) may use the default value of any object operand.
 					// UPDATE: Above is not done because it seems more intuitive to document the other
 					// comparison operators as unsupported than for (obj == "") to evaluate to true.
 					if (right_obj || left_obj)
 					{
-						this_token.SetValue((this_token.symbol != SYM_NOTEQUAL) == (right_obj == left_obj));
+						this_token.SetValue((this_token.symbol != SYM_NOTEQUAL && this_token.symbol != SYM_NOTEQUALCASE) == (right_obj == left_obj));
 						goto push_this_token;
 					}
 				}
@@ -915,9 +916,10 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
 				result_symbol = SYM_INTEGER; // Set default.  Boolean results are treated as integers.
 				switch(this_token.symbol)
 				{
-				case SYM_EQUAL:     this_token.value_int64 = !((g->StringCaseSense == SCS_INSENSITIVE)
-										? _tcsicmp(left_string, right_string)
-										: lstrcmpi(left_string, right_string)); break; // i.e. use the "more correct mode" except when explicitly told to use the fast mode (v1.0.43.03).
+				case SYM_EQUAL:	this_token.value_int64 = !((g->StringCaseSense == SCS_INSENSITIVE)
+								? _tcsicmp(left_string, right_string)
+								: lstrcmpi(left_string, right_string)); break; // i.e. use the "more correct mode" except when explicitly told to use the fast mode (v1.0.43.03).
+				
 				case SYM_EQUALCASE: // Case sensitive.  Also supports binary data.
 					// Support basic equality checking of binary data by using tmemcmp rather than _tcscmp.
 					// The results should be the same for strings, but faster.  Length must be checked first
@@ -925,12 +927,16 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
 					// As a result, the comparison is much faster when the length differs.
 					this_token.value_int64 = (left_length == right_length) && !tmemcmp(left_string, right_string, left_length);
 					break; 
+				case SYM_NOTEQUAL:	this_token.value_int64 = !!((g->StringCaseSense == SCS_INSENSITIVE)	// Same as SYM_EQUAL but inverted result, code copied for performance (assumed). Note the double !! instead of no !, it is for handling the strcmp functions returning -1.
+									? _tcsicmp(left_string, right_string)
+									: lstrcmpi(left_string, right_string)); break;
+				case SYM_NOTEQUALCASE:	this_token.value_int64 = !((left_length == right_length)		// Same as SYM_EQUALCASE but inverted result, code copied for performance (assumed).		
+										&& !tmemcmp(left_string, right_string, left_length) ); break;
 				// The rest all obey g->StringCaseSense since they have no case sensitive counterparts:
-				case SYM_NOTEQUAL:  this_token.value_int64 = g_tcscmp(left_string, right_string) ? 1 : 0; break;
-				case SYM_GT:        this_token.value_int64 = g_tcscmp(left_string, right_string) > 0; break;
-				case SYM_LT:        this_token.value_int64 = g_tcscmp(left_string, right_string) < 0; break;
-				case SYM_GTOE:      this_token.value_int64 = g_tcscmp(left_string, right_string) > -1; break;
-				case SYM_LTOE:      this_token.value_int64 = g_tcscmp(left_string, right_string) < 1; break;
+				case SYM_GT:			this_token.value_int64 = g_tcscmp(left_string, right_string) > 0; break;
+				case SYM_LT:			this_token.value_int64 = g_tcscmp(left_string, right_string) < 0; break;
+				case SYM_GTOE:			this_token.value_int64 = g_tcscmp(left_string, right_string) > -1; break;
+				case SYM_LTOE:			this_token.value_int64 = g_tcscmp(left_string, right_string) < 1; break;
 
 				case SYM_CONCAT:
 					// Even if the left or right is "", must copy the result to temporary memory, at least
@@ -1101,21 +1107,22 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
 				switch(this_token.symbol)
 				{
 				// The most common cases are kept up top to enhance performance if switch() is implemented as if-else ladder.
-				case SYM_ADD:      this_token.value_int64 = left_int64 + right_int64; break;
-				case SYM_SUBTRACT: this_token.value_int64 = left_int64 - right_int64; break;
-				case SYM_MULTIPLY: this_token.value_int64 = left_int64 * right_int64; break;
+				case SYM_ADD:			this_token.value_int64 = left_int64 + right_int64; break;
+				case SYM_SUBTRACT:		this_token.value_int64 = left_int64 - right_int64; break;
+				case SYM_MULTIPLY:		this_token.value_int64 = left_int64 * right_int64; break;
 				// A look at K&R confirms that relational/comparison operations and logical-AND/OR/NOT
 				// always yield a one or a zero rather than arbitrary non-zero values:
 				case SYM_EQUALCASE: // Same behavior as SYM_EQUAL for numeric operands.
-				case SYM_EQUAL:    this_token.value_int64 = left_int64 == right_int64; break;
-				case SYM_NOTEQUAL: this_token.value_int64 = left_int64 != right_int64; break;
-				case SYM_GT:       this_token.value_int64 = left_int64 > right_int64; break;
-				case SYM_LT:       this_token.value_int64 = left_int64 < right_int64; break;
-				case SYM_GTOE:     this_token.value_int64 = left_int64 >= right_int64; break;
-				case SYM_LTOE:     this_token.value_int64 = left_int64 <= right_int64; break;
-				case SYM_BITAND:   this_token.value_int64 = left_int64 & right_int64; break;
-				case SYM_BITOR:    this_token.value_int64 = left_int64 | right_int64; break;
-				case SYM_BITXOR:   this_token.value_int64 = left_int64 ^ right_int64; break;
+				case SYM_EQUAL:			this_token.value_int64 = left_int64 == right_int64; break;
+				case SYM_NOTEQUALCASE: // Same behavior as SYM_NOTEQUAL for numeric operands.
+				case SYM_NOTEQUAL:		this_token.value_int64 = left_int64 != right_int64; break;
+				case SYM_GT:			this_token.value_int64 = left_int64 > right_int64; break;
+				case SYM_LT:			this_token.value_int64 = left_int64 < right_int64; break;
+				case SYM_GTOE:			this_token.value_int64 = left_int64 >= right_int64; break;
+				case SYM_LTOE:			this_token.value_int64 = left_int64 <= right_int64; break;
+				case SYM_BITAND:		this_token.value_int64 = left_int64 & right_int64; break;
+				case SYM_BITOR:			this_token.value_int64 = left_int64 | right_int64; break;
+				case SYM_BITXOR:		this_token.value_int64 = left_int64 ^ right_int64; break;
 				case SYM_BITSHIFTLEFT:  this_token.value_int64 = left_int64 << right_int64; break;
 				case SYM_BITSHIFTRIGHT: this_token.value_int64 = left_int64 >> right_int64; break;
 				case SYM_FLOORDIVIDE:
@@ -1172,6 +1179,7 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
 					break;
 				case SYM_EQUALCASE: // Same behavior as SYM_EQUAL for numeric operands.
 				case SYM_EQUAL:    this_token.value_int64 = left_double == right_double; break;
+				case SYM_NOTEQUALCASE: // Same behavior as SYM_NOTEQUAL for numeric operands.
 				case SYM_NOTEQUAL: this_token.value_int64 = left_double != right_double; break;
 				case SYM_GT:       this_token.value_int64 = left_double > right_double; break;
 				case SYM_LT:       this_token.value_int64 = left_double < right_double; break;

--- a/source/script_expression.cpp
+++ b/source/script_expression.cpp
@@ -882,7 +882,7 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
 				left_is_pure_number = TokenIsPureNumeric(left, left_is_number);
 			// Otherwise, leave left_is' uninitialized as below will short-circuit.
 			if (  !(right_is_number && left_is_number)  // i.e. they're not both numeric (or this is SYM_CONCAT).
-				|| IS_RELATIONAL_OPERATOR(this_token.symbol) && !right_is_pure_number && !left_is_pure_number  ) // i.e. if both are strings, compare them alphabetically.
+				|| IS_EQUALITY_OPERATOR(this_token.symbol) && !right_is_pure_number && !left_is_pure_number  ) // i.e. if both are strings, compare them alphabetically if operator supports it.
 			{
 				// L31: Handle binary ops supported by objects (= == != !==).
 				switch (this_token.symbol)
@@ -932,12 +932,8 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
 									: lstrcmpi(left_string, right_string)); break;
 				case SYM_NOTEQUALCASE:	this_token.value_int64 = !((left_length == right_length)		// Same as SYM_EQUALCASE but inverted result, code copied for performance (assumed).		
 										&& !tmemcmp(left_string, right_string, left_length) ); break;
-				// The rest all obey g->StringCaseSense since they have no case sensitive counterparts:
-				case SYM_GT:			this_token.value_int64 = g_tcscmp(left_string, right_string) > 0; break;
-				case SYM_LT:			this_token.value_int64 = g_tcscmp(left_string, right_string) < 0; break;
-				case SYM_GTOE:			this_token.value_int64 = g_tcscmp(left_string, right_string) > -1; break;
-				case SYM_LTOE:			this_token.value_int64 = g_tcscmp(left_string, right_string) < 1; break;
-
+				
+				
 				case SYM_CONCAT:
 					// Even if the left or right is "", must copy the result to temporary memory, at least
 					// when integers and floats had to be converted to temporary strings above.

--- a/source/script_func_impl.h
+++ b/source/script_func_impl.h
@@ -24,6 +24,18 @@
 #define ParamIndexToOptionalBOOL(index, def)		ParamIndexToOptionalType(BOOL, index, def)
 #define ParamIndexToOptionalVar(index)				(((index) < aParamCount && aParam[index]->symbol == SYM_VAR) ? aParam[index]->var : NULL)
 
+
+// Rather than adding a third value to the CaseSensitive parameter, it obeys StringCaseSense because:
+// 1) It matches the behavior of the equal operator (=) in expressions.
+// 2) It's more friendly for typical international uses because it avoids having to specify that special/third value
+//    for every call of InStr.  It's nice to be able to omit the CaseSensitive parameter every time and know that
+//    the behavior of both InStr and its counterpart the equals operator are always consistent with each other.
+// If the parameter is (false or omitted) insensitive, resolve it to be Locale-mode if the StringCaseSense mode is
+// either case-sensitive or Locale-insensitive.
+// The parameter is assumed to be optional and always defaults to false.
+#define ParamIndexToCaseSense(index)				(!ParamIndexIsOmitted(index) && ParamIndexToBOOL(index) ? SCS_SENSITIVE \
+													: (g->StringCaseSense != SCS_INSENSITIVE ? SCS_INSENSITIVE_LOCALE : SCS_INSENSITIVE) )
+
 #define ParamIndexToOptionalStringDef(index, def, ...)	(ParamIndexIsOmitted(index) ? (def) : ParamIndexToString(index, __VA_ARGS__))
 // The macro below defaults to "", since that is by far the most common default.
 // This allows it to skip the check for SYM_MISSING, which always has marker == _T("").


### PR DESCRIPTION
Hello 👋 

This is a branch from #104 , it is branched because if there is no interest in this, either #104 can be kept as is or it can be extended with `<==` and `>==`.

### StrCompare:

```autohotkey
Result := StrCompare(str1, str2 [, CaseSensitive := false])
```
* `str1`, `str2`, the strings to compare.

* `CaseSensitive`, the case sensitive setting to use.

`Result`, the result of the comparison:

* `< 0`,	if `str1` is less than `str2`.
* `0`,		if `str1` is identical to `str2`.
* `> 0`,	if `str1` is greater than `str2`.

The `CaseSensitive` parameter behaves as `BIF_InStr`.

__Reason__: No loss of information as when using the compare operators to compare strings, i.e., `< <= > >=`.

### Disabling string compairson for operators: `< <= > >=`

Non-numeric operands causes a `Type mismatch.` error.

__Reason__: Superseded by `StrCompare` which doesn't cause a loss of information. Simplifies the behaviour of the operators.

There was some comments [here](https://github.com/Lexikos/AutoHotkey_L/pull/104#issuecomment-400404357).

If there is an interest, I'll look in to making the proper adjustments and additions in the documentation (unless someone else wants to do it 😉 ).

Cheers.