### PR TITLE
introducing namespaces.

### DIFF
--- a/AutoHotkeyx.vcxproj
+++ b/AutoHotkeyx.vcxproj
@@ -223,6 +223,7 @@
     <ClCompile Include="source\hotkey.cpp" />
     <ClCompile Include="source\keyboard_mouse.cpp" />
     <ClCompile Include="source\mt19937ar-cok.cpp" />
+    <ClCompile Include="source\NameSpace.cpp" />
     <ClCompile Include="source\os_version.cpp" />
     <ClCompile Include="source\script.cpp" />
     <ClCompile Include="source\script2.cpp" />
@@ -260,6 +261,8 @@
     <ClInclude Include="source\KuString.h" />
     <ClInclude Include="source\lib_pcre\pcre\pcret.h" />
     <ClInclude Include="source\mt19937ar-cok.h" />
+    <ClInclude Include="source\NameSpace.h" />
+    <ClInclude Include="source\NameSpaceDefines.h" />
     <ClInclude Include="source\os_version.h" />
     <ClInclude Include="source\lib_pcre\pcre\pcre.h" />
     <ClInclude Include="source\qmath.h" />

--- a/AutoHotkeyx.vcxproj.filters
+++ b/AutoHotkeyx.vcxproj.filters
@@ -103,6 +103,9 @@
     <ClCompile Include="source\script_com.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="source\NameSpace.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="source\application.h">
