### PR TITLE
Changing operators << and >> to throw exception when RHS operand is …

### DIFF
--- a/source/script_expression.cpp
+++ b/source/script_expression.cpp
@@ -1123,8 +1123,14 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
 				case SYM_BITAND:		this_token.value_int64 = left_int64 & right_int64; break;
 				case SYM_BITOR:			this_token.value_int64 = left_int64 | right_int64; break;
 				case SYM_BITXOR:		this_token.value_int64 = left_int64 ^ right_int64; break;
-				case SYM_BITSHIFTLEFT:  this_token.value_int64 = left_int64 << right_int64; break;
-				case SYM_BITSHIFTRIGHT: this_token.value_int64 = left_int64 >> right_int64; break;
+				case SYM_BITSHIFTLEFT:
+				case SYM_BITSHIFTRIGHT:
+					if (right_int64 < 0 || right_int64 > 63)
+						goto abort_with_exception;
+					this_token.value_int64 = this_token.symbol == SYM_BITSHIFTLEFT
+						? left_int64 << right_int64
+						: left_int64 >> right_int64;
+					break;
 				case SYM_FLOORDIVIDE:
 					// Since it's integer division, no need for explicit floor() of the result.
 					// Also, performance is much higher for integer vs. float division, which is part


### PR DESCRIPTION
…outside of range `0...63`

Reason,
The behaviour of negative values in the RHS, and values larger or equal to the bit width of the LHS type, is undefined.
Avoids _unexpected_ results, eg, currently, `1 << 64 == 1`.

__Note__ that _undefined behviour_, refers to the behaviour of the c++ operators. AHK could of course define the behaviour. Eg, shifting by more than `63` bit positions could be defined to result in `0`, i.e., all bits are _shifted out_ (or `-1` if the LHS is negative, for `>>`). A negative shift amount could shift in the opposite direction, i.e, `x << -1` could be equivalent to `x >> 1`.

Reference:

https://docs.microsoft.com/en-us/cpp/cpp/left-shift-and-right-shift-operators-input-and-output?view=vs-2017