### PR TITLE
Fixing BIF_Hotkey searching for a variant of the first parameter rather than the second.

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -14583,7 +14583,7 @@ BIF_DECL(BIF_Hotkey)
 				// I.e., find the function implicitly defined by "x::action".
 				for (int i = 0; i < Hotkey::sHotkeyCount; ++i)
 				{
-					if (_tcscmp(Hotkey::shk[i]->mName, aParam0))
+					if (_tcscmp(Hotkey::shk[i]->mName, aParam1))
 						continue;
 					
 					for (HotkeyVariant* v = Hotkey::shk[i]->mFirstVariant; v; v = v->mNextVariant)


### PR DESCRIPTION
For the first issue reported ➡️ [here](https://github.com/Lexikos/AutoHotkey_L/pull/177#issuecomment-640154608).