@@ -193,6 +196,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="source\script_func_impl.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="source\NameSpace.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="source\NameSpaceDefines.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/source/NameSpace.cpp
+++ b/source/NameSpace.cpp
@@ -1,0 +1,548 @@
+/*
+AutoHotkey
+
+Copyright 2003-2009 Chris Mallett (support@autohotkey.com)
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*/
+
+#include "stdafx.h" // pre-compiled headers
+#include "NameSpace.h"
+
+const LPTSTR NameSpace::sAnonymousNameSpaceName = NAMESPACE_ANONYMOUS_NAME;
+
+ResultType NameSpace::AutoExecSection()
+// Returns FAIL if can't run due to critical error.  Otherwise returns OK.
+{
+	ResultType nested_result;
+	if (mNestedNameSpaces)
+	{
+		if ((nested_result = mNestedNameSpaces->AutoExecSection()) != OK)
+			return nested_result;
+	}
+	// At this point all nested namespaces of this namespace, and their nested namespaces has executed their respective auto execute section, and completed their static var initializers.
+	 
+	// Handle this namespace:
+	SetCurrentNameSpace();	
+	DEBUGGER_STACK_PUSH(_T("Auto-execute"))	// Only after the current namespace has been set.
+	// v2: Ensure the Hotkey command defaults to no criterion rather than the last #IfWin.  
+	mSettings.HotCriterion = NULL;
+	
+	ResultType ExecUntil_result;
+	if (!mFirstLine) // In case it's ever possible to be empty.
+		ExecUntil_result = OK;
+	// And continue on to do normal exit routine so that the right ExitCode is returned by the program.
+	else
+	{
+		// The below also sets g->ThreadStartTime and g->UninterruptibleDuration.  Notes about this:
+		// In case the AutoExecute section takes a long time (or never completes), allow interruptions
+		// such as hotkeys and timed subroutines after a short time. Use g->AllowThreadToBeInterrupted
+		// vs. g_AllowInterruption in case commands in the AutoExecute section need exclusive use of
+		// g_AllowInterruption (i.e. they might change its value to false and then back to true,
+		// which would interfere with our use of that var).
+
+		// In comment below g is now t. References to autoexec timer are obsolete.
+		// UPDATE v1.0.48: g->ThreadStartTime and g->UninterruptibleDuration were added so that IsInterruptible()
+		// won't make the AutoExec section interruptible prematurely.  In prior versions, KILL_AUTOEXEC_TIMER() did this,
+		// but with the new IsInterruptible() function, doing it in KILL_AUTOEXEC_TIMER() wouldn't be reliable because
+		// it might already have been done by IsInterruptible() [or vice versa], which might provide a window of
+		// opportunity in which any use of Critical by the AutoExec section would be undone by the second timeout.
+		// More info: Since AutoExecSection() never calls InitNewThread(), it never used to set the uninterruptible
+		// timer.  Instead, it had its own timer.  But now that IsInterruptible() checks for the timeout of
+		// "Thread Interrupt", AutoExec might become interruptible prematurely unless it uses the new method below.
+		
+		// Set these so that all auto execute sections have an (as) equal (as possible) chance to do their thing.
+		t->AllowThreadToBeInterrupted = false;
+		t->ThreadStartTime = GetTickCount();
+		t->UninterruptibleDuration = AUTO_EXEC_UNINTERRUPTIBLE_DURATION;
+		t->UninterruptibleDuration = 0; // So that ExecUntil below calls SetThreadCriticalStatus. Better to do it this way for maintainability.
+
+		// v1.0.25: This is now done here, closer to the actual execution of the first line in the (edit: namespace rather than script),
+		// to avoid an unnecessary Sleep(10) that would otherwise occur in ExecUntil:
+		g_script.mLastPeekTime = GetTickCount();
+		ExecUntil_result = mFirstLine->ExecUntil(UNTIL_RETURN); // Might never return (e.g. infinite loop or ExitApp).
+		
+	}	
+
+	// REMEMBER: The ExecUntil() call above will never return if the AutoExec section never finishes
+	// (e.g. infinite loop) or it uses Exit/ExitApp.
+
+	// It seems best to set ErrorLevel to NONE after the auto-execute part of the script is done.
+	// However, it isn't set to NONE right before launching each new thread (e.g. hotkey subroutine)
+	// because it's more flexible that way (i.e. the user may want one hotkey subroutine to use the value
+	// of ErrorLevel set by another).  This reset was also done by LoadFromFile(), but it is done again
+	// here in case the auto-execute section changed it:
+	g_ErrorLevel->Assign(ERRORLEVEL_NONE);
+	DEBUGGER_STACK_POP()
+	return ExecUntil_result;
+}
+
+Var *NameSpace::FindVar(LPTSTR aVarName, size_t aVarNameLength, int *apInsertPos, int aScope, bool *apIsLocal)
+{
+	NameSpace *prev_namespace = g_CurrentNameSpace;	// save current namespace
+	SetCurrentNameSpace();	// Could assign to g_CurrentNameSpace but done this way for maintainability
+	Var *found_var = g_script.FindVar(aVarName, aVarNameLength, apInsertPos, aScope, apIsLocal);
+	prev_namespace->SetCurrentNameSpace(); // restore namespace
+	return found_var;
+}
+
+Var *NameSpace::FindOrAddVar(LPTSTR aVarName, size_t aVarNameLength /* = 0 */, int aScope /*= FINDVAR_DEFAULT*/) // public
+{
+	NameSpace *prev_namespace = g_CurrentNameSpace;	// save current namespace
+	SetCurrentNameSpace();	// Could assign to g_CurrentNameSpace but done this way for maintainability
+	Var *found_var = g_script.FindOrAddVar(aVarName, aVarNameLength, aScope);
+	prev_namespace->SetCurrentNameSpace(); // restore namespace
+	return found_var;
+}
+
+Func *NameSpace::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength /*= -1*/, int *apInsertPos /*= NULL*/, bool aAllowNested /*= true*/)  // public
+{
+	NameSpace *prev_namespace = g_CurrentNameSpace;	// save current namespace
+	SetCurrentNameSpace();	// cannot just assign g_CurrentNameSpace.
+	Func *found_func = g_script.FindFunc(aFuncName, aFuncNameLength, apInsertPos, aAllowNested);
+	prev_namespace->SetCurrentNameSpace(); // restore namespace
+	return found_func;
+}
+
+// End Script methods
+
+Var * NameSpace::FindVarFromScopeSymbolDelimitedString(LPTSTR aString, bool aAllowAddVar, NameSpace **aFoundNameSpace)
+{
+	// aString, a OPERATOR_SCOPE_SYMBOL delitmited string. Caller is responsible for aString containing at least one delimiter. 
+	//			White space is trimmed but any other invalid symbols are not detected, see next param for exception.
+	// aAllowAddVar, set to true to indicate that if the variable isn't found, it can be added. The var name is validated only if aAllowAddVar is true.
+	// aFoundNameSpace, the namespace in which var was searched for. If *aFoundNameSpace is NULL when this function returns the namespace(s) doesn't exist.
+	
+	// Call BIF_StrSplit to split the string and trim any spaces or tabs. Then use Object::ArrayToStrings.
+	// Done this way for convenience, it isn't the most efficient way imaginable.
+	// Array: = StrSplit(String, Delimiters, OmitChars, MaxParts : = -1)
+	CALL_BIF(StrSplit, result_token,
+		aString,							// String
+		OPERATOR_SCOPE_SYMBOL,				// Delimiters
+		_T(" \t"))							// OmitChars
+	if (CALL_TO_BIF_FAILED(result_token))
+		return NULL; // This is probably out of memory, currently this is not handled but the program should soon fail somewhere else if such a small memory commitment fails here.
+	
+	Object *arr = (Object *)TokenToObject(result_token);	// Array
+	
+	Var* var = NULL;
+	int count = arr->GetNumericItemCount();
+	LPTSTR *strings = (LPTSTR *)alloca(count * sizeof LPTSTR);
+	NameSpace *found_namespace = this;
+	if (arr->ArrayToStrings(strings, count, count)) // should never fail but better safe than sorry.
+	{
+		for (int i = 0; i < count - 1; ++i) // the last string is the variable name, hence the "-1"
+			if (!(found_namespace = found_namespace->GetNestedNameSpace(strings[i], true)))
+				break;
+		LPTSTR var_name = strings[count - 1]; // AddVar will validate the name but not FindVar.
+		if (found_namespace)
+		{
+			var = aAllowAddVar ? found_namespace->FindOrAddVar(var_name, 0, FINDVAR_GLOBAL)			// can add
+				: found_namespace->FindVar(var_name, 0, NULL, FINDVAR_GLOBAL, NULL);				// cannot add
+			if (aFoundNameSpace)
+				*aFoundNameSpace = found_namespace; // caller wants the found namespace
+		}
+	}
+	arr->Release();
+	return var; // Can be NULL
+}
+
+NameSpace::~NameSpace()
+{
+	if (mNestedNameSpaces)
+		delete mNestedNameSpaces;
+	if (mOptionalNameSpaces)
+		delete mOptionalNameSpaces;
+#ifndef AUTOHOTKEYSC
+	if (mSourceFileIndexList)
+		delete mSourceFileIndexList;
+#endif
+}
+
+bool NameSpace::AddOptionalNameSpace(LPTSTR aName)
+{
+	// adds aName to a list of namespace names which will not cause load time error if not found.
+	// to allow "#import *i". Search word: NAMESPACE_INCLUDE_DIRECTIVE_NAME
+	// returns false on out of memory, else true.
+
+	if (!mOptionalNameSpaces)
+		mOptionalNameSpaces = new NameSpaceNameList;
+	LPTSTR name = _tcsdup(aName);
+	if (!name)
+		return false;
+	if (!mOptionalNameSpaces->AddItem(name))
+	{
+		free(name);
+		return false;
+	}
+	return true;
+}
+
+bool NameSpace::IsOptionalNameSpace(LPTSTR aName)
+{
+	// returns true if aName is in the list of optional namespaces.
+	if (!mOptionalNameSpaces)
+		return false;
+	return mOptionalNameSpaces->HasItem(aName);
+}
+
+void NameSpace::FreeOptionalNameSpaceList() 
+{
+	// frees the list of optional namespaces for this namespace and all of its nested ones.
+	if (mNestedNameSpaces)
+		mNestedNameSpaces->FreeOptionalNameSpaceList();
+	if (mOptionalNameSpaces)
+		delete mOptionalNameSpaces;
+	mOptionalNameSpaces = NULL;
+}
+#ifndef AUTOHOTKEYSC
+bool NameSpace::AddSourceFileIndex(int aIndex)
+{
+	// Adds an index to the list of files which was included in this namespace.
+	// Each index in the list corresponds to a source file in Line::sSourceFile
+	// returns false on out of memory, else true.
+
+	if (!mSourceFileIndexList)
+		mSourceFileIndexList = new SimpleList<int>;
+	return mSourceFileIndexList->AddItem(aIndex);
+	
+}
+
+void NameSpace::FreeSourceFileIndexList()
+{
+	// frees the list of source file indices for this namespace and all of its nested ones.
+	if (mNestedNameSpaces)
+		mNestedNameSpaces->FreeSourceFileIndexList();
+	if (mSourceFileIndexList)
+		delete mSourceFileIndexList;
+	mSourceFileIndexList = NULL;
+}
+
+bool NameSpace::HasIncludedSourceFile(TCHAR aPath[])
+{
+	// Finds if aPath was #include:ed in this namespace.
+	if (!mSourceFileIndexList)
+		return false;		// no list, not included.
+	int index = 0;			// iteration index for GetItem (which does the bound checks)
+	int source_index;		// result from get item
+	bool was_found;			// break loop criteria.
+	// Note:
+	// mSourceFileIndexList only contains indicies which are valid for Line::sSourceFile, so the below is safe.
+	while (1)
+	{
+		source_index = mSourceFileIndexList->GetItem(index++, &was_found);
+		if (!was_found) // means no more items in the list to check.
+			return false;
+		if (!lstrcmpi(Line::sSourceFile[source_index], aPath)) // Case insensitive like the file system (testing shows that "Ä" == "ä" in the NTFS, which is hopefully how lstrcmpi works regardless of locale).
+			return true;
+	}
+}
+#endif // #ifndef AUTOHOTKEYSC
+
+NameSpace *NameSpace::GetNestedNameSpace(LPTSTR aNameSpaceName, bool aAllowReserved /*= false*/) // public
+{
+	NameSpace *found;
+	if (aAllowReserved)
+		if (found = GetReservedNameSpace(aNameSpaceName, this))
+			return found;
+	// not a reserved namespace or not looking for one, search nested namespaces, if any.
+	if (!mNestedNameSpaces)
+		return NULL; // no nested
+	mNestedNameSpaces->find(aNameSpaceName, &found); 
+	return found;
+}
+
+NameSpace *NameSpace::GetReservedNameSpace(LPTSTR aName, NameSpace* aSource /* = NULL */) // static public
+{
+	// aName, the name of the namespace to return.
+	// aSource, if aName doesn't match any of the "standard/default" namespaces, find a namespace relative to aSource, for example aSource outer namespace. Can be NULL (omitted).
+	// Get one of the namespaces whose name are reserved. See NameSpaceDefines.h
+	if (NAMESPACE_NAMES_MATCH(aName, NAMESPACE_STANDARD_NAMESPACE_NAME))
+		return g_StandardNameSpace;
+	if (NAMESPACE_NAMES_MATCH(aName, NAMESPACE_DEFAULT_NAMESPACE_NAME))
+		return g_DefaultNameSpace;
+	
+	// Handle relative names:
+	if (!aSource)
+		return NULL;
+	if (NAMESPACE_NAMES_MATCH(aName, NAMESPACE_OUTER_NAMESPACE_NAME))
+		return aSource->mOuter;
+	if (NAMESPACE_NAMES_MATCH(aName, NAMESPACE_TOP_NAMESPACE_NAME))
+		return aSource->GetTopNameSpace();
+	return NULL;
+}
+
+bool NameSpace::SetCurrentNameSpace()	// public
+{
+	// The caller is responsible for restoring the previous namespace if needed.
+	if (this != g_CurrentNameSpace)
+	{
+		g_CurrentNameSpace = this;					// set this to the current namespace.
+		g = &mSettings;								// use the settings of this namespace.
+		return true;	// to indicate namespace was changed.
+	}
+	return false;	// to indicate no restoring needed.
+}
+
+global_struct &NameSpace::GetSettings()
+{
+	// This is needed by HOT_IF_WIN
+	return mSettings;
+}
+
+NameSpace * NameSpace::GetTopNameSpace()
+{
+	// Finds the top namespace for this namespace.
+	NameSpace *top = this; // this function can never return "this" namespace.
+	while ((top = top->GetOuterNameSpace()) && !top->mIsTopNameSpace);
+	return top;
+}
+
+NameSpace * NameSpace::GetOuterNameSpace()
+{
+	// Returns the outer namespace, this can be NULL. 
+	// g_DefaultNameSpace and g_StandardNameSpace does not have any outer namespace, this is relies upon at least in Debugger::context_get.
+	return mOuter;
+}
+
+// Func methods, public:
+
+Func* NameSpace::FuncFind(LPCTSTR aName, int *apInsertPos)
+{
+	return mFuncs.Find(aName, apInsertPos);
+}
+Func* NameSpace::FuncFind(LPCTSTR aName, size_t aNameLength, int *apInsertPos, bool aAllowNested)
+{
+	Func *found_func;
+	NameSpace *prev_namespace = g_CurrentNameSpace;
+	SetCurrentNameSpace();									// Must be set for Script::FindFunc
+	found_func = g_script.FindFunc(aName, aNameLength, apInsertPos, aAllowNested);
+	prev_namespace->SetCurrentNameSpace();
+	return found_func;
+}
+
+ResultType NameSpace::FuncInsert(Func *aFunc, int aInsertPos)
+{
+	return mFuncs.Insert(aFunc, aInsertPos);
+}
+ResultType NameSpace::FuncAlloc(int aAllocCount)
+{
+	return mFuncs.Alloc(aAllocCount);
+}
+
+FuncList &NameSpace::GetFuncs()
+{
+	return mFuncs;
+}
+
+// Var methods, public:
+Var** &NameSpace::GetVar() 
+{
+	return mVar;
+}
+Var** &NameSpace::GetLazyVar()
+{
+	return mLazyVar;
+}
+int &NameSpace::GetVarCount()
+{
+	return mVarCount;
+}
+int &NameSpace::GetLazyVarCount()
+{
+	return mLazyVarCount;
+}
+int &NameSpace::GetVarCountMax()
+{
+	return mVarCountMax;
+}
+
+// Methods for releasing objects in vars:
+void NameSpace::ReleaseVarObjects(Var** aVar, int aVarCount) // private
+{
+	for (int i = 0; i < aVarCount; ++i)
+		if (aVar[i]->IsObject())
+			aVar[i]->ReleaseObject(); // ReleaseObject() vs Free() for performance (though probably not important at this point).
+		// Otherwise, maybe best not to free it in case an object's __Delete meta-function uses it?
+	return;
+}
+void NameSpace::ReleaseStaticVarObjects(Var **aVar, int aVarCount) // private
+{
+	for (int i = 0; i < aVarCount; ++i)
+		if (aVar[i]->IsStatic() && aVar[i]->IsObject()) // For consistency, only free static vars (see below).
+			aVar[i]->ReleaseObject();
+}
+void NameSpace::ReleaseStaticVarObjects(FuncList &aFuncs) // private
+{
+	for (int i = 0; i < aFuncs.mCount; ++i)
+	{
+		Func &f = *aFuncs.mItem[i];
+		if (f.mIsBuiltIn)
+			continue;
+		// Since it doesn't seem feasible to release all var backups created by recursive function
+		// calls and all tokens in the 'stack' of each currently executing expression, currently
+		// only static and global variables are released.  It seems best for consistency to also
+		// avoid releasing top-level non-static local variables (i.e. which aren't in var backups).
+		ReleaseStaticVarObjects(f.mVar, f.mVarCount);
+		ReleaseStaticVarObjects(f.mLazyVar, f.mLazyVarCount);
+		if (f.mFuncs.mCount)
+			ReleaseStaticVarObjects(f.mFuncs);
+	}
+}
+void NameSpace::ReleaseVarObjects()	// public
+{
+	ReleaseVarObjects(mVar, mVarCount);
+	ReleaseVarObjects(mLazyVar, mLazyVarCount);
+	ReleaseStaticVarObjects(mFuncs);
+	if (mNestedNameSpaces)
+		mNestedNameSpaces->ReleaseVarObjects(); // release nested last, it seems more likely that the outer namespace refers to the nested ones, than the other way around.
+}
+
+Func * NameSpace::TokenToFunc(ExprTokenType & aToken, bool aAllowNested)
+{
+	// equivalent to calling ::TokenToFunc in the context of this namespace and restoring the previous namespace.
+	Func *func;
+	NameSpace *prev_namespace = g_CurrentNameSpace;
+	SetCurrentNameSpace();
+	// the following is similar to ::TokenToFunc.
+	if (!(func = dynamic_cast<Func *>(TokenToObject(aToken))))
+	{
+		LPTSTR func_name = TokenToString(aToken);
+		if (*func_name)
+			func = FindFunc(func_name, -1, NULL, aAllowNested);
+	}
+	prev_namespace->SetCurrentNameSpace();
+	return func;
+}
+
+NameSpace *NameSpace::InsertNestedNameSpace(LPTSTR aName, int aFuncsInitSize, NameSpace *aOuter, bool aIsTopNameSpace) // public
+{
+	// Creates a new namespace and inserts it in the this namespace' mNestedNameSpaces.
+	// Duplicate namespace names are detected and causes NULL to be returned. Otherwise the new namespace is returned.
+	// NULL might also be returned in case of some failed memory allocation
+
+	// aName, the name of the new namespace to create and insert
+	// aFuncsInitSize, the number of functions to allocate space for in the namespace' FuncList mFuncs.
+	// aOuter, the enclosing namespace. This will mostlikey always be g_CurrentNameSpace unless g_CurrentNameSpace is one of the top level namespaces.
+	
+	// Since using SimpleHeap::Malloc for allocation of namespaces, callers of this function should avoid
+	// making "many" calls where InsertNestedNameSpace below fails due to duplicate name. The only current caller, DefineNameSpace
+	// causes the program to end on failure.
+	NameSpace *new_namespace = new NameSpace(aName, aFuncsInitSize, aOuter, aIsTopNameSpace);
+	if (InsertNestedNameSpace(new_namespace))
+		return new_namespace;
+	delete new_namespace;
+	return NULL;
+}	
+bool NameSpace::InsertNestedNameSpace(NameSpace *aNameSpace) // public
+{
+	// aNameSpace, the namespace to insert in this namespace' mNestedNameSpaces.
+	// Returns false on out of memory or if this namespace was already added. Otherwise true.
+	if (!mNestedNameSpaces)	// If mNestedNameSpaces doesn't exist, it is created.
+		if (!(mNestedNameSpaces = new NameSpaceList())) // Check since `new` is overloaded to use SimpleHeap::Malloc
+			return false;
+	return mNestedNameSpaces->Add(aNameSpace);
+}
+
+void NameSpace::RemoveLastNameSpace()
+{
+	// caller has ensured mNestedNameSpaces must exist.
+	mNestedNameSpaces->RemoveLastNameSpace();
+}
+
+//
+//	NameSpaceList methods.
+//
+#define NAMESPACELIST_INITIAL_SIZE (5)
+#define NAMESPACELIST_SIZE_GROW (5)
+bool NameSpaceList::Add(NameSpace *aNameSpace)
+{
+	// Adds aNameSpace to mList
+	// return true on succsess, else false
+	if (!aNameSpace)
+		return false;
+	if (IsInList(aNameSpace))	// Namespace names must be unique
+		return false;
+	if (mCount == mListSize) // Expand if needed
+	{
+		size_t new_size = mListSize ? NAMESPACELIST_INITIAL_SIZE : mListSize + NAMESPACELIST_SIZE_GROW;
+		NameSpace **new_list = (NameSpace**)realloc(mList, sizeof(NameSpace*) * new_size);
+		if (!new_list)
+			return false; // out of memory
+		mListSize = new_size;
+		mList = new_list;
+	}
+	// Add namespace and increment count
+	mList[mCount] = aNameSpace;
+	mCount++;
+	return true;
+}
+
+void NameSpaceList::RemoveLastNameSpace()
+{
+	// removes the last namespace.
+	ASSERT(mList);
+	delete mList[--mCount];
+}
+
+bool NameSpaceList::IsInList(NameSpace* aNameSpace)
+{
+	return find(aNameSpace->GetName());
+}
+
+bool NameSpaceList::find(LPTSTR aName, NameSpace **aFound)
+{
+	// Anonymous namespaces never match.
+	for (size_t i = 0; i < mCount; ++i)
+	{
+		if (NAMESPACE_NAMES_MATCH(aName, mList[i]->GetName()))
+		{
+			if (aFound)
+				*aFound = mList[i];
+			return true;
+		}
+	}
+	return false;
+}
+
+ResultType NameSpaceList::AutoExecSection()
+{
+	// Run each namespace' auto exec section.
+	ResultType result;
+	for (size_t i = 0; i < mCount; ++i)
+		if ((result = mList[i]->AutoExecSection()) != OK)
+			return result;
+	return OK;
+}
+
+void NameSpaceList::ReleaseVarObjects() // public
+{
+	for (size_t i = 0; i < mCount; ++i)
+		mList[i]->ReleaseVarObjects(); // this releases the vars in the nested namespaces too.
+}
+
+void NameSpaceList::FreeOptionalNameSpaceList()
+{
+	// see the corresponding NameSpace:: method of comments
+	for (size_t i = 0; i < mCount; ++i)
+		mList[i]->FreeOptionalNameSpaceList();
+}
+#ifndef AUTOHOTKEYSC
+void NameSpaceList::FreeSourceFileIndexList()
+{
+	// see the corresponding NameSpace:: method of comments
+	for (size_t i = 0; i < mCount; ++i)
+		mList[i]->FreeSourceFileIndexList();
+}
+#endif
+
+#undef NAMESPACELIST_INITIAL_SIZE
+#undef NAMESPACELIST_SIZE_GROW

