### PR TITLE
changing operators << and >> to do logical shift, zero-filling.

### DIFF
--- a/source/script_expression.cpp
+++ b/source/script_expression.cpp
@@ -1123,8 +1123,8 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
 				case SYM_BITAND:		this_token.value_int64 = left_int64 & right_int64; break;
 				case SYM_BITOR:			this_token.value_int64 = left_int64 | right_int64; break;
 				case SYM_BITXOR:		this_token.value_int64 = left_int64 ^ right_int64; break;
-				case SYM_BITSHIFTLEFT:  this_token.value_int64 = left_int64 << right_int64; break;
-				case SYM_BITSHIFTRIGHT: this_token.value_int64 = left_int64 >> right_int64; break;
+				case SYM_BITSHIFTLEFT:  this_token.value_int64 = (unsigned __int64) left_int64 << right_int64; break;
+				case SYM_BITSHIFTRIGHT: this_token.value_int64 = (unsigned __int64) left_int64 >> right_int64; break;
 				case SYM_FLOORDIVIDE:
 					// Since it's integer division, no need for explicit floor() of the result.
 					// Also, performance is much higher for integer vs. float division, which is part


### PR DESCRIPTION
new:

`a << b`, performs logical left bit-shift of `a` by `b` positions.
`a >> b`, performs logical right bit-shift of `a` by `b` positions.

In both cases, vacant bit-positions are zero-filled.

Reasons,
__1)__ Logical shift is generally more useful, simple to understand and work with.
__2)__ The behaviour of left shifting a (signed) non-negative number such that the result is not representable in the corresponding unsigned type, or left shifting a negative number, is undefined.

reference:
https://docs.microsoft.com/en-us/cpp/cpp/left-shift-and-right-shift-operators-input-and-output?view=vs-2017 (2018-12-11)