### PR TITLE
Disabling unquoted argument and return types for BIF_DllCall.

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -13337,15 +13337,6 @@ void Script::MaybeWarnLocalSameAsGlobal(Func &func, Var &var)
 {
 	if (!g_Warn_LocalSameAsGlobal)
 		return;
-
-#ifdef ENABLE_DLLCALL
-	if (IsDllArgTypeName(var.mName))
-		// Exclude unquoted DllCall arg type names.  Although variable names like "str" and "ptr"
-		// might be used for other purposes, it seems far more likely that both this var and its
-		// global counterpart (if it exists) are blank vars which were used as DllCall arg types.
-		return;
-#endif
-
 	Line *line = func.mJumpToLine;
 	while (line && line->mActionType != ACT_BLOCK_BEGIN) line = line->mPrevLine;
 	if (!line) line = func.mJumpToLine;

--- a/source/script.h
+++ b/source/script.h
@@ -3027,7 +3027,6 @@ BIV_DECL_R (BIV_ScreenDPI);
 ////////////////////////
 
 #ifdef ENABLE_DLLCALL
-bool IsDllArgTypeName(LPTSTR name);
 void *GetDllProcAddress(LPCTSTR aDllFileFunc, HMODULE *hmodule_to_free = NULL);
 BIF_DECL(BIF_DllCall);
 #endif


### PR DESCRIPTION
Reasons, makes syntax more consistent (no other functions allow unquoted text as input), consequently makes scripts and documentation easier to read / understand. Removes some potential bugs, especially since the introduction of nested functions / closures, specifically, demaning quotes reduces the risk that nested functions becomes closures due to having `dllcall`s with same argument types,

```autothotkey
f(){
	return type(() => dllcall(0, ptr))
	dllcall 0, ptr
}
msgbox f()	; Closure, which ofc is correct, but probably not intended.
```
Also, in this branch, using `#warn LocalSameAsGlobal` will cause warnings if there exists a global variable named `ptr` in the above script.

Simplifies implementation, reduces code size. 

### About the implementation.
 `case SYM_STRING:` was put before `case SYM_VAR:` in two switches, due to the assumption that argument types are more often specified by something like `'str'` rather than `var := 'str'`. Added call to `Var::MaybeWarnUninitialized()` if appropriate before throwing `ERR_INVALID_RETURN_TYPE`, since similar is done for invalid arg types. Obsolete comments removed (w.r.t the changes), some might remain. Function `bool IsDllArgTypeName(LPTSTR name)`  removed since not called anymore.

Cheers.