### PR TITLE
Changing address-of operator (&) to set VAR_ATTRIB_CONTENTS_OUT_OF_DATE...

### DIFF
--- a/source/script_expression.cpp
+++ b/source/script_expression.cpp
@@ -799,7 +799,10 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
 			{
 				Var *right_var = right.var->ResolveAlias();
 				if (right_var->IsPureNumeric())
+				{
 					this_token.value_int64 = (__int64)&right_var->mContentsInt64; // Since the value is a pure number, this seems more useful and less confusing than returning the address of a numeric string.
+					right_var->mAttrib |= VAR_ATTRIB_CONTENTS_OUT_OF_DATE;	// Since the user might change the value via NumPut or DllCall.
+				}
 				else
 					this_token.value_int64 = (__int64)right_var->Contents(); // Contents() vs. mContents to support VAR_CLIPBOARD, and in case mContents needs to be updated by Contents().
 				this_token.symbol = SYM_INTEGER;


### PR DESCRIPTION
...for operand which is a variable with pure numeric content.

Reason, user might change the value via `NumPut` or `DllCall`.

Example,

```autohotkey
x := 0
msgbox x		; 0
numput 1, &x
msgbox x		; currently 0, 1 in this branch
``` 