### PR TITLE
v2: Fixed SoundSet functions crashing the program.

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -7509,7 +7509,7 @@ BIF_DECL(BIF_Sound)
 	float setting_scalar;
 	if (SOUND_MODE_IS_SET)
 	{
-		setting_scalar = (float)(ParamIndexToDouble(0) / 100);
+		setting_scalar = (float)(ATOF(aSetting) / 100);
 		if (setting_scalar < -1)
 			setting_scalar = -1;
 		else if (setting_scalar > 1)


### PR DESCRIPTION
For example, when debugging with VS, `SoundSetMute -1` throws the following exception:

Exception thrown: read access violation.
**aToken** was 0xCCCCCCCC.