### PR TITLE
Ensure g_input doesn't refrence local variable when Line::Input() return

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -1464,7 +1464,14 @@ ResultType Line::Input()
 	if (prior_input)
 		prior_input->EndByNewInput();
 
-	return InputStart(input, output_var);
+	ResultType input_result = InputStart(input, output_var);
+	// Ensure g_input doesn't reference input, which life time is about to end.
+	if (g_input == &input)
+	{
+		input_type *result = InputRelease(&input);
+		ASSERT(result == NULL);
+	}
+	return input_result;
 }
 
 

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -1465,12 +1465,10 @@ ResultType Line::Input()
 		prior_input->EndByNewInput();
 
 	ResultType input_result = InputStart(input, output_var);
-	// Ensure g_input doesn't reference input, which life time is about to end.
-	if (g_input == &input)
-	{
-		input_type *result = InputRelease(&input);
-		ASSERT(result == NULL);
-	}
+	// Ensure input is not present in the input chain, since its life time is about to end.
+	input_type *result = InputRelease(&input);
+	ASSERT(result == NULL);
+	
 	return input_result;
 }
 
@@ -2009,6 +2007,7 @@ input_type *InputRelease(input_type *aInput)
 		if (aInput->ScriptObject->onEnd)
 			return aInput; // Return for caller to call OnEnd and Release.
 		aInput->ScriptObject->Release();
+		aInput->ScriptObject = NULL;
 	}
 	return NULL;
 }


### PR DESCRIPTION
When I run debug build (Win32) with this script, 

```autohotkey
critical
input v, L1
```

`g_input` refrences the local variable `input` when `Line::Input()` returns, which is undefined behaviour (if dereferenced).

Might be related to [this bug report](https://www.autohotkey.com/boards/viewtopic.php?f=14&t=70802), which I cannot reproduce on win10 with any of the release builds.

Cheers.