### PR TITLE
Added A_AhkMajorVersion for v2

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -304,6 +304,7 @@ VarEntry g_BIV[] =
 // name to reduce code size and speed up the comparisons.
 VarEntry g_BIV_A[] =
 {
+	A_(AhkMajorVersion),
 	A_(AhkPath),
 	A_(AhkVersion),
 	A_w(AllowMainWindow),

--- a/source/script.h
+++ b/source/script.h
@@ -2979,6 +2979,7 @@ BIV_DECL_R (BIV_IconFile);
 BIV_DECL_R (BIV_IconNumber);
 BIV_DECL_R (BIV_Space_Tab);
 BIV_DECL_R (BIV_AhkVersion);
+BIV_DECL_R (BIV_AhkMajorVersion);
 BIV_DECL_R (BIV_AhkPath);
 BIV_DECL_R (BIV_TickCount);
 BIV_DECL_R (BIV_Now);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -9727,6 +9727,34 @@ VarSizeType BIV_AhkVersion(LPTSTR aBuf, LPTSTR aVarName)
 	return (VarSizeType)_tcslen(T_AHK_VERSION);
 }
 
+VarSizeType BIV_AhkMajorVersion(LPTSTR aBuf, LPTSTR aVarName)
+{
+	LPTSTR origin = T_AHK_VERSION;
+	LPTSTR found_first = 0;
+	LPTSTR found_second = 0;
+	TCHAR needle[2];
+	needle[0] = _T('.');
+	needle[1] = _T('\0');
+	TCHAR test = needle[0];
+	if (found_first = (TCHAR*)_tcsstr(origin, needle)) {
+
+		if (!(found_second = _tcsstr(found_first+1, needle))) {
+			needle[0] = _T('-');
+			found_second = _tcsstr(found_first, needle);
+		}
+	}
+	size_t char_length = 6;
+	if (found_second) {
+		char_length = (size_t)((UINT_PTR)found_second - (UINT_PTR)origin);
+	}
+	size_t tchar_length = char_length/sizeof(TCHAR);
+	if (aBuf) {
+		memcpy((void*)aBuf, (void*)origin, char_length);
+		aBuf[(int)tchar_length] = _T('\0');
+	}
+	return (VarSizeType)tchar_length;
+}
+
 VarSizeType BIV_AhkPath(LPTSTR aBuf, LPTSTR aVarName) // v1.0.41.
 {
 #ifdef AUTOHOTKEYSC


### PR DESCRIPTION
The built in variable A_AhkMajorVersion was added.
It tries to find the major part of T_AHK_VERSION.
It does that by finding the second . and returning the string before that.
If it cannot find a second dot it will look for a - instead of the second dot (the first dot needs to be found regardless).
If all fails it just returns the first 3 characters.

This code should also work for v1