### PR TITLE
 adding new directive #LoadLibrary

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -3524,6 +3524,44 @@ inline ResultType Script::IsDirective(LPTSTR aBuf)
 #endif
 	}
 
+	if (IS_DIRECTIVE_MATCH(_T("#LoadLibrary")))
+	{
+		if (!parameter)
+		{
+			// an empty #LoadLibrary restores the default search order.
+			if (!SetDllDirectory(NULL))
+				return ScriptError(ERR_INTERNAL_CALL);
+			return CONDITION_TRUE;
+		}
+		// ignore failure if path is preceeded by "*i".
+		bool ignore_load_failure = (parameter[0] == '*' && ctoupper(parameter[1]) == 'I'); // Relies on short-circuit boolean order.
+		if (ignore_load_failure)
+		{
+			parameter += 2;
+			if (IS_SPACE_OR_TAB(*parameter)) // Skip over at most one space or tab, since others might be a literal part of the filename.
+				++parameter;
+		}
+		LPTSTR library_path;	// needs to be freed before return, unless DerefInclude return FAIL.
+		if (!DerefInclude(library_path, parameter))
+			return FAIL;
+		DWORD attr = GetFileAttributes(library_path);
+		if (attr != 0xFFFFFFFF && (attr & FILE_ATTRIBUTE_DIRECTORY)) // File exists and its a directory
+		{
+			BOOL result = SetDllDirectory(library_path);
+			free(library_path);
+			if (!result)
+				return ScriptError(ERR_INTERNAL_CALL);
+			return CONDITION_TRUE;
+		}
+		ResultType result = CONDITION_TRUE;	// set default
+		HMODULE hmodule = LoadLibrary(library_path);
+		if (!hmodule					// the library couldn't be loaded
+			&& !ignore_load_failure)	// no *i was specified
+			result = ScriptError(_T("Failed to load DLL."), library_path);
+		free(library_path);
+		return result;
+	} // end #LoadLibrary
+
 	if (IS_DIRECTIVE_MATCH(_T("#NoTrayIcon")))
 	{
 		g_NoTrayIcon = true;
@@ -12423,7 +12461,7 @@ BIF_DECL(BIF_PerformAction)
 
 
 ResultType Script::DerefInclude(LPTSTR &aOutput, LPTSTR aBuf)
-// For #Include and #IncludeAgain.
+// For #Include, #IncludeAgain and #LoadLibrary.
 // Based on Line::Deref above, but with a few differences for backward-compatibility:
 //  1) Percent signs that aren't part of a valid deref are not omitted.
 //  2) Escape sequences aren't recognized (`; is handled elsewhere).

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -3555,7 +3555,13 @@ inline ResultType Script::IsDirective(LPTSTR aBuf)
 		}
 		ResultType result = CONDITION_TRUE;	// set default
 		HMODULE hmodule = LoadLibrary(library_path);
-		
+
+		if (hmodule)
+			// "Pin" the dll so that the script cannot unload it with FreeLibrary.
+			// This is done to avoid undefined behaviour when DllCall optimizations
+			// resolves a proc address in a dll loaded by this directive.
+			GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_PIN, library_path, &hmodule);  // MSDN regarding hmodule: "If the function fails, this parameter is NULL."
+
 		if (!hmodule					// the library couldn't be loaded
 			&& !ignore_load_failure)	// no *i was specified
 			result = ScriptError(_T("Failed to load DLL."), library_path);

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -3524,11 +3524,11 @@ inline ResultType Script::IsDirective(LPTSTR aBuf)
 #endif
 	}
 