--- a/source/NameSpace.cpp
+++ b/source/NameSpace.cpp
@@ -275,8 +275,6 @@ NameSpace *NameSpace::GetReservedNameSpace(LPTSTR aName, NameSpace* aSource /* =
 		return NULL;
 	if (NAMESPACE_NAMES_MATCH(aName, NAMESPACE_OUTER_NAMESPACE_NAME))
 		return aSource->mOuter;
-	if (NAMESPACE_NAMES_MATCH(aName, NAMESPACE_TOP_NAMESPACE_NAME))
-		return aSource->GetTopNameSpace();
 	return NULL;
 }
 
@@ -296,14 +294,6 @@ global_struct &NameSpace::GetSettings()
 {
 	// This is needed by HOT_IF_WIN
 	return mSettings;
-}
-
-NameSpace * NameSpace::GetTopNameSpace()
-{
-	// Finds the top namespace for this namespace.
-	NameSpace *top = this; // this function can never return "this" namespace.
-	while ((top = top->GetOuterNameSpace()) && !top->mIsTopNameSpace);
-	return top;
 }
 
 NameSpace * NameSpace::GetOuterNameSpace()
@@ -423,7 +413,7 @@ Func * NameSpace::TokenToFunc(ExprTokenType & aToken, bool aAllowNested)
 	return func;
 }
 
-NameSpace *NameSpace::InsertNestedNameSpace(LPTSTR aName, int aFuncsInitSize, NameSpace *aOuter, bool aIsTopNameSpace) // public
+NameSpace *NameSpace::InsertNestedNameSpace(LPTSTR aName, int aFuncsInitSize, NameSpace *aOuter) // public
 {
 	// Creates a new namespace and inserts it in the this namespace' mNestedNameSpaces.
 	// Duplicate namespace names are detected and causes NULL to be returned. Otherwise the new namespace is returned.
@@ -436,7 +426,7 @@ NameSpace *NameSpace::InsertNestedNameSpace(LPTSTR aName, int aFuncsInitSize, Na
 	// Since using SimpleHeap::Malloc for allocation of namespaces, callers of this function should avoid
 	// making "many" calls where InsertNestedNameSpace below fails due to duplicate name. The only current caller, DefineNameSpace
 	// causes the program to end on failure.
-	NameSpace *new_namespace = new NameSpace(aName, aFuncsInitSize, aOuter, aIsTopNameSpace);
+	NameSpace *new_namespace = new NameSpace(aName, aFuncsInitSize, aOuter);
 	if (!new_namespace) // Check since `new` is overloaded to use SimpleHeap::Malloc
 		return NULL;
 	if (InsertNestedNameSpace(new_namespace))

--- a/source/NameSpace.cpp
+++ b/source/NameSpace.cpp
@@ -437,6 +437,8 @@ NameSpace *NameSpace::InsertNestedNameSpace(LPTSTR aName, int aFuncsInitSize, Na
 	// making "many" calls where InsertNestedNameSpace below fails due to duplicate name. The only current caller, DefineNameSpace
 	// causes the program to end on failure.
 	NameSpace *new_namespace = new NameSpace(aName, aFuncsInitSize, aOuter, aIsTopNameSpace);
+	if (!new_namespace) // Check since `new` is overloaded to use SimpleHeap::Malloc
+		return NULL;
 	if (InsertNestedNameSpace(new_namespace))
 		return new_namespace;
 	delete new_namespace;

--- a/source/NameSpace.h
+++ b/source/NameSpace.h
@@ -1,0 +1,224 @@
+/*
+AutoHotkey
+
+Copyright 2003-2009 Chris Mallett (support@autohotkey.com)
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*/
+
+#include "defines.h"
+#include "var.h"
+#include "globaldata.h"
+#include "script.h"
+#include "NameSpaceDefines.h"
+
+// Both class NameSpace and class NameSpaceList uses SimpleHeap::Malloc with the `new` operator.
+
+// Forward declarations.
+class NameSpaceList;
+struct FuncList;
+class Line;
+class NameSpace
+{
+private:
+	LPTSTR mName;										// Name of namespace.
+	NameSpaceList *mNestedNameSpaces;					// List of nested namespaces, this is NULL until a request to add a nested namespace, see InsertNestedNameSpace
+	NameSpace *mOuter;									// The namesspace in which this name space resides. 
+														// Having a reference to the enclosing namespace facilitates load time restoration of the outer namespace when the inner namespace definition ends.
+														// Also used by scope operator to access the enclosing scope, referenced to as NAMESPACE_OUTER_NAMESPACE_NAME.
+	// Top namespace:
+	// A top namespace can be reference to by all its nested
+	// namespaces via NAMESPACE_TOP_NAMESPACE_NAME with the scope operator
+	bool mIsTopNameSpace;								// Indicates wheter this namespace is a "top" namespace or not.
+												
+	FuncList mFuncs;									// List of functions
+	Var **mVar, **mLazyVar;								// Array of pointers-to-variable, allocated upon first use and later expanded as needed.
+	int mVarCount, mVarCountMax, mLazyVarCount;			// Count of items in the above array as well as the maximum capacity.
+	
+	// Only for load time -- start
+	class NameSpaceNameList : public SimpleList<LPTSTR>
+	{
+	public:
+		NameSpaceNameList() : SimpleList(true) {}
+		bool AreEqual(LPTSTR aName1, LPTSTR aName2) { return NAMESPACE_NAMES_MATCH(aName1, aName2); } // virtual
+		void FreeItem(LPTSTR aName) { free(aName); }	// virtual
+	} *mOptionalNameSpaces;								// A list of optional namespaces to allow "#import *i". Search word: NAMESPACE_INCLUDE_DIRECTIVE_NAME
+
+#ifndef AUTOHOTKEYSC
+	SimpleList<int> *mSourceFileIndexList;				// A list of numbers corresponding to indices in Line::sSourceFile, to allow #include duplicates across namespaces.
+#endif
+	
+	// Only for load time -- end
+
+	global_struct mSettings;							// The settings belonging to the namespace.
+
+
+	bool mLaunchesCriticalThreads;						// If true, each new thread which has its first line in this namespace, will be critical.
+	DWORD mPeekFrequency;								// The peek frequency for critical threads.
+
+	
+	// Methods for releasing objects in vars.
+	void ReleaseVarObjects(Var** aVar, int aCount);
+	void ReleaseStaticVarObjects(Var **aVar, int aVarCount);
+	void ReleaseStaticVarObjects(FuncList &aFuncs);
+
+public:
+	static const LPTSTR sAnonymousNameSpaceName;							// All anonymous namespaces will share this name
+																			// to facilitate implementation and debugging.
+
+	// To control the order of the autoexecute sections and static var initializers,
+	// the following "Script::" vars and methods are introduced.
+	Line *mFirstLine, *mLastLine;											// For starting the autoexec section for each namespace.
+	Line *mFirstStaticLine, *mLastStaticLine;								// The first and last static var initializer.
+
+	ResultType AutoExecSection();											// Each namespace has its own autoexecute section.
+
+	// only for load time:
+	Object *mUnresolvedClasses;		// A list of unresolved classes. To enable extending a class which definition has not yet been encountered.
+	bool mNoHotkeyLabels;			// To indicate that the first hotkey in this namespace should be "prefixed" with a return line.	
+	bool mHasPreparsedExpressions;	// If true, indicates that when auto including a func due to the scope operator, the new lines must be preparsed separately.
+
+	Var *FindVar(LPTSTR aVarName, size_t aVarNameLength = 0, int *apInsertPos = NULL, int aScope = FINDVAR_DEFAULT, bool *apIsLocal = NULL);
+	Var *FindOrAddVar(LPTSTR aVarName, size_t aVarNameLength = 0, int aScope = FINDVAR_DEFAULT);
+	Func *FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength = -1, int *apInsertPos = NULL, bool aAllowNested = true);
+	// end "Script::" vars and methods.
+
+	Var *FindVarFromScopeSymbolDelimitedString(LPTSTR aString, bool aAllowAddVar, NameSpace **aFoundNameSpace = NULL);
+
+	NameSpace(LPTSTR aName, int aFuncsInitSize = 0, NameSpace *aOuter = NULL, bool aIsTopNameSpace = false) :
+		mNestedNameSpaces(NULL),
+		mOptionalNameSpaces(NULL),
+#ifndef AUTOHOTKEYSC
+		mSourceFileIndexList(NULL),
+#endif
+		mFirstLine(NULL), mLastLine(NULL),
+		mFirstStaticLine(NULL), mLastStaticLine(NULL),
+		mUnresolvedClasses(NULL),
+		mNoHotkeyLabels(true),
+		mHasPreparsedExpressions(false),
+		mVar(NULL), mLazyVar(NULL),
+		mVarCount(0), mVarCountMax(0), mLazyVarCount(0),
+		mOuter(aOuter),
+		mIsTopNameSpace(aIsTopNameSpace),
+		mLaunchesCriticalThreads(false),
+		mPeekFrequency(DEFAULT_PEEK_FREQUENCY)
+	{
+		if (aName != NAMESPACE_ANONYMOUS)
+			mName = SimpleHeap::Malloc(aName);	// copy the name for simplicity.
+		else
+			mName = NAMESPACE_ANONYMOUS;
+		if (!mName)
+			return; // out of memory
+		if (aFuncsInitSize && !mFuncs.Alloc(aFuncsInitSize))
+			return; // out of memory
+
+		global_init(mSettings);			// sets defaults
+	}
+	~NameSpace();
+	LPTSTR GetName() { return mName; }
+	NameSpaceList *GetNestedNameSpaces() { return mNestedNameSpaces; }		// Returns the list on nested namespaces.
+	bool IsNestedNamespace() { return mOuter != NULL; }						// Returns true if this namesspace is nested inside another nested namespace.
+	bool LeaveCurrentNameSpace() { return mOuter->SetCurrentNameSpace(); }	// Sets the enclosing namespace to be the current namespace.
+																			// Caller must ensure mOuter is not NULL. This should only happen for the default and standard namespaces.
+	bool AddOptionalNameSpace(LPTSTR aName);								// Manages a list of optional namespaces. To avoid load time errors when using "#import *i". Search word: NAMESPACE_INCLUDE_DIRECTIVE_NAME
+	bool IsOptionalNameSpace(LPTSTR aName);									// Finds a name in the list of optional namespaces.
+	void FreeOptionalNameSpaceList();
+#ifndef AUTOHOTKEYSC
+	bool AddSourceFileIndex(int aIndex);
+	void FreeSourceFileIndexList();
+	bool HasIncludedSourceFile(TCHAR aPath[]);
+#endif
+
+	// For handling critical:
+	void SetThreadCriticalStatus(ScriptThread &t) { t.ThreadIsCritical = mLaunchesCriticalThreads; t.PeekFrequency = mPeekFrequency; t.AllowThreadToBeInterrupted = (bool)mLaunchesCriticalThreads; }
+	DWORD GetPeekFrequency() { return mPeekFrequency; }
+	bool GetCritical() { return mLaunchesCriticalThreads; }
+	void MakeNameSpaceCritical(DWORD aNewPeekFrequency) { mLaunchesCriticalThreads = true;  mPeekFrequency = aNewPeekFrequency; }
+	void MakeNameSpaceNonCritical() { mLaunchesCriticalThreads = false; mPeekFrequency = DEFAULT_PEEK_FREQUENCY; }
+
+	NameSpace *GetNestedNameSpace(LPTSTR aNameSpaceName, bool aAllowReserved = false); // returns the namespace if this namespace has a nested namespace with name aNameSpaceName, else NULL.
+	
+
+	static NameSpace *GetReservedNameSpace(LPTSTR aName, NameSpace* aSource = NULL); // Returns one of the reserved namespace if aName matches.
+
+	
+	bool SetCurrentNameSpace();												// Sets this namespace to be the current one, should always be used instead of assigning g_CurrentNameSpace directly.
+
+	global_struct &GetSettings();											// This is needed by HOT_IF_ACTIVE et al.
+
+	NameSpace *GetTopNameSpace();
+	NameSpace *GetOuterNameSpace();
+	// Methods for inserting nested namespaces:
+	NameSpace *InsertNestedNameSpace(LPTSTR aName, int aFuncsInitSize = 0, NameSpace *aOuter = NULL, bool aIsTopNameSpace = false);
+	bool InsertNestedNameSpace(NameSpace *aNameSpace);
+	void RemoveLastNameSpace();
+
+	// Misc methods:
+	void ReleaseVarObjects();			// Called during application termination.
+
+	Func *TokenToFunc(ExprTokenType &aToken, bool aAllowNested = false);
+
+	// FuncList method wrappers:
+	Func *FuncFind(LPCTSTR aName, int *apInsertPos);
+	Func* FuncFind(LPCTSTR aName, size_t aNameLength, int *apInsertPos = NULL, bool aAllowNested = false);
+	ResultType FuncInsert(Func *aFunc, int aInsertPos);
+	ResultType FuncAlloc(int aAllocCount);
+	FuncList &GetFuncs();
+
+	// Var methods
+	Var** &GetVar();
+	Var** &GetLazyVar();
+	int &GetVarCount();
+	int &GetLazyVarCount();
+	int &GetVarCountMax();
+
+	// Operators
+	void *operator new(size_t aBytes) { return SimpleHeap::Malloc(aBytes); }
+	void *operator new[](size_t aBytes) { return SimpleHeap::Malloc(aBytes); }
+	void operator delete(void *aPtr) {}
+	void operator delete[](void *aPtr) {}
+
+};
+
+class NameSpaceList
+{
+	NameSpace **mList;				// an array of namespaces
+	size_t mCount;					// the number of namespaces in mList
+	size_t mListSize;				// the size of mList
+public:
+	NameSpaceList() : mList(NULL), mCount(0), mListSize(0) {}	// constructor
+	~NameSpaceList()
+	{
+		if (mList)
+			free(mList);
+	}
+	// list management:
+	bool Add(NameSpace * aNameSpace);
+	void RemoveLastNameSpace();
+	bool IsInList(NameSpace *aNameSpace);
+	bool find(LPTSTR aName, NameSpace **aFound = NULL);
+
+	// Script methods:
+	ResultType AutoExecSection();
+	void ReleaseVarObjects();
+	
+	// misc methods:
+	void FreeOptionalNameSpaceList();	// calls the corresponding NameSpace method for all namespaces in the list.
+#ifndef AUTOHOTKEYSC
+	void FreeSourceFileIndexList();		// ---
+#endif
+	
+	// Operators
+	void *operator new(size_t aBytes) { return SimpleHeap::Malloc(aBytes); }
+	void *operator new[](size_t aBytes) { return SimpleHeap::Malloc(aBytes); }
+	void operator delete(void *aPtr) {}
+	void operator delete[](void *aPtr) {}
+};

