### PR TITLE
Changing operators // and //=  to only do integer division.

### DIFF
--- a/source/defines.h
+++ b/source/defines.h
@@ -170,7 +170,7 @@ enum SymbolType // For use with ExpandExpression() and IsNumeric().
 #define SYM_CPAREN_FOR_OPAREN(symbol) ((symbol) - (SYM_OPAREN - SYM_CPAREN)) // Caller must confirm it is OPAREN or OBRACKET.
 #define SYM_OPAREN_FOR_CPAREN(symbol) ((symbol) + (SYM_OPAREN - SYM_CPAREN)) // Caller must confirm it is CPAREN or CBRACKET.
 #define YIELDS_AN_OPERAND(symbol) ((symbol) < SYM_OPAREN) // CPAREN also covers the tail end of a function call.  Post-inc/dec yields an operand for things like Var++ + 2.  Definitely needs the parentheses around symbol.
-	, SYM_ASSIGN, SYM_ASSIGN_ADD, SYM_ASSIGN_SUBTRACT, SYM_ASSIGN_MULTIPLY, SYM_ASSIGN_DIVIDE, SYM_ASSIGN_FLOORDIVIDE
+	, SYM_ASSIGN, SYM_ASSIGN_ADD, SYM_ASSIGN_SUBTRACT, SYM_ASSIGN_MULTIPLY, SYM_ASSIGN_DIVIDE, SYM_ASSIGN_INTEGERDIVIDE
 	, SYM_ASSIGN_BITOR, SYM_ASSIGN_BITXOR, SYM_ASSIGN_BITAND, SYM_ASSIGN_BITSHIFTLEFT, SYM_ASSIGN_BITSHIFTRIGHT
 	, SYM_ASSIGN_CONCAT // THIS MUST BE KEPT AS THE LAST (AND SYM_ASSIGN THE FIRST) BECAUSE THEY'RE USED IN A RANGE-CHECK.
 #define IS_ASSIGNMENT_EXCEPT_POST_AND_PRE(symbol) (symbol <= SYM_ASSIGN_CONCAT && symbol >= SYM_ASSIGN) // Check upper bound first for short-circuit performance.
@@ -192,7 +192,7 @@ enum SymbolType // For use with ExpandExpression() and IsNumeric().
 	, SYM_BITSHIFTLEFT, SYM_BITSHIFTRIGHT // << >>  ALSO: SYM_BITSHIFTRIGHT MUST BE KEPT LAST AMONG THE BIT OPERATORS BECAUSE IT'S USED IN A RANGE-CHECK.
 #define IS_BIT_OPERATOR(symbol) ((symbol) <= SYM_BITSHIFTRIGHT && (symbol) >= SYM_BITOR) // Check upper bound first for short-circuit performance (because operators like +-*/ are much more frequently used).
 	, SYM_ADD, SYM_SUBTRACT
-	, SYM_MULTIPLY, SYM_DIVIDE, SYM_FLOORDIVIDE
+	, SYM_MULTIPLY, SYM_DIVIDE, SYM_INTEGERDIVIDE
 	, SYM_POWER
 	, SYM_LOWNOT  // LOWNOT is the word "not", the low precedence counterpart of !
 	, SYM_NEGATIVE, SYM_POSITIVE, SYM_HIGHNOT, SYM_BITNOT, SYM_ADDRESS  // Don't change position or order of these because Infix-to-postfix converter's special handling for SYM_POWER relies on them being adjacent to each other.

--- a/source/defines.h
+++ b/source/defines.h
@@ -188,13 +188,13 @@ enum SymbolType // For use with ExpandExpression() and IsNumeric().
 	, SYM_LOW_CONCAT // Zero-precedence concat, used so that "x%y=z%" is equivalent to "x%(y=z)%".
 	
 	// INTEGER OPERATORS START
