### PR TITLE
Adding help function: TokensToScriptObject and two related macros.

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -17524,3 +17524,17 @@ DWORD GetProcessName(DWORD aProcessID, LPTSTR aBuf, DWORD aBufSize, bool aGetNam
 	CloseHandle(hproc);
 	return buf_length;
 }
+
+Object* TokensToScriptObject(ExprTokenType aTokens[], int aCount)
+{
+	/*
+	This function is used to make a script object which can be returned to the script.
+	aTokens, an array of key-value pairs to add to the new script object.
+	aCount, number tokens in aTokens.
+	*/
+	ExprTokenType **obj_params = (ExprTokenType**)alloca(aCount * sizeof (ExprTokenType*));
+	int i = 0;
+	while(i++ < aCount)
+		*obj_params++ = aTokens++;
+	return Object::Create(obj_params - aCount, aCount);
+}


### PR DESCRIPTION
Hello :wave:

The help function returns an object with key-value pairs according to the first parameter.

Example usage:

```c++
ExprTokenType params[] = 
{
	_T("Key1"), _T("Value1"),
	_T("Key2"), _T("Value2")
};
Object* obj = TokensToScriptObject(params, 4);
```

The macros can be used in BIFs and methods and are easy to find in connection to the other useful and common `_f_xxx` and `_o_xxx` macros. Example, equivalent to the above (plus error check)

```c++
Object* obj;
_f_create_script_object(obj, _T("Key1"), _T("Value1"), _T("Key2"), _T("Value2"));
```

Objects are currently not very common as return values, however, future functions/methods might return objects, this addition will make this easier.

Reason: Facilitate the use of objects as return values. Reduce redundancy and improves code clarity. Making the source code easier for the uninitiated to work with. 

Perhaps it is odd to add something which isn't actually being used, however, I do have use cases in mind and I think many others can find it useful too.

Cheers.