### PR TITLE
Adding CaseSensitive parameter to Switch

### DIFF
--- a/source/globaldata.cpp
+++ b/source/globaldata.cpp
@@ -287,7 +287,7 @@ Action g_act[] =
 	, {_T("Catch"), 0, 1, false, NULL} // fincs: seems best to allow catch without a parameter
 	, {_T("Finally"), 0, 0, false, NULL}
 	, {_T("Throw"), 0, 1, false, {1, 0}}
-	, {_T("Switch"), 0, 1, false, {1, 0}}
+	, {_T("Switch"), 0, 2, false, {1, 0}}
 	, {_T("Case"), 1, MAX_ARGS, false, NULL}
 
 	, {_T("Exit"), 0, 1, false, {1, 0}} // ExitCode

--- a/source/script.h
+++ b/source/script.h
@@ -3423,7 +3423,7 @@ IObject *StringToLabelOrFunctor(LPTSTR aStr);
 IObject *StringToFunctor(LPTSTR aStr);
 ResultType ValidateFunctor(IObject *aFunc, int aParamCount, ResultToken &aResultToken, LPTSTR aNullErr = ERR_TYPE_MISMATCH);
 ResultType TokenSetResult(ResultToken &aResultToken, LPCTSTR aValue, size_t aLength = -1);
-BOOL TokensAreEqual(ExprTokenType &left, ExprTokenType &right);
+BOOL TokensAreEqual(ExprTokenType &left, ExprTokenType &right, StringCaseSenseType aStringCaseSense);
 LPTSTR TokenTypeString(ExprTokenType &aToken);
 
 LPTSTR RegExMatch(LPTSTR aHaystack, LPTSTR aNeedleRegEx);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -17570,7 +17570,7 @@ SymbolType TypeOfToken(ExprTokenType &aToken, SymbolType &aIsNum)
 
 
 
-BOOL TokensAreEqual(ExprTokenType &left, ExprTokenType &right)
+BOOL TokensAreEqual(ExprTokenType &left, ExprTokenType &right, StringCaseSenseType aStringCaseSense)
 // Compares two tokens using similar rules to SYM_EQUAL, but case sensitive if appropriate.
 {
 	SymbolType left_is_numeric, left_type = TypeOfToken(left, left_is_numeric)
@@ -17582,7 +17582,7 @@ BOOL TokensAreEqual(ExprTokenType &left, ExprTokenType &right)
 	{
 		TCHAR left_buf[MAX_NUMBER_SIZE], *left_string = TokenToString(left, left_buf);
 		TCHAR right_buf[MAX_NUMBER_SIZE], *right_string = TokenToString(right, right_buf);
-		switch (g->StringCaseSense)
+		switch (aStringCaseSense)
 		{
 		case SCS_INSENSITIVE:	return !_tcsicmp(left_string, right_string);
 		case SCS_SENSITIVE:		return !_tcscmp(left_string, right_string);


### PR DESCRIPTION
New:

```autohotkey
Switch [Exression, CaseSensitive := false]
```
The `CaseSensitive` parameter works as the other `CaseSensitive` paramters, i.e., as for `StrCompare` and `InStr`.

Specifying the `CaseSensitive` parameter while omitting the expression is an error.

This is an alternative to #170, with #167 and small modification, this will not depend on `A_StrinCaseSense`

Cheers.