### PR TITLE
Changing address-of (&) operator to flag operands containing pure numbers with VAR_ATTRIB_CONTENTS_OUT_OF_DATE_UNTIL_REASSIGNED.

### DIFF
--- a/source/script_expression.cpp
+++ b/source/script_expression.cpp
@@ -799,7 +799,10 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
 			{
 				Var *right_var = right.var->ResolveAlias();
 				if (right_var->IsPureNumeric())
+				{
 					this_token.value_int64 = (__int64)&right_var->mContentsInt64; // Since the value is a pure number, this seems more useful and less confusing than returning the address of a numeric string.
+					right_var->mAttrib |= VAR_ATTRIB_CONTENTS_OUT_OF_DATE_UNTIL_REASSIGNED | VAR_ATTRIB_CONTENTS_OUT_OF_DATE; // Since the user might change the value via NumPut or DllCall.
+				}
 				else
 					this_token.value_int64 = (__int64)right_var->Contents(); // Contents() vs. mContents to support VAR_CLIPBOARD, and in case mContents needs to be updated by Contents().
 				this_token.symbol = SYM_INTEGER;


### PR DESCRIPTION
### New:
Variables containing pure numbers retain the `VAR_ATTRIB_CONTENTS_OUT_OF_DATE` and `VAR_ATTRIB_CONTENTS_OUT_OF_DATE_UNTIL_REASSIGNED` flags after being operated on by the address-of  (`&`) operator, until reassigned.

The address from `&var` should be considered valid only until `var` has been reassigned by any assignment operator (including `++` and `--`) or used as an _OutputVar_ in a built-in function, including being passed as `str, var` or `type*, var` to `DllCall`.

Reason, the user might change the value via `NumPut` or `DllCall`.

I will submit a suggestion to the documentation.

Happy holidays 🎅 