### PR TITLE
Adding verification that string is null-terminated for varsetcapacity(var, -1)

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -13070,7 +13070,13 @@ int Line::FormatError(LPTSTR aBuf, int aBufSize, ResultType aErrorType, LPCTSTR 
 	return (int)(aBuf - aBuf_orig);
 }
 
-
+ResultType Script::CriticalScriptError(LPCTSTR aErrorText, LPCTSTR aExtraInfo)
+{
+	// Displays an error message and terminates the script.
+	g->ExcptMode = EXCPTMODE_NONE; // Do not throw an exception.
+	ScriptError(aErrorText, aExtraInfo);
+	return ExitApp(EXIT_CRITICAL); // Called this way, it will run the OnExit function, which is debatable because it could cause more good than harm, but might avoid loss of data if the OnExit function does something important.
+}
 
 ResultType Script::ScriptError(LPCTSTR aErrorText, LPCTSTR aExtraInfo) //, ResultType aErrorType)
 // Even though this is a Script method, including it here since it shares

--- a/source/script.h
+++ b/source/script.h
@@ -236,7 +236,7 @@ enum CommandIDs {CONTROL_ID_FIRST = IDCANCEL + 1
 #define ERR_INVALID_HWND _T("Invalid HWND.")
 #define ERR_INVALID_USAGE _T("Invalid usage.")
 #define ERR_INTERNAL_CALL _T("An internal function call failed.")
-
+#define ERR_STRING_NOT_TERMINATED _T("String not null-terminated.")
 #define WARNING_USE_UNSET_VARIABLE _T("This variable has not been assigned a value.")
 #define WARNING_LOCAL_SAME_AS_GLOBAL _T("This local variable has the same name as a global variable.")
 #define WARNING_USE_ENV_VARIABLE _T("An environment variable is being accessed; see #NoEnv.")

--- a/source/script.h
+++ b/source/script.h
@@ -236,7 +236,7 @@ enum CommandIDs {CONTROL_ID_FIRST = IDCANCEL + 1
 #define ERR_INVALID_HWND _T("Invalid HWND.")
 #define ERR_INVALID_USAGE _T("Invalid usage.")
 #define ERR_INTERNAL_CALL _T("An internal function call failed.")
-#define ERR_STRING_NOT_TERMINATED _T("String not null-terminated.")
+#define ERR_STRING_NOT_TERMINATED _T("String not null-terminated. The program is now unstable and will exit.")
 #define WARNING_USE_UNSET_VARIABLE _T("This variable has not been assigned a value.")
 #define WARNING_LOCAL_SAME_AS_GLOBAL _T("This local variable has the same name as a global variable.")
 #define WARNING_USE_ENV_VARIABLE _T("An environment variable is being accessed; see #NoEnv.")
@@ -421,6 +421,7 @@ struct ArgStruct
 #define _o_throw(...)			_o__ret(aResultToken.Error(__VA_ARGS__))
 #define _f_return_FAIL			_f__ret(aResultToken.SetExitResult(FAIL))
 #define _o_return_FAIL			_o__ret(aResultToken.SetExitResult(FAIL))
+#define _f_critical_error(...)	{ g_script.CriticalScriptError(__VA_ARGS__); _f_return_FAIL; } // Returns FAIL if the program doesn't terminate.
 // The _f_set_retval macros should be used with care because the integer macros assume symbol
 // is set to its default value; i.e. don't set a string and then attempt to return an integer.
 // It is also best for maintainability to avoid setting mem_to_free or an object without
@@ -2883,6 +2884,7 @@ public:
 	static ResultType SetSendMode(LPTSTR aValue);
 	static ResultType SetSendLevel(int aValue, LPTSTR aValueStr);
 
+	ResultType CriticalScriptError(LPCTSTR aErrorText, LPCTSTR aExtraInfo = _T("")); // Displays an error message and terminates the program. 
 	// Call this SciptError to avoid confusion with Line's error-displaying functions:
 	ResultType ScriptError(LPCTSTR aErrorText, LPCTSTR aExtraInfo = _T("")); // , ResultType aErrorType = FAIL);
 

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -11444,10 +11444,7 @@ has_valid_return_type:
 		*Var::sEmptyString = '\0';
 		// Don't bother with freeing hmodule_to_free since a critical error like this calls for minimal cleanup.
 		// The OS almost certainly frees it upon termination anyway.
-		// Call ScriptErrror() so that the user knows *which* DllCall is at fault:
-		g->ExcptMode = EXCPTMODE_NONE; // Do not throw an exception.
-		g_script.ScriptError(_T("This DllCall requires a prior VarSetCapacity. The program is now unstable and will exit."));
-		g_script.ExitApp(EXIT_CRITICAL); // Called this way, it will run the OnExit function, which is debatable because it could cause more good than harm, but might avoid loss of data if the OnExit function does something important.
+		_f_critical_error(_T("This DllCall requires a prior VarSetCapacity. The program is now unstable and will exit."))
 	}
 
 	if (g->ThrownToken)
@@ -14027,7 +14024,7 @@ BIF_DECL(BIF_VarSetCapacity)
 					{
 						string_length = _tcsnlen(var.Contents(), max_count);	// measure the string
 						if (string_length == max_count)
-							_f_throw(ERR_STRING_NOT_TERMINATED);
+							_f_critical_error(ERR_STRING_NOT_TERMINATED, var.mName)
 						string_length = _TSIZE(string_length);
 					}
 					// Seems more useful to report length vs. capacity in this special case. Scripts might be able

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -14019,9 +14019,21 @@ BIF_DECL(BIF_VarSetCapacity)
 			{
 				if (param1 == -1) // Adjust variable's internal length.
 				{
+					// Performance: Length() and Contents() will update mContents if necessary, it's unlikely to be necessary under the circumstances of this call.
+					// In any case, it seems appropriate to do it this way.
+					size_t string_length = 0;
+					size_t max_count = var.Capacity(); // to detect a non null-terminated string.
+					if (max_count != 0)
+					{
+						string_length = _tcsnlen(var.Contents(), max_count);	// measure the string
+						if (string_length == max_count)
+							_f_throw(ERR_STRING_NOT_TERMINATED);
+						string_length = _TSIZE(string_length);
+					}
 					// Seems more useful to report length vs. capacity in this special case. Scripts might be able
 					// to use this to boost performance.
-					aResultToken.value_int64 = var.ByteLength() = ((VarSizeType)_tcslen(var.Contents()) * sizeof(TCHAR)); // Performance: Length() and Contents() will update mContents if necessary, it's unlikely to be necessary under the circumstances of this call.  In any case, it seems appropriate to do it this way.
+					var.ByteLength() = string_length;
+					aResultToken.value_int64 = string_length;
 					var.Close();
 					return;
 				}


### PR DESCRIPTION
### New

throws exception if string is not null-terminated.

__Reason__, helps detect mistakes, avoids reading outside the variable's string buffer.

### Example

```autohotkey
varsetcapacity var, 8
strput 'abcde', &var, 5
varsetcapacity var, -1 ; Error:  String not null-terminated.
```

Cheers.