-	// Integer operators truncates float operands to integers.
+	// Note that the below macro does not consider SYM_BITNOT or the bit-assignment operators.
 	, SYM_BITOR // Seems more intuitive to have these higher in prec. than the above, unlike C and Perl, but like Python.
 	, SYM_BITXOR // SYM_BITOR (ABOVE) MUST BE KEPT FIRST AMONG THE INTEGER OPERATORS BECAUSE IT'S USED IN A RANGE-CHECK (see IS_INTEGER_OPERATOR).
 	, SYM_BITAND
 	, SYM_BITSHIFTLEFT, SYM_BITSHIFTRIGHT // << >>  
 	, SYM_INTEGERDIVIDE	// eg, x // y ALSO : SYM_INTEGERDIVIDE MUST BE KEPT LAST AMONG THE INTEGER OPERATORS BECAUSE IT'S USED IN A RANGE-CHECK (see IS_INTEGER_OPERATOR).
-#define IS_INTEGER_OPERATOR(symbol) ((symbol) <= SYM_INTEGERDIVIDE && (symbol) >= SYM_BITOR) // Check upper bound first for short-circuit performance (because operators like +-*/ are much more frequently used).
+#define IS_INTEGER_OPERATOR(symbol) ((symbol) <= SYM_INTEGERDIVIDE && (symbol) >= SYM_BITOR) // Currently not considered: SYM_BITNOT and the bit-assignment operators.
 	// INTEGER OPERATORS END
 
 	, SYM_ADD, SYM_SUBTRACT

--- a/source/defines.h
+++ b/source/defines.h
@@ -186,13 +186,19 @@ enum SymbolType // For use with ExpandExpression() and IsNumeric().
 	, SYM_REGEXMATCH // ~=, equivalent to a RegExMatch call in two-parameter mode.
 	, SYM_CONCAT
 	, SYM_LOW_CONCAT // Zero-precedence concat, used so that "x%y=z%" is equivalent to "x%(y=z)%".
+	
+	// INTEGER OPERATORS START
+	// Integer operators truncates float operands to integers.
 	, SYM_BITOR // Seems more intuitive to have these higher in prec. than the above, unlike C and Perl, but like Python.
-	, SYM_BITXOR // SYM_BITOR (ABOVE) MUST BE KEPT FIRST AMONG THE BIT OPERATORS BECAUSE IT'S USED IN A RANGE-CHECK.
+	, SYM_BITXOR // SYM_BITOR (ABOVE) MUST BE KEPT FIRST AMONG THE INTEGER OPERATORS BECAUSE IT'S USED IN A RANGE-CHECK (see IS_INTEGER_OPERATOR).
 	, SYM_BITAND
-	, SYM_BITSHIFTLEFT, SYM_BITSHIFTRIGHT // << >>  ALSO: SYM_BITSHIFTRIGHT MUST BE KEPT LAST AMONG THE BIT OPERATORS BECAUSE IT'S USED IN A RANGE-CHECK.
-#define IS_BIT_OPERATOR(symbol) ((symbol) <= SYM_BITSHIFTRIGHT && (symbol) >= SYM_BITOR) // Check upper bound first for short-circuit performance (because operators like +-*/ are much more frequently used).
+	, SYM_BITSHIFTLEFT, SYM_BITSHIFTRIGHT // << >>  
+	, SYM_INTEGERDIVIDE	// eg, x // y ALSO : SYM_INTEGERDIVIDE MUST BE KEPT LAST AMONG THE INTEGER OPERATORS BECAUSE IT'S USED IN A RANGE-CHECK (see IS_INTEGER_OPERATOR).
+#define IS_INTEGER_OPERATOR(symbol) ((symbol) <= SYM_INTEGERDIVIDE && (symbol) >= SYM_BITOR) // Check upper bound first for short-circuit performance (because operators like +-*/ are much more frequently used).
+	// INTEGER OPERATORS END
+
 	, SYM_ADD, SYM_SUBTRACT
