### PR TITLE
adding operators >>>, <<<, >>>= and <<<=

### DIFF
--- a/source/defines.h
+++ b/source/defines.h
@@ -171,7 +171,7 @@ enum SymbolType // For use with ExpandExpression() and IsNumeric().
 #define SYM_OPAREN_FOR_CPAREN(symbol) ((symbol) + (SYM_OPAREN - SYM_CPAREN)) // Caller must confirm it is CPAREN or CBRACKET.
 #define YIELDS_AN_OPERAND(symbol) ((symbol) < SYM_OPAREN) // CPAREN also covers the tail end of a function call.  Post-inc/dec yields an operand for things like Var++ + 2.  Definitely needs the parentheses around symbol.
 	, SYM_ASSIGN, SYM_ASSIGN_ADD, SYM_ASSIGN_SUBTRACT, SYM_ASSIGN_MULTIPLY, SYM_ASSIGN_DIVIDE, SYM_ASSIGN_FLOORDIVIDE
-	, SYM_ASSIGN_BITOR, SYM_ASSIGN_BITXOR, SYM_ASSIGN_BITAND, SYM_ASSIGN_BITSHIFTLEFT, SYM_ASSIGN_BITSHIFTRIGHT
+	, SYM_ASSIGN_BITOR, SYM_ASSIGN_BITXOR, SYM_ASSIGN_BITAND, SYM_ASSIGN_BITSHIFTLEFT, SYM_ASSIGN_BITSHIFTRIGHT, SYM_ASSIGN_BITSHIFTRIGHT_LOGICAL // SYM_ASSIGN_BITSHIFTLEFT_LOGICAL doesn't exist but <<<= is the same as <<=
 	, SYM_ASSIGN_CONCAT // THIS MUST BE KEPT AS THE LAST (AND SYM_ASSIGN THE FIRST) BECAUSE THEY'RE USED IN A RANGE-CHECK.
 #define IS_ASSIGNMENT_EXCEPT_POST_AND_PRE(symbol) (symbol <= SYM_ASSIGN_CONCAT && symbol >= SYM_ASSIGN) // Check upper bound first for short-circuit performance.
 #define IS_ASSIGNMENT_OR_POST_OP(symbol) (IS_ASSIGNMENT_EXCEPT_POST_AND_PRE(symbol) || symbol == SYM_POST_INCREMENT || symbol == SYM_POST_DECREMENT)
@@ -189,8 +189,8 @@ enum SymbolType // For use with ExpandExpression() and IsNumeric().
 	, SYM_BITOR // Seems more intuitive to have these higher in prec. than the above, unlike C and Perl, but like Python.
 	, SYM_BITXOR // SYM_BITOR (ABOVE) MUST BE KEPT FIRST AMONG THE BIT OPERATORS BECAUSE IT'S USED IN A RANGE-CHECK.
 	, SYM_BITAND
-	, SYM_BITSHIFTLEFT, SYM_BITSHIFTRIGHT // << >>  ALSO: SYM_BITSHIFTRIGHT MUST BE KEPT LAST AMONG THE BIT OPERATORS BECAUSE IT'S USED IN A RANGE-CHECK.
-#define IS_BIT_OPERATOR(symbol) ((symbol) <= SYM_BITSHIFTRIGHT && (symbol) >= SYM_BITOR) // Check upper bound first for short-circuit performance (because operators like +-*/ are much more frequently used).
+	, SYM_BITSHIFTLEFT, SYM_BITSHIFTRIGHT, SYM_BITSHIFTRIGHT_LOGICAL // << >> >>>  ALSO: SYM_BITSHIFTRIGHT_LOGICAL MUST BE KEPT LAST AMONG THE BIT OPERATORS BECAUSE IT'S USED IN A RANGE-CHECK. <<< is the same as SYM_BITSHIFTLEFT
+#define IS_BIT_OPERATOR(symbol) ((symbol) <= SYM_BITSHIFTRIGHT_LOGICAL && (symbol) >= SYM_BITOR) // Check upper bound first for short-circuit performance (because operators like +-*/ are much more frequently used).
 	, SYM_ADD, SYM_SUBTRACT
 	, SYM_MULTIPLY, SYM_DIVIDE, SYM_FLOORDIVIDE
 	, SYM_POWER

--- a/source/script_expression.cpp
+++ b/source/script_expression.cpp
@@ -856,17 +856,18 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
 						this_token.symbol = SYM_VAR; // address can be taken, and it can be passed ByRef. e.g. &(x:=1)
 					}
 					goto push_this_token;
