### PR TITLE
Adding call to SetDllDirectory before calling Script::PreparseExpression

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -1559,7 +1559,12 @@ UINT Script::LoadFromFile()
 	if (   LoadIncludedFile(g_RunStdIn ? _T("*") : mFileSpec, false, false) != OK
 		|| !AddLine(ACT_EXIT)) // Add an Exit to ensure lib auto-includes aren't auto-executed, for backward compatibility.
 		return LOADING_FAILED;
-
+#ifdef ENABLE_DLLCALL
+	// So that (the last occuring) "#DllLoad directory" doesn't affect calls to GetDllProcAddress for run time calls to DllCall
+	// or DllCall optimizations in Line::ExpressionToPostfix.
+	if (!SetDllDirectory(NULL))
+		return ScriptError(ERR_INTERNAL_CALL);
+#endif
 	if (!PreparseExpressions(mFirstLine))
 		return LOADING_FAILED; // Error was already displayed by the above call.
 	// ABOVE: In v1.0.47, the above may have auto-included additional files from the userlib/stdlib.


### PR DESCRIPTION
Reason, so that (the last occuring) `#DllLoad directory` doesn't affect all calls to `LoadLibrary` for `DllCall` optimizations in `Line::ExpressionToPostfix`.