### PR TITLE
Adding #define COORD_MODE_INVALID

### DIFF
--- a/source/defines.h
+++ b/source/defines.h
@@ -753,6 +753,7 @@ enum GuiEventKinds {GUI_EVENTKIND_EVENT = 0, GUI_EVENTKIND_NOTIFY, GUI_EVENTKIND
 
 typedef USHORT CoordModeType;
 
+#define COORD_MODE_INVALID ((CoordModeType) -1)
 // Bit-field offsets:
 #define COORD_MODE_PIXEL   0
 #define COORD_MODE_MOUSE   2

--- a/source/script.h
+++ b/source/script.h
@@ -1322,7 +1322,7 @@ public:
 			return COORD_MODE_WINDOW;
 		else if (!_tcsicmp(aBuf, _T("Client")))
 			return COORD_MODE_CLIENT;
-		return -1;
+		return COORD_MODE_INVALID;
 	}
 
 	static CoordModeType ConvertCoordModeCmd(LPTSTR aBuf)
@@ -1333,7 +1333,7 @@ public:
 		if (!_tcsicmp(aBuf, _T("ToolTip"))) return COORD_MODE_TOOLTIP;
 		if (!_tcsicmp(aBuf, _T("Caret"))) return COORD_MODE_CARET;
 		if (!_tcsicmp(aBuf, _T("Menu"))) return COORD_MODE_MENU;
-		return -1;
+		return COORD_MODE_INVALID;
 	}
 
 	static VariableTypeType ConvertVariableTypeName(LPTSTR aBuf)

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -5187,7 +5187,7 @@ ResultType Script::SetCoordMode(LPTSTR aCommand, LPTSTR aMode)
 {
 	CoordModeType mode = Line::ConvertCoordMode(aMode);
 	CoordModeType shift = Line::ConvertCoordModeCmd(aCommand);
-	if (shift == -1 || mode == -1) // Compare directly to -1 because unsigned.
+	if (shift == COORD_MODE_INVALID || mode == COORD_MODE_INVALID)
 		return g_script.ScriptError(ERR_INVALID_VALUE, aMode);
 	g->CoordMode = (g->CoordMode & ~(COORD_MODE_MASK << shift)) | (mode << shift);
 	return OK;


### PR DESCRIPTION
Reason: mainly for correct input validation in `Script::SetCoordMode` where before the change there are issues due to the operands of `==` being promoted to `int`. Also slightly improves maintainability and readability.

Issue example,

```autohotkey
a_coordmodemouse := 'invalid'
(a_coordmodemouse) ; undefined behaviour in BIV_CoordMode
```
Note: the `shift` value in `Script::SetCoordMode` cannot be  `COORD_MODE_INVALID` (from the script side) when setting via `A_CoordModeXXX`. So I do not _fix_ the error message when setting via the command. Since I expect the commands to be remove, this check could be removed then I guess.

OT:
Having a blank value, `''`, default to `'screen'` is questionable imo.

Cheers.