-	if (IS_DIRECTIVE_MATCH(_T("#LoadLibrary")))
+	if (IS_DIRECTIVE_MATCH(_T("#DllLoad")))
 	{
 		if (!parameter)
 		{
-			// an empty #LoadLibrary restores the default search order.
+			// an empty #DllLoad restores the default search order.
 			if (!SetDllDirectory(NULL))
 				return ScriptError(ERR_INTERNAL_CALL);
 			return CONDITION_TRUE;
@@ -3555,12 +3555,13 @@ inline ResultType Script::IsDirective(LPTSTR aBuf)
 		}
 		ResultType result = CONDITION_TRUE;	// set default
 		HMODULE hmodule = LoadLibrary(library_path);
+		
 		if (!hmodule					// the library couldn't be loaded
 			&& !ignore_load_failure)	// no *i was specified
 			result = ScriptError(_T("Failed to load DLL."), library_path);
 		free(library_path);
 		return result;
-	} // end #LoadLibrary
+	} // end #DllLoad
 
 	if (IS_DIRECTIVE_MATCH(_T("#NoTrayIcon")))
 	{
@@ -12461,7 +12462,7 @@ BIF_DECL(BIF_PerformAction)
 
 
 ResultType Script::DerefInclude(LPTSTR &aOutput, LPTSTR aBuf)
-// For #Include, #IncludeAgain and #LoadLibrary.
+// For #Include, #IncludeAgain and #DllLoad.
 // Based on Line::Deref above, but with a few differences for backward-compatibility:
 //  1) Percent signs that aren't part of a valid deref are not omitted.
 //  2) Escape sequences aren't recognized (`; is handled elsewhere).

--- a/source/stdafx.h
+++ b/source/stdafx.h
@@ -38,7 +38,8 @@ GNU General Public License for more details.
 // UPDATE v1.1.10.00: Using 0x0600 for Vista/7/8's audio APIs.
 // UPDATE v1.1.10.01: Using 0x0600 broke Process Close and who knows what else on Win XP.
 // Instead, use 0x0501 and redefine it to 0x0600 only for the specific APIs which we need.
-#define _WIN32_WINNT 0x0501
+// v2: using 0x0502 for #LoadLibrary, specifically for SetDllDirectory.
+#define _WIN32_WINNT 0x0502
 //#define _WIN32_IE 0x0501  // Added for v1.0.35 to have MCS_NOTODAY resolve as expected, and possibly solve other problems on newer systems.
 #define _WIN32_IE _WIN32_IE_IE70  // Added for TVN_ITEMCHANGED, which most likely requires Vista.
 

--- a/source/stdafx.h
+++ b/source/stdafx.h
@@ -38,7 +38,7 @@ GNU General Public License for more details.
 // UPDATE v1.1.10.00: Using 0x0600 for Vista/7/8's audio APIs.
 // UPDATE v1.1.10.01: Using 0x0600 broke Process Close and who knows what else on Win XP.
 // Instead, use 0x0501 and redefine it to 0x0600 only for the specific APIs which we need.
-// v2: using 0x0502 for #LoadLibrary, specifically for SetDllDirectory.
+// v2: using 0x0502 for #DllLoad, specifically for SetDllDirectory.
 #define _WIN32_WINNT 0x0502
 //#define _WIN32_IE 0x0501  // Added for v1.0.35 to have MCS_NOTODAY resolve as expected, and possibly solve other problems on newer systems.
 #define _WIN32_IE _WIN32_IE_IE70  // Added for TVN_ITEMCHANGED, which most likely requires Vista.


### PR DESCRIPTION
### New:
```autohotkey
#LoadLibrary path_to_dll
#LoadLibrary dir
```
`#LoadLibrary path_to_dll`: Loads the dll at `path_to_dll`. `path_to_dll` can be a relative path or just a filename. `path_to_dll` may be preceded by `*i`, to prevent load time error if `path_to_dll` doesn't exist. This is useful for optional functionality and `fileinstall`.

`#LoadLibrary dir`: Alters the search path for subsequent uses of the directives which doesn't specify a direct path to a _dll_. Similar to `#include dir`, but this calls `SetDllDirectory`. Omitting _dir_, i.e, a lone `#LoadLibrary` restores the default search path for `LoadLibrary` (calls `SetDllDirectory(NULL)`).

Note: the script can call `FreeLibrary` once per `#LoadLibrary` if wanted, otherwise the system will free the library when the application terminates. If calling `FreeLibrary` the script should not execute any _dllcalls_ which has been subject to loadtime optimisation for the relevant dll.

Above, _dll_ can be _exe_.

__Reasons__: enables load time optimisation for `dllcall("dll\function")` which improves performance and convenience, and readability over manually loading and looking up function address via `LoadLibrary` + `GetProcAddress` at run time.


### About the implementation:

Without any fear, changed `_WIN32_WINNT` from `0x0501` to `0x0502`. If this is unacceptable, `#LoadLibrary dir` can be removed and we can use `#include dir` instead, which will call `SetCurrentDirectory` which is against the recommendation in the documentation for `LoadLibrary`.

Cheers.