### PR TITLE
fix BIF_StrGetPut to return byte count instead of char count for zero length string.

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -13631,7 +13631,7 @@ BIF_DECL(BIF_StrGetPut) // BIF_DECL(BIF_StrGet), BIF_DECL(BIF_StrPut)
 				else
 					*(LPSTR)address = '\0';
 			}
-			aResultToken.value_int64 = 1;
+			aResultToken.value_int64 = encoding == CP_UTF16 ? sizeof(WCHAR) : sizeof(CHAR);
 			return;
 		}
 


### PR DESCRIPTION
Issue example,
```autohotkey
msgbox strput('', &a:='a', 'utf-16') ; now 2, prev 1
msgbox strput('', 'utf-16') ; now 2, prev 1
```