### PR TITLE
Adding CaseSensitive parameter to BIF_Sort

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -241,7 +241,7 @@ FuncEntry g_BIF[] =
 	BIFn(SendMessage, 1, 9, BIF_PostSendMessage),
 	BIF1(SetTimer, 0, 3),
 	BIF1(Sin, 1, 1),
-	BIF1(Sort, 1, 3),
+	BIF1(Sort, 1, 4),
 	BIFn(SoundGetInterface, 1, 3, BIF_Sound),
 	BIFn(SoundGetMute, 0, 2, BIF_Sound),
 	BIFn(SoundGetName, 0, 2, BIF_Sound),

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -6546,7 +6546,9 @@ BIF_DECL(BIF_Sort)
 
 	// Resolve options.  First set defaults for options:
 	TCHAR delimiter = '\n';
-	g_SortCaseSensitive = SCS_INSENSITIVE;
+	g_SortCaseSensitive = ParamIndexToCaseSense(3);
+	if (g_SortCaseSensitive == SCS_INVALID)
+		_f_throw(ERR_PARAM4_INVALID);
 	g_SortNumeric = false;
 	g_SortReverse = false;
 	g_SortColumnOffset = 0;
@@ -6559,15 +6561,6 @@ BIF_DECL(BIF_Sort)
 	{
 		switch(_totupper(*cp))
 		{
-		case 'C':
-			if (ctoupper(cp[1]) == 'L') // v1.0.43.03: Locale-insensitive mode, which probably performs considerably worse.
-			{
-				++cp;
-				g_SortCaseSensitive = SCS_INSENSITIVE_LOCALE;
-			}
-			else
-				g_SortCaseSensitive = SCS_SENSITIVE;
-			break;
 		case 'D':
 			if (!cp[1]) // Avoids out-of-bounds when the loop's own ++cp is done.
 				break;

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -25,6 +25,7 @@ GNU General Public License for more details.
 #include "resources/resource.h"  // For InputBox.
 #include "TextIO.h"
 #include <Psapi.h> // for GetModuleBaseName.
+#include "shlwapi.h" // for StrCmpLogicalW
 
 #include <mmdeviceapi.h> // for SoundSet/SoundGet.
 #include <endpointvolume.h> // for SoundSet/SoundGet.
@@ -6453,7 +6454,7 @@ int SortWithOptions(const void *a1, const void *a2)
 	}
 	// Otherwise, it's a non-numeric sort.
 	// v1.0.43.03: Added support the new locale-insensitive mode.
-	int result = tcscmp2(sort_item1, sort_item2, g_SortCaseSensitive); // Resolve large macro only once for code size reduction.
+	int result = tcscmp3(sort_item1, sort_item2, g_SortCaseSensitive); // Resolve large macro only once for code size reduction.
 	return g_SortReverse ? -result : result;
 }
 
@@ -6470,7 +6471,7 @@ int SortByNakedFilename(const void *a1, const void *a2)
 	if (cp = _tcsrchr(sort_item2, '\\'))  // Assign
 		sort_item2 = cp + 1;
 	// v1.0.43.03: Added support the new locale-insensitive mode.
-	int result = tcscmp2(sort_item1, sort_item2, g_SortCaseSensitive); // Resolve large macro only once for code size reduction.
+	int result = tcscmp3(sort_item1, sort_item2, g_SortCaseSensitive); // Resolve large macro only once for code size reduction.
 	return g_SortReverse ? -result : result;
 }
 

--- a/source/util.h
+++ b/source/util.h
@@ -549,6 +549,11 @@ int FTOA(double aValue, LPTSTR aBuf, int aBufSize);
 // the program when the new locale-case-insensitive mode is in effect.
 #define tcscmp2(str1, str2, string_case_sense) ((string_case_sense) == SCS_INSENSITIVE ? _tcsicmp(str1, str2) \
 	: ((string_case_sense) == SCS_INSENSITIVE_LOCALE ? lstrcmpi(str1, str2) : _tcscmp(str1, str2)))
+
+// tcscmp3 requires '#include "shlwapi.h"'
+#define tcscmp3(str1, str2, string_case_sense) ((string_case_sense) == SCS_INSENSITIVE_LOGICAL ? StrCmpLogicalW((str1), (str2)) \
+: tcscmp2((str1), (str2), (string_case_sense)) )
+
 #define g_tcscmp(str1, str2) tcscmp2(str1, str2, ::g->StringCaseSense)
 // The most common mode is listed first for performance:
 #define tcsstr2(haystack, needle, string_case_sense) ((string_case_sense) == SCS_INSENSITIVE ? tcscasestr(haystack, needle) \


### PR DESCRIPTION
New:
```autohotkey
SortedString := Sort(String [, Options, Callback, CaseSensitive := false])
```
Also removing the __C__ and __CL__ options.

Also adding handling of `SCS_INSENSITIVE_LOGICAL` to `BIF_Sort`. To be useful #167 or something similar would need to be implemented.

I'm not passionate about the parameter order. It would also be possible to join the `Callback` and `CaseSensitive` parameters, since both can't be meaningful at the same time. But I think it is better to have a separate parameter.

Cheers.