### PR TITLE
Updating realloc condition for input_type::match in input_type::SetMatchList

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -681,7 +681,7 @@ ResultType input_type::SetMatchList(LPTSTR aMatchList, size_t aMatchList_length)
 			}
 			if (*(source + 1)) // There is a next element.
 			{
-				if (MatchCount >= MatchCountMax) // Rarely needed, so just realloc() to expand.
+				if (MatchCount >= MatchCountMax - 1) // Rarely needed, so just realloc() to expand.
 				{
 					// Expand the array by one block:
 					if (   !(realloc_temp = (LPTSTR *)realloc(match  // Must use a temp variable.


### PR DESCRIPTION
Reason, to avoid out of bounds access.

Issue example, ➡️ [__[a108] InputHook MatchList: Invalid pointer read__](https://www.autohotkey.com/boards/viewtopic.php?f=14&t=74821)
