### PR TITLE
v2: Replace deprecated <typeinfo.h>.

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -17,7 +17,7 @@ GNU General Public License for more details.
 #include "stdafx.h" // pre-compiled headers
 #include <olectl.h> // for OleLoadPicture()
 #include <winioctl.h> // For PREVENT_MEDIA_REMOVAL and CD lock/unlock.
-#include <typeinfo.h> // For typeid in BIF_Type.
+#include <typeinfo> // For typeid in BIF_Type.
 #include "qmath.h" // Used by Transform() [math.h incurs 2k larger code size just for ceil() & floor()]
 #include "mt19937ar-cok.h" // for sorting in random order
 #include "script.h"


### PR DESCRIPTION
As of [MSVC v14.23](https://docs.microsoft.com/en-us/cpp/overview/cpp-conformance-improvements?view=vs-2019#standard-library-improvements-1), the header is no longer part of the toolset.
