### PR TITLE
Changing operator ** to not cast integer operands to float and then c…

### DIFF
--- a/source/script.h
+++ b/source/script.h
@@ -398,6 +398,8 @@ struct ArgStruct
 	ExprTokenType *postfix;  // An array of tokens in postfix order.
 };
 
+__int64 pow_ll(__int64 base, __int64 exp); // integer power function
+
 #define BIF_DECL_PARAMS ResultToken &aResultToken, ExprTokenType *aParam[], int aParamCount
 
 // The following macro is used for definitions and declarations of built-in functions:

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -17891,3 +17891,26 @@ DWORD GetProcessName(DWORD aProcessID, LPTSTR aBuf, DWORD aBufSize, bool aGetNam
 	CloseHandle(hproc);
 	return buf_length;
 }
+
+__int64 pow_ll(__int64 base, __int64 exp)
+{
+	/*
+	Caller must ensure exp >= 0
+	Below uses 'a^b' to denote 'raising a to the power of b'.
+	Computes and returns base^exp. If the mathematical result doesn't fit in __int64, the result is undefined.
+	By convention, x^0 returns 1, even when x == 0,	caller should ensure base is non-zero when exp is zero to handle 0^0.
+	*/
+	if (exp == 0)
+		return 1ll;
+
+	// based on: https://en.wikipedia.org/wiki/Exponentiation_by_squaring (2018-11-03)
+	__int64 result = 1;
+	while (exp > 1)
+	{
+		if (exp % 2) // exp is odd
+			result *= base;
+		base *= base;
+		exp /= 2;
+	}
+	return result * base;
+}

--- a/source/script_expression.cpp
+++ b/source/script_expression.cpp
@@ -1163,6 +1163,12 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
 					}
 					else // We have a valid base and exponent and both are integers, so the calculation will always have a defined result.
 					{
+						if (right_int64 >= 0)	// result is an integer.
+						{
+							this_token.value_int64 = pow_ll(left_int64, right_int64);
+							break;
+						}
+						result_symbol = SYM_FLOAT; // Due to negative exponent, override to float.
 #ifdef USE_INLINE_ASM	// see qmath.h
 						// Note: The function pow() in math.h adds about 28 KB of code size (uncompressed)! That is why it's not used here.
 						// v1.0.44.11: With Laszlo's help, negative integer bases are now supported.
@@ -1174,10 +1180,6 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ResultToken *a
 #else
 						this_token.value_double = pow((double)left_int64, (double)right_int64);
 #endif
-						if (right_int64 < 0)
-							result_symbol = SYM_FLOAT; // Due to negative exponent, override to float.
-						else
-							this_token.value_int64 = (__int64)this_token.value_double;
 					}
 					break;
 				}


### PR DESCRIPTION
…ast result back to integer for exponents `>= 0`

__Reasons__, allow correct results for all `x**y` (`x,y` integer, `y>0`) which is within the range of **__int64**.

Behaviour of overflow is undefined.

This is an alternative to #119.

Cheers.