--- a/source/NameSpace.h
+++ b/source/NameSpace.h
@@ -34,10 +34,6 @@ private:
 	NameSpace *mOuter;									// The namesspace in which this name space resides. 
 														// Having a reference to the enclosing namespace facilitates load time restoration of the outer namespace when the inner namespace definition ends.
 														// Also used by scope operator to access the enclosing scope, referenced to as NAMESPACE_OUTER_NAMESPACE_NAME.
-	// Top namespace:
-	// A top namespace can be reference to by all its nested
-	// namespaces via NAMESPACE_TOP_NAMESPACE_NAME with the scope operator
-	bool mIsTopNameSpace;								// Indicates wheter this namespace is a "top" namespace or not.
 												
 	FuncList mFuncs;									// List of functions
 	Var **mVar, **mLazyVar;								// Array of pointers-to-variable, allocated upon first use and later expanded as needed.
@@ -93,7 +89,7 @@ public:
 
 	Var *FindVarFromScopeSymbolDelimitedString(LPTSTR aString, bool aAllowAddVar, NameSpace **aFoundNameSpace = NULL);
 
-	NameSpace(LPTSTR aName, int aFuncsInitSize = 0, NameSpace *aOuter = NULL, bool aIsTopNameSpace = false) :
+	NameSpace(LPTSTR aName, int aFuncsInitSize = 0, NameSpace *aOuter = NULL) :
 		mNestedNameSpaces(NULL),
 		mOptionalNameSpaces(NULL),
 #ifndef AUTOHOTKEYSC
