### PR TITLE
Changing CaseSensitive parameters to not depend on A_StringCaseSense.

### DIFF
--- a/source/script.h
+++ b/source/script.h
@@ -3414,6 +3414,7 @@ __int64 TokenToInt64(ExprTokenType &aToken);
 double TokenToDouble(ExprTokenType &aToken, BOOL aCheckForHex = TRUE);
 LPTSTR TokenToString(ExprTokenType &aToken, LPTSTR aBuf = NULL, size_t *aLength = NULL);
 ResultType TokenToDoubleOrInt64(const ExprTokenType &aInput, ExprTokenType &aOutput);
+StringCaseSenseType TokenToStringCase(ExprTokenType& aToken);
 IObject *TokenToObject(ExprTokenType &aToken); // L31
 Func *TokenToFunc(ExprTokenType &aToken);
 IObject *TokenToFunctor(ExprTokenType &aToken);

--- a/source/script_func_impl.h
+++ b/source/script_func_impl.h
@@ -7,17 +7,9 @@
 #define ParamIndexToNumber(index, output)			TokenToDoubleOrInt64(*aParam[(index)], output)
 #define ParamIndexToBOOL(index)						TokenToBOOL(*aParam[(index)])
 #define ParamIndexToObject(index)					TokenToObject(*aParam[(index)])
-
-// Rather than adding a third value to the CaseSensitive parameter, it obeys StringCaseSense because:
-// 1) It matches the behavior of the equal operator (=) in expressions.
-// 2) It's more friendly for typical international uses because it avoids having to specify that special/third value
-//    for every call of InStr.  It's nice to be able to omit the CaseSensitive parameter every time and know that
-//    the behavior of both InStr and its counterpart the equals operator are always consistent with each other.
-// If the parameter is (false or omitted) insensitive, resolve it to be Locale-mode if the StringCaseSense mode is
-// either case-sensitive or Locale-insensitive.
-// The parameter is assumed to be optional and always defaults to false.
-#define ParamIndexToCaseSense(index)				(!ParamIndexIsOmitted(index) && ParamIndexToBOOL(index) ? SCS_SENSITIVE \
-													: (g->StringCaseSense != SCS_INSENSITIVE ? SCS_INSENSITIVE_LOCALE : SCS_INSENSITIVE) )
+													
+// Omitted parameter returns SCS_INSENSITIVE.
+#define ParamIndexToCaseSense(index)				(ParamIndexIsOmitted((index)) ? SCS_INSENSITIVE : TokenToStringCase(*aParam[(index)]))
 
 #define ParamIndexIsNumeric(index)  (TokenIsNumeric(*aParam[(index)]))
 


### PR DESCRIPTION
Also adding option __Logical__, __Locale__, __On__ and __Off__.

New:

* __1__ (`true`) and __On__ means `SCS_SENSITIVE`
* __0__, (`false`) and __Off__, means `SCS_INSENSITIVE`
* __Locale__, means `SCS_INSENSITIVE_LOCALE` 
* __Logical__, means `SCS_INSENSITVE_LOGICAL`.

Any other values yields `SCS_INVALID` and should be considered an error.

`StrCompare` now handles `CaseSensitive := "Logical"`, by calling `StrCmpLogicalW`.

`InStr` throws for `CaseSensitive := "Logical"`, alternatively it could mean `SCS_INSENSITIVE`, but it seems more likely that it would be a mistake and hence better to inform the user.

Cheers.