### PR TITLE
Adding ability to update the internally stored string length for strings stored in objects.

### DIFF
--- a/source/script.h
+++ b/source/script.h
@@ -236,7 +236,7 @@ enum CommandIDs {CONTROL_ID_FIRST = IDCANCEL + 1
 #define ERR_INVALID_HWND _T("Invalid HWND.")
 #define ERR_INVALID_USAGE _T("Invalid usage.")
 #define ERR_INTERNAL_CALL _T("An internal function call failed.")
-
+#define ERR_STRING_NOT_TERMINATED _T("String not null-terminated.")
 #define WARNING_USE_UNSET_VARIABLE _T("This variable has not been assigned a value.")
 #define WARNING_LOCAL_SAME_AS_GLOBAL _T("This local variable has the same name as a global variable.")
 #define WARNING_USE_ENV_VARIABLE _T("An environment variable is being accessed; see #NoEnv.")


### PR DESCRIPTION
### New

pass `-1` for the second paramter of `SetCapacity` to update the string length.

__Reason__, the user might change the string via `dllcall` or `strput`.

__About__, throws exception if string is not null-terminated, similar to #130 .

### Example

```autohotkey
o := []
o.setcapacity 1, 8
strput 'abc', o.getaddress(1), 4
o.setcapacity 1, -1		; new
msgbox o.1 			; 'abc' in this branch, else blank.
```

### Note

the use of `-1` is chosen for symmetry with `varsetcapacity`, not because it is considered better than having, more flexible, separate methods/functions for updating string lengths.

Cheers.