### PR TITLE
Changing Switch to not depend A_StringCaseSense

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -17582,12 +17582,7 @@ BOOL TokensAreEqual(ExprTokenType &left, ExprTokenType &right)
 	{
 		TCHAR left_buf[MAX_NUMBER_SIZE], *left_string = TokenToString(left, left_buf);
 		TCHAR right_buf[MAX_NUMBER_SIZE], *right_string = TokenToString(right, right_buf);
-		switch (g->StringCaseSense)
-		{
-		case SCS_INSENSITIVE:	return !_tcsicmp(left_string, right_string);
-		case SCS_SENSITIVE:		return !_tcscmp(left_string, right_string);
-		default:				return !lstrcmpi(left_string, right_string);
-		}
+		return !_tcscmp(left_string, right_string);
 	}
 	if (left_type == PURE_INTEGER && right_type == PURE_INTEGER)
 		return TokenToInt64(left) == TokenToInt64(right);


### PR DESCRIPTION
Always does case sensitive comparison.

Some examples on how to handle this change,

```autohotkey
Switch StrLower(str)
{
	case 'abc': ; ...
	case 'def': ; ...
}

Switch chr
{
	case 'A', 'a': ; ...
	case 'B', 'b': ; ...
}
```

I am aware these examples have limitations.

I'll also make an alternative PR with an added `CaseSensitive` parameter. __Edit:__ See #171.

Cheers.