### PR TITLE
Adding check in BoundFunc::Invoke to avoid handling setting and getting Call

### DIFF
--- a/source/script_object.cpp
+++ b/source/script_object.cpp
@@ -1908,7 +1908,7 @@ ResultType STDMETHODCALLTYPE BoundFunc::Invoke(ResultToken &aResultToken, ExprTo
 	if (  !(aFlags & IF_FUNCOBJ) && aParamCount  )
 	{
 		// No methods/properties implemented yet, except Call().
-		if (_tcsicmp(TokenToString(*aParam[0]), _T("Call")))
+		if (!IS_INVOKE_CALL || _tcsicmp(TokenToString(*aParam[0]), _T("Call")))
 			return INVOKE_NOT_HANDLED; // Reserved.
 		++aParam;
 		--aParamCount;


### PR DESCRIPTION
__Reasons__, avoids unexpectedly calling the target function when setting or getting `Call`. Helps identifying mistakes.

Issue example.

```autohotkey
msgbox func('abs').bind().call := -1 ; calls the target function passing -1
```

Cheers.