### PR TITLE
Changing BIV_LastError to use _ultot instead of _itot.

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -9543,7 +9543,7 @@ VarSizeType BIV_LastError(LPTSTR aBuf, LPTSTR aVarName)
 {
 	TCHAR buf[MAX_INTEGER_SIZE];
 	LPTSTR target_buf = aBuf ? aBuf : buf;
-	_itot(g->LastError, target_buf, 10);  // Always output as decimal vs. hex in this case (so that scripts can use "If var in list" with confidence).
+	_ultot(g->LastError, target_buf, 10);  // Always output as decimal vs. hex in this case (so that scripts can use "If var in list" with confidence).
 	return (VarSizeType)_tcslen(target_buf);
 }
 


### PR DESCRIPTION
Example,
```autohotkey
a_lasterror := -1
msgbox a_lasterror ; new: 4294967295. old: -1
```

Reason, documentation says it should be unsigned.