-	, SYM_MULTIPLY, SYM_DIVIDE, SYM_INTEGERDIVIDE
+	, SYM_MULTIPLY, SYM_DIVIDE
 	, SYM_POWER
 	, SYM_LOWNOT  // LOWNOT is the word "not", the low precedence counterpart of !
 	, SYM_NEGATIVE, SYM_POSITIVE, SYM_HIGHNOT, SYM_BITNOT, SYM_ADDRESS  // Don't change position or order of these because Infix-to-postfix converter's special handling for SYM_POWER relies on them being adjacent to each other.

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -7982,7 +7982,7 @@ ResultType Line::ExpressionToPostfix(ArgStruct &aArg)
 		, 50             // SYM_BITAND
 		, 54, 54         // SYM_BITSHIFTLEFT, SYM_BITSHIFTRIGHT
 		, 58, 58         // SYM_ADD, SYM_SUBTRACT
-		, 62, 62, 62     // SYM_MULTIPLY, SYM_DIVIDE, SYM_FLOORDIVIDE
+		, 62, 62, 62     // SYM_MULTIPLY, SYM_DIVIDE, SYM_INTEGERDIVIDE
 		, 72             // SYM_POWER (see note below).  Associativity kept as left-to-right for backward compatibility (e.g. 2**2**3 is 4**3=64 not 2**8=256).
 		, 25             // SYM_LOWNOT (the word "NOT": the low precedence version of logical-not).  HAS AN ODD NUMBER to indicate right-to-left evaluation order so that things like "not not var" are supports (which can be used to convert a variable into a pure 1/0 boolean value).
 		, 67,67,67,67,67 // SYM_NEGATIVE (unary minus), SYM_POSITIVE (unary plus), SYM_HIGHNOT (the high precedence "!" operator), SYM_BITNOT, SYM_ADDRESS
@@ -8194,12 +8194,12 @@ ResultType Line::ExpressionToPostfix(ArgStruct &aArg)
 						if (cp[2] == '=')
 						{
 							cp += 2; // An additional increment to have loop skip over the operator's 2nd & 3rd symbols.
-							this_infix_item.symbol = SYM_ASSIGN_FLOORDIVIDE;
+							this_infix_item.symbol = SYM_ASSIGN_INTEGERDIVIDE;
 						}
 						else
 						{
 							++cp; // An additional increment to have loop skip over the second '/' too.
-							this_infix_item.symbol = SYM_FLOORDIVIDE;
+							this_infix_item.symbol = SYM_INTEGERDIVIDE;
 						}
 					}
 					else
@@ -9537,7 +9537,7 @@ standard_pop_into_postfix: // Use of a goto slightly reduces code size.
 					case SYM_ASSIGN_SUBTRACT:      postfix_symbol = SYM_SUBTRACT; break;
 					case SYM_ASSIGN_MULTIPLY:      postfix_symbol = SYM_MULTIPLY; break;
 					case SYM_ASSIGN_DIVIDE:        postfix_symbol = SYM_DIVIDE; break;
-					case SYM_ASSIGN_FLOORDIVIDE:   postfix_symbol = SYM_FLOORDIVIDE; break;
+					case SYM_ASSIGN_INTEGERDIVIDE: postfix_symbol = SYM_INTEGERDIVIDE; break;
 					case SYM_ASSIGN_BITOR:         postfix_symbol = SYM_BITOR; break;
 					case SYM_ASSIGN_BITXOR:        postfix_symbol = SYM_BITXOR; break;
 					case SYM_ASSIGN_BITAND:        postfix_symbol = SYM_BITAND; break;

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -7981,8 +7981,9 @@ ResultType Line::ExpressionToPostfix(ArgStruct &aArg)
 		, 46             // SYM_BITXOR
 		, 50             // SYM_BITAND
 		, 54, 54         // SYM_BITSHIFTLEFT, SYM_BITSHIFTRIGHT
