### PR TITLE
Replacing F option for BIF_Sort with Function parameter.

### DIFF
--- a/source/globaldata.cpp
+++ b/source/globaldata.cpp
@@ -146,8 +146,9 @@ MsgMonitorList g_MsgMonitor;
 UCHAR g_SortCaseSensitive;
 bool g_SortNumeric;
 bool g_SortReverse;
+bool g_SortFuncIsCallable;
 int g_SortColumnOffset;
-Func *g_SortFunc;
+IObject *g_SortFunc;
 
 // Hot-string vars (initialized when ResetHook() is first called):
 TCHAR g_HSBuf[HS_BUF_SIZE];

--- a/source/globaldata.h
+++ b/source/globaldata.h
@@ -123,8 +123,9 @@ extern MsgMonitorList g_MsgMonitor;
 extern UCHAR g_SortCaseSensitive;
 extern bool g_SortNumeric;
 extern bool g_SortReverse;
+extern bool g_SortFuncIsCallable;
 extern int g_SortColumnOffset;
-extern Func *g_SortFunc;
+extern IObject *g_SortFunc;
 
 #define g_DerefChar   '%' // As of v2 these are constant, so even more parts of the code assume they
 #define g_EscapeChar  '`' // are at their usual default values to reduce code size/complexity.

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -232,7 +232,7 @@ FuncEntry g_BIF[] =
 	BIFn(SendMessage, 1, 9, BIF_PostSendMessage),
 	BIF1(SetTimer, 0, 3),
 	BIF1(Sin, 1, 1),
-	BIF1(Sort, 1, 2),
+	BIF1(Sort, 1, 3),
 	BIFn(SoundGet, 0, 3, BIF_Sound),
 	BIFn(SoundSet, 1, 4, BIF_Sound),
 	BIFn(Sqrt, 1, 1, BIF_SqrtLogLn),


### PR DESCRIPTION
Reason, to enable passing functors, for convenince and consistency with other functions which calls user functions. (Regex callouts aside.)

### New:

```autohotkey
Sort String [,Options, Function]
```

`Function`, string or object, a function name or reference.

### About the implementation.

No attempts to validate _parameter count_, _byref_ of _isbuiltin_ for the functor is done.

`SortUDF` returns `0` on `FAIL` and `INVOKE_NOT_HANDLED`. On `INVOKE_NOT_HANDLED`, no more attemps to call the user's function are made and an invalid parameter exception is thrown after `qsort` returns. Handling `INVOKE_NOT_HANDLED` is useful to avoid something like `sort str,, []`, to silently sort the string deeming all items being equal.

Consider using [`qsort_s`](https://msdn.microsoft.com/en-us/library/4xc60xas.aspx) instead, to avoid the use of the `g_xxx` variables. 

Cheers.