### PR TITLE
Update mt19937ar-cok.h

### DIFF
--- a/source/mt19937ar-cok.h
+++ b/source/mt19937ar-cok.h
@@ -38,7 +38,8 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
    Any feedback is very welcome.
-   http://www.math.keio.ac.jp/matumoto/emt.html
+   http://www.math.keio.ac.jp/matumoto/emt.html (now 404)
+   http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html
    email: matumoto@math.keio.ac.jp
 */
 


### PR DESCRIPTION
MT19937 Mersenne Twister random number generator website has moved since.  Also, this function has since been updated in 2004, and there is also a 64-bit machine version from 2005.  Also, they no longer have any license requirements as of 2001.