@@ -107,7 +103,6 @@ public:
 		mVar(NULL), mLazyVar(NULL),
 		mVarCount(0), mVarCountMax(0), mLazyVarCount(0),
 		mOuter(aOuter),
-		mIsTopNameSpace(aIsTopNameSpace),
 		mLaunchesCriticalThreads(false),
 		mPeekFrequency(DEFAULT_PEEK_FREQUENCY)
 	{
@@ -154,10 +149,9 @@ public:
 
 	global_struct &GetSettings();											// This is needed by HOT_IF_ACTIVE et al.
 
-	NameSpace *GetTopNameSpace();
 	NameSpace *GetOuterNameSpace();
 	// Methods for inserting nested namespaces:
-	NameSpace *InsertNestedNameSpace(LPTSTR aName, int aFuncsInitSize = 0, NameSpace *aOuter = NULL, bool aIsTopNameSpace = false);
+	NameSpace *InsertNestedNameSpace(LPTSTR aName, int aFuncsInitSize = 0, NameSpace *aOuter = NULL);
 	bool InsertNestedNameSpace(NameSpace *aNameSpace);
 	void RemoveLastNameSpace();
 

--- a/source/NameSpaceDefines.h
+++ b/source/NameSpaceDefines.h
@@ -63,6 +63,7 @@ GNU General Public License for more details.
 #define ERR_NAMESPACE_IN_FUNCTION _T("Functions cannot contain namespaces.")
 #define ERR_NAMESPACE_IN_CLASS _T("Classes cannot contain namespaces.")
 #define ERR_NAMESPACE_IN_BLOCK _T("This block cannot contain namespaces.")
+#define ERR_NAMESPACE_DEFINITION_SYNTAX _T("Syntax error in namespace definition.") // Also used with #import.
 #define ERR_SCOPE_OPERATOR_MISSING_VAR_OR_FUNC _T("Scope resolution operator missing its end variable or function.")
 
 // Misc

--- a/source/NameSpaceDefines.h
+++ b/source/NameSpaceDefines.h
@@ -21,7 +21,6 @@ GNU General Public License for more details.
 
 #define NAMESPACE_STANDARD_NAMESPACE_NAME _T("std")		// This is the name of the standard namespace for easy access to built-in functions and possibly future addititions. This namespace is parallel to the scripts namespace.
 
-#define NAMESPACE_TOP_NAMESPACE_NAME _T("Library")
 #define NAMESPACE_OUTER_NAMESPACE_NAME _T("Outer")
 
 // For anonymous namespaces:
@@ -43,16 +42,9 @@ GNU General Public License for more details.
 #define NAMESPACE_DECLARATION_KEYWORD_NAME _T("Namespace")
 #define NAMESPACE_DECLARATION_KEYWORD_NAME_LENGTH (_countof(NAMESPACE_DECLARATION_KEYWORD_NAME) - 1) // - 1 to exclude the '\0
 
-#define NAMESPACE_DECLARATION_TOP_KEYWORD_NAME _T("Library") // This can be changed to a multiword keyword, eg, Namespace Library
-#define NAMESPACE_DECLARATION_TOP_KEYWORD_NAME_LENGTH (_countof(NAMESPACE_DECLARATION_TOP_KEYWORD_NAME) - 1) // - 1 to exclude the '\0
-
 // For including file to namespace:
 #define NAMESPACE_INCLUDE_DIRECTIVE_NAME _T("#Import")
 #define NAMESPACE_INCLUDE_DIRECTIVE_NAME_LENGTH (_countof(NAMESPACE_INCLUDE_DIRECTIVE_NAME) - 1) // - 1 to exclude the '\0'
-
-#define NAMESPACE_INCLUDE_TOP_DIRECTIVE_NAME _T("#ImportLibrary")
-#define NAMESPACE_INCLUDE_TOP_DIRECTIVE_NAME_LENGTH (_countof(NAMESPACE_INCLUDE_TOP_DIRECTIVE_NAME) - 1) // - 1 to exclude the '\0'
-
 
 // Rule for namespace names match:
 #define NAMESPACE_NAMES_MATCH(name1, name2) ((name1) != NAMESPACE_ANONYMOUS && (name2) != NAMESPACE_ANONYMOUS && !_tcsicmp( (name1), (name2)))

--- a/source/NameSpaceDefines.h
+++ b/source/NameSpaceDefines.h
@@ -1,0 +1,71 @@
+/*
+AutoHotkey
+
+Copyright 2003-2009 Chris Mallett (support@autohotkey.com)
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*/
+
+// These names are reserved (as namespace names) and cannot be defined by the script.
+// They can be changed here to any valid "var name". 
+#define NAMESPACE_DEFAULT_NAMESPACE_NAME _T("Script")	// This is the name of the namespace which the entire script resides in. 
+														// It allows easy access to the top layer in a general and recognizable way.
+
+#define NAMESPACE_STANDARD_NAMESPACE_NAME _T("std")		// This is the name of the standard namespace for easy access to built-in functions and possibly future addititions. This namespace is parallel to the scripts namespace.
+
+#define NAMESPACE_TOP_NAMESPACE_NAME _T("Library")
+#define NAMESPACE_OUTER_NAMESPACE_NAME _T("Outer")
+
+// For anonymous namespaces:
+#define NAMESPACE_ANONYMOUS_NAME _T("<anonymous namespace>")		// For listlines / errors etc. This name is invalid for scripts due to '<', ' ' and '>'. This name can be any string.
+#define NAMESPACE_ANONYMOUS	(NameSpace::sAnonymousNameSpaceName)	// This is a static string for quickly identifying a anonymous namespace and avoid allocating a string for each anonymous namespace.
+
+// the scope operator:
+// Note that changing the symbols here doesn't automatically change the symbol
+// for example, some switches will have case '-': rather than case OPERATOR_SCOPE_SYMBOL_PART1: 
+// since '-' is used for other operators too.
+
+// Maintain these together,
+#define OPERATOR_SCOPE_SYMBOL_PART1 '-'
+#define OPERATOR_SCOPE_SYMBOL_PART2 '>'
+#define OPERATOR_SCOPE_SYMBOL _T("->")	
+#define OPERATOR_SCOPE_SYMBOL_LENGTH (_countof(OPERATOR_SCOPE_SYMBOL) - 1)	 // - 1 to exclude the '\0'
+
+// For literal namespace definitions:
+#define NAMESPACE_DECLARATION_KEYWORD_NAME _T("Namespace")
+#define NAMESPACE_DECLARATION_KEYWORD_NAME_LENGTH (_countof(NAMESPACE_DECLARATION_KEYWORD_NAME) - 1) // - 1 to exclude the '\0
+
+#define NAMESPACE_DECLARATION_TOP_KEYWORD_NAME _T("Library") // This can be changed to a multiword keyword, eg, Namespace Library
+#define NAMESPACE_DECLARATION_TOP_KEYWORD_NAME_LENGTH (_countof(NAMESPACE_DECLARATION_TOP_KEYWORD_NAME) - 1) // - 1 to exclude the '\0
+
+// For including file to namespace:
+#define NAMESPACE_INCLUDE_DIRECTIVE_NAME _T("#Import")
+#define NAMESPACE_INCLUDE_DIRECTIVE_NAME_LENGTH (_countof(NAMESPACE_INCLUDE_DIRECTIVE_NAME) - 1) // - 1 to exclude the '\0'
+
+#define NAMESPACE_INCLUDE_TOP_DIRECTIVE_NAME _T("#ImportLibrary")
+#define NAMESPACE_INCLUDE_TOP_DIRECTIVE_NAME_LENGTH (_countof(NAMESPACE_INCLUDE_TOP_DIRECTIVE_NAME) - 1) // - 1 to exclude the '\0'
+
+
+// Rule for namespace names match:
+#define NAMESPACE_NAMES_MATCH(name1, name2) ((name1) != NAMESPACE_ANONYMOUS && (name2) != NAMESPACE_ANONYMOUS && !_tcsicmp( (name1), (name2)))
+
+// Error messages:
+#define ERR_NAMESPACE_NOT_FOUND _T("Namespace not found.")
+#define ERR_NAMESPACE_DUPLICATE_NAME _T("Duplicate namespace definition.")
+#define ERR_NAMESPACE_IN_FUNCTION _T("Functions cannot contain namespaces.")
+#define ERR_NAMESPACE_IN_CLASS _T("Classes cannot contain namespaces.")
+#define ERR_NAMESPACE_IN_BLOCK _T("This block cannot contain namespaces.")
+#define ERR_SCOPE_OPERATOR_MISSING_VAR_OR_FUNC _T("Scope resolution operator missing its end variable or function.")
+
+// Misc
+
+// Warning: This macro declares a variable outside the for block
+#define FOR_EACH_NAMESPACE(ns) int Macro_Index = 0; for ( NameSpace *ns; ns = g_script.mNameSpaceSimpleList.GetItem(Macro_Index); ++Macro_Index)

--- a/source/TextIO.cpp
+++ b/source/TextIO.cpp
@@ -1222,11 +1222,11 @@ BIF_DECL(BIF_FileOpen)
 		aResultToken.marker = _T("");
 	}
 
