### PR TITLE
Improving detection of invalid Buffer-like objects passed to built-in functions and methods.

### DIFF
--- a/source/TextIO.cpp
+++ b/source/TextIO.cpp
@@ -893,9 +893,8 @@ class FileObject : public ObjectBase // fincs: No longer allowing the script to 
 					if (IObject *obj = TokenToObject(target_token))
 					{
 						size_t ptr, size;
-						GetBufferObjectPtr(aResultToken, obj, ptr, size);
-						if (aResultToken.Exited())
-							return aResultToken.Result();
+						if (!GetBufferObjectPtr(aResultToken, obj, ptr, size))
+							_o_throw(ERR_MISSING_PROPERTY, ERR_PTR_OR_SIZE);
 						target = (LPVOID)ptr;
 						max_size = (DWORD)size;
 					}

--- a/source/script.h
+++ b/source/script.h
@@ -142,6 +142,8 @@ enum CommandIDs {CONTROL_ID_FIRST = IDCANCEL + 1
 #define ERR_NONEXISTENT_FUNCTION _T("Call to nonexistent function.")
 #define ERR_UNRECOGNIZED_DIRECTIVE _T("Unknown directive.")
 #define ERR_EXE_CORRUPTED _T("EXE corrupted")
+#define ERR_MISSING_PROPERTY _T("This object is missing a required property.")
+#define ERR_PTR_OR_SIZE _T("\"Ptr\" and/or \"Size\".")
 #define ERR_INVALID_VALUE _T("Invalid value.")
 #define ERR_PARAM_INVALID _T("Invalid parameter(s).")
 #define ERR_PARAM1_INVALID _T("Parameter #1 invalid.")
@@ -3323,8 +3325,8 @@ ResultType SoundSetGet2kXP(ResultToken &aResultToken, LPTSTR aSetting
 ResultType SoundSetGetVista(ResultToken &aResultToken, LPTSTR aSetting
 	, DWORD aComponentType, int aComponentInstance, DWORD aControlType, LPTSTR aDevice);
 
-void GetBufferObjectPtr(ResultToken &aResultToken, IObject *obj, size_t &aPtr, size_t &aSize);
-void GetBufferObjectPtr(ResultToken &aResultToken, IObject *obj, size_t &aPtr);
+ResultType GetBufferObjectPtr(ResultToken &aResultToken, IObject *obj, size_t &aPtr, size_t &aSize);
+ResultType GetBufferObjectPtr(ResultToken &aResultToken, IObject *obj, size_t &aPtr);
 
 #endif
 


### PR DESCRIPTION
Example,

```autohotkey
dllcall callbackcreate((p)=>msgbox(p)), 'ptr', {} ; new: error, old: passes 0
```

Affects, `numget`, `numput`, `strget`, `strput`, `file.rawread`, `file.rawwrite` and `dllcall`.

Reason, to help facilitate error detection.