### PR TITLE
Changing #If and #IfTimeout to #HotIf and #HotIfTimeout

### DIFF
--- a/source/application.cpp
+++ b/source/application.cpp
@@ -898,7 +898,7 @@ bool MsgSleep(int aSleepDuration, MessageMode aMode)
 				if (!hc || hc->Type == HOT_IF_NOT_ACTIVE || hc->Type == HOT_IF_NOT_EXIST)
 					criterion_found_hwnd = NULL; // For "NONE" and "NOT", there is no last found window.
 				else if (HOT_IF_REQUIRES_EVAL(hc->Type))
-					criterion_found_hwnd = g_HotExprLFW; // For #if WinExist(WinTitle) and similar.
+					criterion_found_hwnd = g_HotExprLFW; // For #HotIf WinExist(WinTitle) and similar.
 
 				priority = variant->mPriority;
 			} // switch(msg.message)

--- a/source/globaldata.cpp
+++ b/source/globaldata.cpp
@@ -114,9 +114,9 @@ bool g_SuspendExempt = false;
 SendLevelType g_InputLevel = 0;
 HotkeyCriterion *g_FirstHotCriterion = NULL, *g_LastHotCriterion = NULL;
 
-// Global variables for #if (expression).
-UINT g_HotExprTimeout = 1000; // Timeout for #if (expression) evaluation, in milliseconds.
-HWND g_HotExprLFW = NULL; // Last Found Window of last #if expression.
+// Global variables for #HotIf (expression).
+UINT g_HotExprTimeout = 1000; // Timeout for #HotIf (expression) evaluation, in milliseconds.
+HWND g_HotExprLFW = NULL; // Last Found Window of last #HotIf expression.
 HotkeyCriterion *g_FirstHotExpr = NULL, *g_LastHotExpr = NULL;
 
 static int GetScreenDPI()

--- a/source/globaldata.h
+++ b/source/globaldata.h
@@ -108,7 +108,7 @@ extern bool g_SuspendExempt;
 extern SendLevelType g_InputLevel;
 extern HotkeyCriterion *g_FirstHotCriterion, *g_LastHotCriterion;
 
-// Global variables for #if (expression). See globaldata.cpp for comments.
+// Global variables for #HotIf (expression). See globaldata.cpp for comments.
 extern UINT g_HotExprTimeout;
 extern HWND g_HotExprLFW;
 extern HotkeyCriterion *g_FirstHotExpr, *g_LastHotExpr;

--- a/source/hotkey.cpp
+++ b/source/hotkey.cpp
@@ -55,7 +55,7 @@ HWND HotCriterionAllowsFiring(HotkeyCriterion *aCriterion, LPTSTR aHotkeyName)
 	case HOT_IF_NOT_EXIST:
 		found_hwnd = WinExist(g_default, aCriterion->WinTitle, aCriterion->WinText, _T(""), _T(""), false, false); // Thread-safe.
 		break;
-	// L4: Handling of #if (expression) hotkey variants.
+	// L4: Handling of #HotIf (expression) hotkey variants.
 	case HOT_IF_EXPR:
 	case HOT_IF_CALLBACK:
 		// Expression evaluation must be done in the main thread. If the message times out, the hotkey/hotstring is not allowed to fire.
@@ -164,7 +164,7 @@ HotkeyCriterion *FindHotkeyIfExpr(LPTSTR aExpr)
 
 
 void Script::PreparseHotkeyIfExpr(Line *aLine)
-// Optimize simple #If expressions into the more specific HOT_IF_ types so that they can be
+// Optimize simple #HotIf expressions into the more specific HOT_IF_ types so that they can be
 // evaluated by the hook directly, without synchronizing with the main thread.
 {
 	ExprTokenType *postfix = aLine->mArg[0].postfix;

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -3650,8 +3650,8 @@ inline ResultType Script::IsDirective(LPTSTR aBuf)
 		return CONDITION_TRUE;
 	}
 
-	// L4: Handle #if (expression) directive.
-	if (IS_DIRECTIVE_MATCH(_T("#If")))
+	// L4: Handle #HotIf (expression) directive.
+	if (IS_DIRECTIVE_MATCH(_T("#HotIf")))
 	{
 		if (!parameter) // The omission of the parameter indicates that any existing criteria should be turned off.
 		{
@@ -3659,7 +3659,7 @@ inline ResultType Script::IsDirective(LPTSTR aBuf)
 			return CONDITION_TRUE;
 		}
 
-		// Check for a duplicate #If expression;
+		// Check for a duplicate #HotIf expression;
 		//  - Prevents duplicate hotkeys under separate copies of the same expression.
 		//  - Hotkey,If would only be able to select the first expression with the given source code.
 		//  - Conserves memory.
@@ -3689,8 +3689,8 @@ inline ResultType Script::IsDirective(LPTSTR aBuf)
 		return CONDITION_TRUE;
 	}
 
-	// L4: Allow #if timeout to be adjusted.
-	if (IS_DIRECTIVE_MATCH(_T("#IfTimeout")))
+	// L4: Allow #HotIf timeout to be adjusted.
+	if (IS_DIRECTIVE_MATCH(_T("#HotIfTimeout")))
 	{
 		if (parameter)
 			g_HotExprTimeout = ATOU(parameter);
@@ -7756,7 +7756,7 @@ ResultType Script::PreparseStaticLines(Line *aStartingLine)
 			mLastStaticLine = line;
 			break;
 		case ACT_HOTKEY_IF:
-			if (line->mArg[0].is_expression) // May be false for optimized cases like "#If somevar".
+			if (line->mArg[0].is_expression) // May be false for optimized cases like "#HotIf somevar".
 				PreparseHotkeyIfExpr(line);
 			// It's already been added to the hot-expr list, so just remove it from the script (below).
 			break;
@@ -9798,7 +9798,7 @@ end_of_infix_to_postfix:
 		&& (mActionType < ACT_FOR || mActionType > ACT_UNTIL) // It's not WHILE or UNTIL, which currently perform better as expressions, or FOR, which performs the same but currently expects aResultToken to always be set.
 		&& (mActionType != ACT_SWITCH && mActionType != ACT_CASE) // It's not SWITCH or CASE, which require a proper postfix expression.
 		&& (mActionType != ACT_THROW) // Exclude THROW to simplify variable handling (ensures vars are always dereferenced).
-		&& (mActionType != ACT_HOTKEY_IF) // #If requires the expression text not be modified.
+		&& (mActionType != ACT_HOTKEY_IF) // #HotIf requires the expression text not be modified.
 		&& ((only_symbol != SYM_VAR && only_symbol != SYM_DYNAMIC) || mActionType != ACT_RETURN) // "return var" is kept as an expression for correct handling of built-ins, locals (see "ToReturnValue") and ByRef.
 		)
 	{


### PR DESCRIPTION
__Reason__, `#If` is often confused with `if`. `#HotIf` is more _descriptive_. Changed `#IfTimout` to match `#HotIf`.
Less relevant, sometimes also confused with C-like `#if`. If we want something like C's `#if` in the future, `#if` will be available.

Also changed some relevant comments, some might remain.