-	g->LastError = GetLastError(); // Even on success, since it might provide something useful.
+	t->LastError = GetLastError(); // Even on success, since it might provide something useful.
 	return;
 
 invalid_param:
-	g->LastError = ERROR_INVALID_PARAMETER; // For consistency.
+	t->LastError = ERROR_INVALID_PARAMETER; // For consistency.
 	_f_throw(ERR_PARAM_INVALID);
 }
 

--- a/source/application.h
+++ b/source/application.h
@@ -86,7 +86,7 @@ void PollJoysticks();
 #define POLL_JOYSTICK_IF_NEEDED if (Hotkey::sJoyHotkeyCount) PollJoysticks();
 
 bool MsgMonitor(HWND aWnd, UINT aMsg, WPARAM awParam, LPARAM alParam, MSG *apMsg, LRESULT &aMsgReply);
-
+ResultType InitScriptThreads(); // Initilizes global "array" t0 (t).
 void InitNewThread(int aPriority, bool aSkipUninterruptible, bool aIncrementThreadCountAndUpdateTrayIcon
 	, bool aIsCritical = false);
 struct VarBkp;
@@ -94,7 +94,6 @@ void ResumeUnderlyingThread(VarBkp &aSavedErrorLevel);
 BOOL IsInterruptible();
 
 VOID CALLBACK MsgBoxTimeout(HWND hWnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime);
-VOID CALLBACK AutoExecSectionTimeout(HWND hWnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime);
 VOID CALLBACK InputTimeout(HWND hWnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime);
 VOID CALLBACK RefreshInterruptibility(HWND hWnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime);
 

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -13989,7 +13989,7 @@ IObject *Line::CreateRuntimeException(LPCTSTR aErrorText, LPCTSTR aWhat, LPCTSTR
 	aParams[6].SetValue(_T("Message"), 7);
 	aParams[7].SetValue((LPTSTR)aErrorText);
 	aParams[8].SetValue(NAMESPACE_DECLARATION_KEYWORD_NAME, NAMESPACE_DECLARATION_KEYWORD_NAME_LENGTH);
-	aParams[9].SetValue(g_CurrentNameSpace ? g_CurrentNameSpace->GetName() : _T(""));
+	aParams[9].SetValue(mNameSpace->GetName());
 	if (aExtraInfo && *aExtraInfo)
 	{
 		aParamCount += 2;

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -7354,10 +7354,6 @@ Func *Script::AddFunc(LPCTSTR aFuncName, size_t aFuncNameLength, bool aIsBuiltIn
 		// Also add it to the script's list of functions, to support #Warn LocalSameAsGlobal
 		// and automatic cleanup of objects in static vars on program exit.
 	}
-	/*
-	the_new_func->mOuterFunc = aIsBuiltIn ? NULL : g->CurrentFunc;
-	FuncList &funcs = the_new_func->mOuterFunc ? the_new_func->mOuterFunc->mFuncs : g_CurrentNameSpace->mFuncs;
-	*/
 	the_new_func->mOuterFunc = aIsBuiltIn ? NULL : t->CurrentFunc;
 	ResultType insert_result;
 	if (the_new_func->mOuterFunc)

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -3652,7 +3652,6 @@ inline ResultType Script::IsDirective(LPTSTR aBuf)
 			if (!*name)
 				return CONDITION_FALSE;
 		}
-
 		if (!DefineNameSpace(name, is_alternative_directive_name)) // this sets the new namespace to be the current one.
 			return FAIL; // DefineNameSpace displays the error message.
 
@@ -6360,9 +6359,13 @@ ResultType Script::DefineNameSpace(LPTSTR aNameSpaceName, bool aIsTopNameSpace)
 	if (aNameSpaceName != NAMESPACE_ANONYMOUS)
 	{
 		LPTSTR cp;
-		for (cp = aNameSpaceName; *cp && !IS_SPACE_OR_TAB(*cp); ++cp); // trim the name, it might be something like "myNamespace {".
+		for (cp = aNameSpaceName; *cp && !IS_SPACE_OR_TAB(*cp); ++cp); // trim the name.
+	
+		if (*cp && !IS_SPACE_OR_TAB(*omit_leading_whitespace(cp)))	// detect something like "MyNamespace x".
+			return ScriptError(ERR_NAMESPACE_DEFINITION_SYNTAX, aNameSpaceName);
+		
 		*cp = '\0';  // terminate the name string.
-
+		
 		if (!Var::ValidateName(aNameSpaceName, DISPLAY_NAMESPACE_ERROR))
 			return FAIL; // ValidateName displays the error message.
 	}

--- a/source/script.h
+++ b/source/script.h
@@ -3048,7 +3048,7 @@ public:
 	FuncEntry *FindBuiltInFunc(LPTSTR aFuncName);
 	Func *AddFunc(LPCTSTR aFuncName, size_t aFuncNameLength, bool aIsBuiltIn, int aInsertPos, Object *aClassObject = NULL);
 
-	ResultType DefineNameSpace(LPTSTR aNameSpaceName, bool aIsTopNameSpace);
+	ResultType DefineNameSpace(LPTSTR aNameSpaceName);
 
 	ResultType DefineClass(LPTSTR aBuf);
 	ResultType DefineClassVars(LPTSTR aBuf, bool aStatic);

--- a/source/script.h
+++ b/source/script.h
@@ -2942,7 +2942,7 @@ private:
 	ResultType AddLabel(LPTSTR aLabelName, bool aAllowDupe);
 	void RemoveLabel(Label *aLabel);
 	ResultType AddLine(ActionTypeType aActionType, LPTSTR aArg[] = NULL, int aArgc = 0, LPTSTR aArgMap[] = NULL, bool aAllArgsAreExpressions = false);
-
+	ResultType AddLineNoParent(ActionTypeType aActionType, LPTSTR aArg[] = NULL, int aArgc = 0, LPTSTR aArgMap[] = NULL, bool aAllArgsAreExpressions = false); // Adds a line which cannot be preceeded by a "parent line", eg, ACT_IF.
 	// These aren't in the Line class because I think they're easier to implement
 	// if aStartingLine is allowed to be NULL (for recursive calls).  If they
 	// were member functions of class Line, a check for NULL would have to

--- a/source/script_autoit.cpp
+++ b/source/script_autoit.cpp
@@ -1390,7 +1390,7 @@ BIF_DECL(BIF_FileGetVersion)
 	// Locate the fixed information
 		|| !VerQueryValue(pInfo, _T("\\"), (LPVOID *)&pFFI, &uSize))
 	{
-		g->LastError = GetLastError();
+		t->LastError = GetLastError();
 		free(pInfo);
 		g_ErrorLevel->Assign(ERRORLEVEL_ERROR);
 		_f_return_empty;

--- a/source/script_com.h
+++ b/source/script_com.h
@@ -3,6 +3,11 @@
 
 extern bool g_ComErrorNotify;
 
+struct ComEventPrefix // For BIF_ComObjConnect
+{
+	TCHAR mString[64];
+	NameSpace *mNameSpace;
+};
 
 class ComObject;
 class ComEvent : public ObjectBase
@@ -12,7 +17,7 @@ class ComEvent : public ObjectBase
 	ITypeInfo *mTypeInfo;
 	IID mIID;
 	IObject *mAhkObject;
-	TCHAR mPrefix[64];
+	ComEventPrefix mPrefix;
 
 public:
 	STDMETHODIMP QueryInterface(REFIID riid, void **ppv);

--- a/source/script_menu.cpp
+++ b/source/script_menu.cpp
@@ -1144,7 +1144,7 @@ ResultType UserMenu::Display(bool aForceToForeground, int aX, int aY)
 	{
 		// These are okay even if the menu items don't exist (perhaps because the user customized the menu):
 		CheckMenuItem(mMenu, ID_TRAY_SUSPEND, g_IsSuspended ? MF_CHECKED : MF_UNCHECKED);
-		CheckMenuItem(mMenu, ID_TRAY_PAUSE, g->IsPaused ? MF_CHECKED : MF_UNCHECKED);
+		CheckMenuItem(mMenu, ID_TRAY_PAUSE, t->IsPaused ? MF_CHECKED : MF_UNCHECKED);
 	}
 
 	POINT pt;

--- a/source/script_object.h
+++ b/source/script_object.h
@@ -279,6 +279,7 @@ public:
 	bool Append(ExprTokenType &aValue);
 	bool Append(LPTSTR aValue, size_t aValueLength = -1) { return Append(ExprTokenType(aValue, aValueLength)); }
 	bool Append(__int64 aValue) { return Append(ExprTokenType(aValue)); }
+	bool Append(IObject *aValue) { return Append(ExprTokenType(aValue)); }
 
 	Object *Clone(BOOL aExcludeIntegerKeys = false);
 	void ArrayToParams(ExprTokenType *token, ExprTokenType **param_list, int extra_params, ExprTokenType **aParam, int aParamCount);

--- a/source/util.cpp
+++ b/source/util.cpp
@@ -20,7 +20,6 @@ GNU General Public License for more details.
 #include "util.h"
 #include "globaldata.h"
 
-
 int GetYDay(int aMon, int aDay, bool aIsLeapYear)
 // Returns a number between 1 and 366.
 // Caller must verify that aMon is a number between 1 and 12, and aDay is a number between 1 and 31.
@@ -3001,8 +3000,6 @@ int FindTextDelim(LPCTSTR aBuf, TCHAR aDelimiter, int aStartIndex, LPCTSTR aLite
 		}
 	}
 }
