### PR TITLE
Changing operator ** to not cast integer operands to float...

### DIFF
--- a/source/script.h
+++ b/source/script.h
@@ -400,6 +400,9 @@ struct ArgStruct
 	ExprTokenType *postfix;  // An array of tokens in postfix order.
 };
 
+__int64 pow_ll(__int64 base, __int64 exp);
+bool mul_ll(unsigned __int64 x, unsigned __int64 y, unsigned __int64* res);
+
 #define BIF_DECL_PARAMS ResultToken &aResultToken, ExprTokenType *aParam[], int aParamCount
 
 // The following macro is used for definitions and declarations of built-in functions:

--- a/source/script_expression.cpp
+++ b/source/script_expression.cpp
@@ -1144,15 +1144,17 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
 					}
 					else // We have a valid base and exponent and both are integers, so the calculation will always have a defined result.
 					{
+						if (right_int64 >= 0)	// result is an integer.
+						{
+							this_token.value_int64 = pow_ll(left_int64, right_int64);
+							break;
+						}
+						result_symbol = SYM_FLOAT; // Due to negative exponent, override to float.
 						if (left_was_negative = (left_int64 < 0))
 							left_int64 = -left_int64; // Force a positive due to the limitations of qmathPow().
 						this_token.value_double = qmathPow((double)left_int64, (double)right_int64);
 						if (left_was_negative && right_int64 % 2) // Negative base and odd exponent (not zero or even).
 							this_token.value_double = -this_token.value_double;
-						if (right_int64 < 0)
-							result_symbol = SYM_FLOAT; // Due to negative exponent, override to float.
-						else
-							this_token.value_int64 = (__int64)this_token.value_double;
 					}
 					break;
 				}


### PR DESCRIPTION
...and then cast result back to integer for exponents `>= 0`.

__Reasons,__ allow correct results for all `x**y` (`x,y` integer, `y>0`) which is within the range of `__int64`.

Example.

```autohotkey
msgbox 1234**6 ; yields correct result in this branch
```

### Overflow.
Overflow is detected and causes the result to be `_I64_MIN`,  which is useful because it enables, eg, `2**63-1 == 9223372036854775807` which is the correct result. While other operators do not handle overflow, the `**` operator should beacuse it causes overflow even for quite small operands, eg `100**100` is _huge_.

I have implemented the behaviour in this branch in a much simpler way, less complex, less code, it perfroms slightly slower. If there is an interest I'll provide the alternative version.

Not detecting overflow simplifies the implementation, and reduces code size.

__Note:__ Introduces a different inconsistency, which needs separate handling, that is, `0**0.0` is `0.0` on `32` build while `1.0` on `64`, `0**0` is `1` on both builds. Currently, both `0**0` and `0.0**0` is `0` on `32` and `1` on `64` build. See #118.

Cheers.