+		, 62			 // SYM_INTEGERDIVIDE
 		, 58, 58         // SYM_ADD, SYM_SUBTRACT
-		, 62, 62, 62     // SYM_MULTIPLY, SYM_DIVIDE, SYM_INTEGERDIVIDE
+		, 62, 62	     // SYM_MULTIPLY, SYM_DIVIDE
 		, 72             // SYM_POWER (see note below).  Associativity kept as left-to-right for backward compatibility (e.g. 2**2**3 is 4**3=64 not 2**8=256).
 		, 25             // SYM_LOWNOT (the word "NOT": the low precedence version of logical-not).  HAS AN ODD NUMBER to indicate right-to-left evaluation order so that things like "not not var" are supports (which can be used to convert a variable into a pure 1/0 boolean value).
 		, 67,67,67,67,67 // SYM_NEGATIVE (unary minus), SYM_POSITIVE (unary plus), SYM_HIGHNOT (the high precedence "!" operator), SYM_BITNOT, SYM_ADDRESS

--- a/source/script_expression.cpp
+++ b/source/script_expression.cpp
@@ -1095,12 +1095,12 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
 			}
 
 			else if (right_is_number == PURE_INTEGER && left_is_number == PURE_INTEGER && this_token.symbol != SYM_DIVIDE
-				|| IS_BIT_OPERATOR(this_token.symbol))
+				|| IS_INTEGER_OPERATOR(this_token.symbol))
 			{
 				// Because both are integers and the operation isn't division, the result is integer.
-				// The result is also an integer for the bitwise operations listed in the if-statement
-				// above.  This is because it is not legal to perform ~, &, |, or ^ on doubles.  Any
-				// floating point operands are truncated to integers prior to doing the bitwise operation.
+				// The result is also an integer for the integer operations listed in the if-statement
+				// above.  This is because it is not legal to perform //, ~, &, |, or ^ on doubles. Any
+				// floating point operands are truncated to integers prior to doing the bitwise operation or integer division (i.e, //).
 				right_int64 = TokenToInt64(right); // It can't be SYM_STRING because in here, both right and
 				left_int64 = TokenToInt64(left);    // left are known to be numbers (otherwise an earlier "else if" would have executed instead of this one).
 				result_symbol = SYM_INTEGER; // Set default.
@@ -1193,18 +1193,6 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
 					if (left_was_negative && qmathFabs(qmathFmod(right_double, 2.0)) == 1.0) // Negative base and exactly-odd exponent (otherwise, it can only be zero or even because if not it would have returned higher above).
 						this_token.value_double = -this_token.value_double;
 					break;
-				case SYM_INTEGERDIVIDE:
-					// this case is in effect identical to the same case where both operands are integers,
-					// this redundancy avoids an extra check for this symbol in the above branch.
-					// Doubles are truncated before integer division.
-					right_int64 = TokenToInt64(right); 
-					left_int64 = TokenToInt64(left);   
-					result_symbol = SYM_INTEGER;
-					if (right_int64 == 0)
-						goto divide_by_zero;
-					this_token.value_int64 = left_int64 / right_int64;
-					break;
-
 				} // switch(this_token.symbol)
 				this_token.symbol = result_symbol; // Must be done only after the switch() above.
 			} // Result is floating point.


### PR DESCRIPTION
Hello 👋 .

Float operands are truncated to integers before the division.

Reason, simplifies behaviour and documentation, floor divide is already possible with (more readable) `floor(x/y)`, disregarding it produces an integer. Integer division is not easily achieved in any other way, and is important to keep for accurate division of integers which cannot be represented as floats.

### About the implementation

As mentioned in code comment, some redundancy is added to avoid extra an extra check for the preceding branch. It might not be very significant, but _every little helps_. (I hope _that_ makes sense, I translated)

Edit, I will fix the redundancy issue.