-
-
 
 int BalanceExpr(LPCTSTR aBuf, int aStartBalance, TCHAR aExpect[])
 {

--- a/source/util.h
+++ b/source/util.h
@@ -169,8 +169,6 @@ inline LPTSTR omit_leading_whitespace(LPTSTR aBuf)
 {
 	return (LPTSTR) omit_leading_whitespace((LPCTSTR) aBuf);
 }
-
-
 inline LPTSTR omit_leading_any(LPTSTR aBuf, LPTSTR aOmitList, size_t aLength)
 // Returns the address of the first character in aBuf that isn't a member of aOmitList.
 // But no more than aLength characters of aBuf will be considered.  If aBuf is composed
@@ -230,6 +228,18 @@ inline size_t omit_trailing_any(LPTSTR aBuf, LPTSTR aOmitList, LPTSTR aBuf_marke
 	return 1;
 }
 
+inline bool is_preceded_by_string(LPTSTR aBuf, LPTSTR aBuf_marker, LPTSTR aString, int aStringLength)
+{
+	// returns true if aBuf is preceeded only by aString and whitespace.
+	// search is stopped at aBuf_marker.
+	// aStringLength most hold the length of the symbol.
+	aBuf = omit_trailing_whitespace(aBuf_marker, aBuf);
+	if (aBuf - aStringLength < aBuf_marker) // no need to compare.
+		return false;
+	// here aBuf points to the first non-white char preceeding original aBuf 
+	aBuf -= aStringLength - 1; // Jump to the potential start of aString.
+	return !_tcsncmp(aBuf, aString, aStringLength); // compare
+}
 
 
 inline size_t ltrim(LPTSTR aStr, size_t aLength = -1)

--- a/source/window.h
+++ b/source/window.h
@@ -289,7 +289,7 @@ void SetForegroundLockTimeout();
 // dismisses the dialog, the thread becomes critical again.
 // 
 // Update for v1.0.38.04: Rather than setting AllowInterruption unconditionally to
-// true, make it reflect the state of g->ThreadIsCritical.  This increases flexibility by allowing
+// true, make it reflect the state of t->ThreadIsCritical.  This increases flexibility by allowing
 // threads to stay interrruptible even when they're displaying a dialog.  In such cases, an
 // incoming thread-event such as a hotkey will get routed to our MainWindowProc by the dialog's
 // message pump; and from there it will get reposted to our queue, and then get pumped again.
@@ -322,8 +322,8 @@ void SetForegroundLockTimeout();
 // displaying a dialog and waiting for it to finish.
 #define DIALOG_END \
 {\
-	g->ThreadIsCritical = thread_was_critical;\
-	g->AllowThreadToBeInterrupted = !thread_was_critical;\
+	t->ThreadIsCritical = thread_was_critical;\
+	t->AllowThreadToBeInterrupted = !thread_was_critical;\
 }
 bool DialogPrep();
 


### PR DESCRIPTION
# Goal and motivation

The problems associated with large or shared namespaces and shared state across a large application are considered well known. The best known solution to the problem is to avoid it, by simply allowing _names_, as well as _state_, to be isolated within more manageable blocks or files.

The ultimate goal is to facilitate writing code which is much less __dependent__ on the script in which it is used, code that is more __modular__, and code which is more __predictable__, __readable__ and __maintainable__. This is code which is __faster to develop and integrate__, this is code which is __share friendly__, just like the _AHK community_.

___
# Design

See the [documentation](https://github.com/HelgeffegleH/NS_FILES_AND_DOCS/blob/master/AutoHotkey.chm) (Open __Usage and Syntax -> Namespaces__ ). The documentation is not complete, several aspects of the final design are undecided. Executables are also available [here](https://github.com/HelgeffegleH/NS_FILES_AND_DOCS)

## Threads

_Threads_ is __the__ breaking change, this will also affect scripts which doesn't define any additional namespaces. Fundamentally, it doesn't makes sense that a certain _thread_ has a certain setting for, eg, case sensitivity or string encoding, these kinds of settings are more suited for limited scopes rather than a thread which can call any function in any library. Settings are now confined to a namespace block or an _#imported_ file. 

Although namespaces gives script authors better control of settings (and often favourable performance), it would probably be better if all settings were function parameters for the relevant functions instead. Taking that step from this branch will not be more difficult than from the current _alpha_. This is another discussion though.

## Auto-execute sections

The new design allows better control of _one time_  tasks and initialisation of libraries and scripts. The confusing and unpredictable auto-exec. timer has been removed. The new design also allows multiple scripts to be merged much more easily, than the current design. 

## Function references

Currently, a reference to a function can be obtained via `Func('namespace_name', 'funcName')`, this is not matched by `isFunc` since there might be better ways to do this. One idea is to have a function, eg, `namespace(names*)` to return a _namespace object_. A namespace object could return a  func reference via a property or method. Variable references could be returned as _outputvars_ I guess, or the index operator could be used to set or get values of a namespace' variables.

## Directives

At present, only `#if`s belongs to namespaces, directives such as `#warn` are still applied to the entire script. If eg `#warn` would be applied to specific namespaces, perhaps it should be positional or _inherited down_ from a namespace to its nested ones. __Edit:__ Also `#include` belongs to namespaces, but I didn't handle the changing of working directory yet.

## Misc - unfinished / undecided

* __Window groups__, not namespace specific. I guessed the implementation regarding groups will be changed, so I postponed work on this.
* __Default base object__, not namespace specific. I think it should be but I have postponed this for now.
* __Ahk2Exe__, no work on the _compiler_ has been done. In my mind, `#import x.ahk -> y`, would simply be replaced with `namespace y { #include x.ahk } `. Optional imports would need additional work though, due to load time optimisations.
* It might be nice to add means to _use_ names from other namespaces, eg, `#use a() in b` to allow using `a()` without prefixing `b->`. If someone wants to lay out a complete suggestion, please do so.
* A lone scope resolution at the beginning of a line requires `()` to be a function call.
* `#Import` does not implement `<name>` yet, cf, `#Include <libName>`.
* `ErrorLevel` and `A_Args` are only added to the _Script_ namespace. Imo, `ErrorLevel` should be removed anyways. For `A_Args` I think this is fine, it could also be a _BIV_.
___

# About the implementation

This is a brief introduction to the implementation.

## `class NameSpace`

Each namespace defined in the script yields an instance of this class. 

Some important members and methods, which are recongnised from `Script::` and have the same meaning except they are now limited to their specific namespace,

* `mVar` and `mLazyVar`, each namespace contains its own set of vars. 
    * `FindVar()` and `FindOrAddVar()`, searches in invoking `NameSpace` instance. These return local variables if there is a _current func_.
* `mFuncs`, each namespace has its own set of functions.
    * `FindFunc()`, finds a func in the namespace.
* `mFirstLine`, `mLastLine`, `mFirstStaticLine` and `mLastStaticLine`, used to control auto-exec section and static var initialisation and preprocessing at load time.

Note that `NameSpace::FindXXX` calls (slightly modified) `Script::FindXXX`, this should be improved eventually.

Other important members and methods,

* `mSettings` ( `global_stuct`),  each namespace has its own _script settings_, that is most of the A_ variables.
* `mNestedNamespaces` (`class NameSpaceList`), a list of the namespace' nested namespaces. Get with `GetNestedNameSpaces()`.
* `SetCurrentNameSpace()`, used to change _this_ namespace to be the current one. More on this below.
* `mName`, get the namespace name with `GetName()`

__Labels__, are namespace specific, but namespaces do not store their own labels, these are still stored via `Script::mFirstLabel`. Labels instead have a new member, `mNameSpace`, defining which namespace the label belongs to and allows duplicate labels across namespaces. `Goto` and `gosub` can not jump to a label in another namespace, this is intended. 

Some important global variables:

* `NameSpace *g_CurrentNameSpace`. Always refers to the _current namespace_ which most often means the namespace which owns the current executing or loading line (`Line`). At some stages during loading, there is no natural candidate for which namespace this should be. 
* `NameSpace *g_DefaultNameSpace`. Refers to the _Script_ namespace, in which the entire script is defined. The script's namespaces are all nested namespaces of the default namespace.
* `NameSpace *g_StandardNameSpace`. The _standard namespace_, can be used to access overridden BIFs. This namespace is parallel to the _default namespace_, and accessible everywhere via `std -> ...`.

# Threads and settings

*A_* settings now belong to the namespaces and not threads. This means that any change to an *A_* setting takes effect immediately for all threads, which runs in the relevant namespace. 

## `struct global_struct` and `struct ScriptThread`

The struct `global_struct` has been split into two structs. `global_struct` now only contains settings which belongs to namespaces, such as _WinDelay_, _DetectHiddenWindows_ and most (perhaps all) other settings which are set via A_ variables. Whereas `ScriptThread` contains thread specific settings only, eg, _CurrentFunc_. 

Important global variables:

* `g` (`global_struct`) is kept, but is no longer an array, and only refers to the relevant settings of the current namespace.
* `t` (`ScriptThread`), this is the new _thread array_, its base is defined by `::t0` (prev: `g_array`). Its size is defined by `g_MaxThreadsTotal` and its _position_ is defined by `g_nThreads`. Default settings are defined in `::t_default`.

_Script properties_ are unaffected, at present.

## Setting the current namespace

To set the current namespace, `g_CurrentNameSpace` should not be assigned to directly. But instead by calling `NameSpace::SetCurrentNameSpace()`. This also updates `::g`  to refer to the relevant `mSettings`.

At run time, the namespace is changed when _jumping_ to a line, when calling a built-in function and when getting or setting a BIV. Typically, when setting the namespace at run time, one must save and restore the previous namespace. 

Some classes have a new instance member which indicates which namespace they belong to. It is typically called `mNameSpace` (`NameSpace*`). This is used for various purposes, most importantly is to set the correct namespace, but also for debugging, for example, `Line::mNameSpace` is used by `listlines` to show when _entering_ a new namespace.

Changing namespace is very low cost and doesn't affect performance.

## Scope resolution operator

The scope operator is implemented as a short-circuit operator. The following `SymbolType`s has been added

* `SYM_NAMESPACE`, indicates that `ExprTokenType::resolved_namespace` is used. This new (union) member holds a pointer to a namespace which has either been resolved by the expression evaluator or by load time optimisations.
* `SYM_SCOPE`, means the `->`. In expression evaluation, `SYM_SCOPE` requires a `SYM_NAMESPACE` from the stack.
* `SYM_SCOPE_BEGIN` , is the first `->` in a series of scope resolutions. The beginning is marked to indicate that this scope op does not consume a `SYM_NAMESPACE` from the stack. This allows nested scope ops, eg, `a -> ( b -> c ) -> d`. Where the second `->` cannot consume the `SYM_NAMESPACE` resolved by the first one.
* `SYM_UNRESOLVED_NAMESPACE_VAR` and `SYM_UNRESOLVED_NAMESPACE_DYNAMIC_VAR`, these are the ending variables in a scope resolution series, that is, `b` in `a -> b` or `%b%` in `a -> %b%`.
* `SYM_UNRESOLVED_NAMESPACE_FUNC` and `SYM_UNRESOLVED_NAMESPACE_DYNAMIC_FUNC`, these are the ending functions in a scope resolution series, that is, `b()` in `a -> b()` or `%b%()` in `a -> %b%()`.

Load time optimisations resolves scope resolutions as far a possible, if completely non-dynamic, the final variable or func reference is resolved and there is no performance penalty for using the scope op vs a direct variable or func reference. If a non-dynamic reference to a non-existent func or namespace is made, a load time error occurs. A notable exception is for a optional namespace, example,
```autohotkey
#import *i a.ahk -> b
b -> f() ; if a.ahk couldn't be loaded, this line will only yield a runtime error if executed due to *i.
```
this will present some issues with the compiler.

Important functions relating to the scope operator:
* `Line::ProcessScopeResolution()`, called in `ExpressionToPostfix`. Calls:
    * `FindScopeBegin()`, converts relevant `SYM_SCOPE` to `SYM_SCOPE_BEGIN`, handles the `new` operator and does some syntax verification.
    * `ResolveScopeOperands()`, load time optimisations, resolves namespaces and / or variables and func references from scope resolution series.

## `HotCriterionAllowsFiring()`

This function passes a namespace' `mSettings` to `WinExist` and `WinActive` which I believe, strictly speaking, isn't thread safe, since the _script thread_ can write to `mSettings` at any time while the _hook thread_ reads from it, and reading and writing concurrently is undefined behaviour. However, it seems that the current implementation, which passes `g_default` suffers from this potential unsafe issue too, since `g_default` is written to in `AutoExecSectionTimeout()` and `Script::AutoExecSection()` when hotkeys are active.

Disregarding undefined behaviour on the c++ side, this can potentially cause unexpected behaviour on the script side. An example is a script which uses `settitlematchmode` and `detecthiddenwindows` in two combinations:

```autohotkey 
setting1:
settitlematchmode 1
detecthiddenwindows true
; or
setting2:
settitlematchmode 2
detecthiddenwindows false
``` 

Let's say the script wants to set `setting1`, when `setting2` is active, then it is possible for the hook thread to read the current setting between the two lines, so that the situations becomes,

```autohotkey
settitlematchmode 1
; hook thread comes in here
detecthiddenwindows false
```

## Blocks

Namespace blocks cannot be enclosed in any other block than another namespace block. For consistency, and sanity, class bodies has now also been prohibited from being defined in any block. Example,

```autohotkey
if x {
	namespace { ; or class ... yeilds a load time error
	}
}
```
However, currently this is tolerated, and works,
```autohotkey
if x
	namespace { ; this namespace or any of its lines has nothing to do with the above "if x"
	}
	msgbox ; this line belongs to the above "if x"
```
The same goes for `#import`. No changes has been made to function definitions in this regard.

## Remappings

Remappings now save and restore the relevant keydelay, I think this works but is meant to be a temporary solution, example,

```autothokey
a::lbutton
; Yields:
*a::
std->remap_delay := A_MouseDelay, A_MouseDelay := -1, !GetKeyState("lbutton") ? Send("{Blind}{lbutton DownR}") : '', A_MouseDelay := std->remap_delay
return
*a up::
std->remap_delay := A_MouseDelay, A_MouseDelay := -1, Send("{Blind}{lbutton Up}"), A_MouseDelay := std->remap_delay
return
```

A better solution would not make a code replacement but instead let an internal function _carry out_ the remapping, this could also allow a built in function to enable scripts to easily enable / disable remappings at run time, eg, `Remap('a','b', onoff)`. A better code replacement solution would be easy if settings were function parameters, eg , `send(str, keydelay, pressdur)`. 

## Debugger

Added context name _Namespace_, `PropertyContextType::PC_Namespace`. `context_get -c 2 -d x` now returns the name of the namespace at the given stack depth (`x`) and all names of its enclosing namespaces. Example,
```text
context_get -c 2 -d 0
<?xml version="1.0" encoding="UTF-8"?><response command="context_get" context="2" transaction_id=""><property name="n3"></property><property name="n2"></property><property name="n1"></property><property name="Script"></property></response>
```
from:
```autohotkey
namespace n1 {
	namespace n2 {
		namespace n3 {
			msgbox 'context_get here'
		}
	}
}
```
`proptery_get` and `property_set` can resolve variables with the scope operator. Example,
```
property_get -n "n1 -> n2 -> n3 -> abc"
<?xml version="1.0" encoding="UTF-8"?><response command="property_get" transaction_id=""><property name="n1 -&gt; n2 -&gt; n3 -&gt; abc" fullname="n1 -&gt; n2 -&gt; n3 -&gt; abc" type="integer" facet="" children="0" encoding="base64" size="3">MTIz</property></response>
-
```
from:
```autohotkey
namespace n1 {
	namespace n2 {
		namespace n3 {
			abc := 123
		}
	}
}
msgbox 'property_get here'
```
This also works with the dot and indexing operators.
Note that the scope of the var is resolved relative to the context of the relevant stack depth, to get a specific var independent of this context, start the scope resolution with `Script -> ...`.

### Stack depth context

At some stack depths, the context is not what might be expected, example,
```
namespace n1 {
	abc := 123
}
x::
	msgbox 'break'
return
}
```
If the __x thread__ interrupts the __Auto-execute thread__ of `namespace n1`, the namespace context of that stack item is still __n1__, but the following stack item, __x sub__, will be in the __Script__ namespace. This is due to pushing onto the stack before the namespace has changed. See `DbgStack::current_namespace` for some additional comments. In such cases there should always be a following stack item with the correct context.

# How to continue

If there is no desire to have this, for whatever reason, _at least I tried_ 😄 . If there is an interest, I could finish the work according to some agreement. I would also be very happy to leave the remaining development of this in the hands of someone else, eg, __Lexikos__. Then I'd continue to contribute via PRs _as usual_. 

Cheers ☕️ 