-				case SYM_ASSIGN_ADD:           this_token.symbol = SYM_ADD; break;
-				case SYM_ASSIGN_SUBTRACT:      this_token.symbol = SYM_SUBTRACT; break;
-				case SYM_ASSIGN_MULTIPLY:      this_token.symbol = SYM_MULTIPLY; break;
-				case SYM_ASSIGN_DIVIDE:        this_token.symbol = SYM_DIVIDE; break;
-				case SYM_ASSIGN_FLOORDIVIDE:   this_token.symbol = SYM_FLOORDIVIDE; break;
-				case SYM_ASSIGN_BITOR:         this_token.symbol = SYM_BITOR; break;
-				case SYM_ASSIGN_BITXOR:        this_token.symbol = SYM_BITXOR; break;
-				case SYM_ASSIGN_BITAND:        this_token.symbol = SYM_BITAND; break;
-				case SYM_ASSIGN_BITSHIFTLEFT:  this_token.symbol = SYM_BITSHIFTLEFT; break;
-				case SYM_ASSIGN_BITSHIFTRIGHT: this_token.symbol = SYM_BITSHIFTRIGHT; break;
-				case SYM_ASSIGN_CONCAT:        this_token.symbol = SYM_CONCAT; break;
+				case SYM_ASSIGN_ADD:					this_token.symbol = SYM_ADD; break;
+				case SYM_ASSIGN_SUBTRACT:				this_token.symbol = SYM_SUBTRACT; break;
+				case SYM_ASSIGN_MULTIPLY:				this_token.symbol = SYM_MULTIPLY; break;
+				case SYM_ASSIGN_DIVIDE:					this_token.symbol = SYM_DIVIDE; break;
+				case SYM_ASSIGN_FLOORDIVIDE:			this_token.symbol = SYM_FLOORDIVIDE; break;
+				case SYM_ASSIGN_BITOR:					this_token.symbol = SYM_BITOR; break;
+				case SYM_ASSIGN_BITXOR:					this_token.symbol = SYM_BITXOR; break;
+				case SYM_ASSIGN_BITAND:					this_token.symbol = SYM_BITAND; break;
+				case SYM_ASSIGN_BITSHIFTLEFT:			this_token.symbol = SYM_BITSHIFTLEFT; break;
+				case SYM_ASSIGN_BITSHIFTRIGHT:			this_token.symbol = SYM_BITSHIFTRIGHT; break;
+				case SYM_ASSIGN_BITSHIFTRIGHT_LOGICAL:	this_token.symbol = SYM_BITSHIFTRIGHT_LOGICAL; break;
+				case SYM_ASSIGN_CONCAT:					this_token.symbol = SYM_CONCAT; break;
 				}
 				// Since above didn't goto or break out of the outer loop, this is an assignment other than
 				// SYM_ASSIGN, so it needs further evaluation later below before the assignment will actually be made.
@@ -1128,9 +1129,13 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
 				case SYM_BITXOR:		this_token.value_int64 = left_int64 ^ right_int64; break;
 				case SYM_BITSHIFTLEFT:
 				case SYM_BITSHIFTRIGHT:
+				case SYM_BITSHIFTRIGHT_LOGICAL:
 					if (right_int64 < 0 || right_int64 > 63)
 						goto abort_with_exception;
-					this_token.value_int64 = this_token.symbol == SYM_BITSHIFTLEFT
+					if (this_token.symbol == SYM_BITSHIFTRIGHT_LOGICAL)
+						this_token.value_int64 = (unsigned __int64)left_int64 >> right_int64;
+					else
+						this_token.value_int64 = this_token.symbol == SYM_BITSHIFTLEFT
 						? left_int64 << right_int64
 						: left_int64 >> right_int64;
 					break;


### PR DESCRIPTION
### New:

`a <<< b`, performs logical left bit-shift of `a` by `b` positions.
`a >>> b`, performs logical right bit-shift of `a` by `b` positions.

In both cases, vacant bit-positions are zero-filled. The corresponding compound assignment operators are `>>>=` and `<<<=`.

__Reason__: Convenience.

The reason for adding  `<<<` which behaves identical to `<<` is for _symmetry_ only. If `>>>` is used for logical rightshift, `<<<` is unlikely to be used for anything else. I'd be happy to change the operators to something shorter if anyone has a good suggestion.