### PR TITLE
Adding StringCaseSense 'Logical' and sort option 'L' for logical sort.

### DIFF
--- a/source/script.h
+++ b/source/script.h
@@ -1207,6 +1207,7 @@ public:
 		if (!_tcsicmp(aBuf, _T("On")) || !_tcscmp(aBuf, _T("1"))) return SCS_SENSITIVE;
 		if (!_tcsicmp(aBuf, _T("Off")) || !_tcscmp(aBuf, _T("0"))) return SCS_INSENSITIVE;
 		if (!_tcsicmp(aBuf, _T("Locale"))) return SCS_INSENSITIVE_LOCALE;
+		if (!_tcsicmp(aBuf, _T("Logical"))) return SCS_INSENSITIVE_LOGICAL;
 		return SCS_INVALID;
 	}
 

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -6569,6 +6569,9 @@ BIF_DECL(BIF_Sort)
 			else
 				g_SortCaseSensitive = SCS_SENSITIVE;
 			break;
+		case 'L':
+			g_SortCaseSensitive = SCS_INSENSITIVE_LOGICAL;
+			break;
 		case 'D':
 			if (!cp[1]) // Avoids out-of-bounds when the loop's own ++cp is done.
 				break;

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -25,6 +25,7 @@ GNU General Public License for more details.
 #include "resources/resource.h"  // For InputBox.
 #include "TextIO.h"
 #include <Psapi.h> // for GetModuleBaseName.
+#include <Shlwapi.h> // for StrCmpLogicalW
 
 #include <mmdeviceapi.h> // for SoundSet/SoundGet.
 #include <endpointvolume.h> // for SoundSet/SoundGet.
@@ -9509,8 +9510,9 @@ VarSizeType BIV_StringCaseSense(LPTSTR aBuf, LPTSTR aVarName)
 {
 	return aBuf
 		? (VarSizeType)_tcslen(_tcscpy(aBuf, g->StringCaseSense == SCS_INSENSITIVE ? _T("Off") // For backward compatibility (due to StringCaseSense), never change the case used here.  Fixed in v1.0.42.01 to return exact length (required).
-			: (g->StringCaseSense == SCS_SENSITIVE ? _T("On") : _T("Locale"))))
-		: 6; // Room for On, Off, or Locale (in the estimation phase).
+			: (g->StringCaseSense == SCS_SENSITIVE ? _T("On") 
+				: g->StringCaseSense == SCS_INSENSITIVE_LOCALE ? _T("Locale") : _T("Logical"))))
+		: 7; // Room for On, Off, Locale or Logical (in the estimation phase).
 }
 
 BIV_DECL_W(BIV_StringCaseSense_Set)

--- a/source/script_expression.cpp
+++ b/source/script_expression.cpp
@@ -42,6 +42,7 @@ GNU General Public License for more details.
 #include "script_object.h"
 #include "globaldata.h" // for a lot of things
 #include "qmath.h" // For ExpandExpression()
+#include <Shlwapi.h> // for StrCmpLogicalW
 
 // __forceinline: Decided against it for this function because although it's only called by one caller,
 // testing shows that it wastes stack space (room for its automatic variables would be unconditionally 

--- a/source/util.cpp
+++ b/source/util.cpp
@@ -19,7 +19,7 @@ GNU General Public License for more details.
 #include <gdiplus.h> // Used by LoadPicture().
 #include "util.h"
 #include "globaldata.h"
-
+#include <Shlwapi.h> // for StrCmpLogicalW
 
 int GetYDay(int aMon, int aDay, bool aIsLeapYear)
 // Returns a number between 1 and 366.

--- a/source/util.h
+++ b/source/util.h
@@ -548,7 +548,8 @@ int FTOA(double aValue, LPTSTR aBuf, int aBufSize);
 // And both of them benchmark the same, so lstrcmpi is now used here and in various other places throughout
 // the program when the new locale-case-insensitive mode is in effect.
 #define tcscmp2(str1, str2, string_case_sense) ((string_case_sense) == SCS_INSENSITIVE ? _tcsicmp(str1, str2) \
-	: ((string_case_sense) == SCS_INSENSITIVE_LOCALE ? lstrcmpi(str1, str2) : _tcscmp(str1, str2)))
+	: ((string_case_sense) == SCS_INSENSITIVE_LOCALE ? lstrcmpi(str1, str2)  \
+	:  (string_case_sense) == SCS_INSENSITIVE_LOGICAL ? StrCmpLogicalW(str1, str2) : _tcscmp(str1, str2)))
 #define g_tcscmp(str1, str2) tcscmp2(str1, str2, ::g->StringCaseSense)
 // The most common mode is listed first for performance:
 #define tcsstr2(haystack, needle, string_case_sense) ((string_case_sense) == SCS_INSENSITIVE ? tcscasestr(haystack, needle) \


### PR DESCRIPTION
Uses  ➡️ [`StrCmpLogicalW`](https://docs.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-strcmplogicalw).

Reason, the sort option is for convenience and performance, the `stringcasesense` option is mostly for completeness imo.

This doesn't affect `StrCompare`. I guess there are multiple ways it could be done. I think the `CaseSensitive` parameter should be changed to accept any of the `StringCaseSense` options directly, and not rely on `A_StringCaseSense` in any case. 

__Edit:__ I guess that if the `CaseSenseitive` parameter for `StrCompare` was changed as suggested above, it would be better to let `sort` have its own, similar, `CaseSenseitive` parameter instead of the __C, CL, L__ options.

Example,
```autohotkey
str := '
(
string20
3string
20string
2string
string3
st3ring
st20ring
string2
st2ring
)'
msgbox '2string' < '20string'	; 0
a_stringcasesense := 'Logical'
msgbox '2string' < '20string'	; 1
msgbox sort(str, 'L')
/*
output:
2string
3string
20string
st2ring
st3ring
st20ring
string2
string3
string20
*/
```

__Con__: It doesn't consider negative numbers it seems. 

Cheers.