### PR TITLE
Freeing Script::mHotFuncs.mItem after calling Script::PreprocessLocalVars.

### DIFF
--- a/source/hotkey.h
+++ b/source/hotkey.h
@@ -77,9 +77,9 @@ HotkeyCriterion *FindHotkeyIfExpr(LPTSTR aExpr);
 struct HotkeyVariant
 {
 	LabelRef mJumpToLabel;
-	LabelPtr mOriginalCallback; // This is the callback set at load time. 
-								 // Keep it to allow restoring it via hotkey() function if changed
-								 // during load time (also via hotkey() function).
+	LabelPtr mOriginalCallback;	// This is the callback set at load time. 
+								// Keep it to allow restoring it via hotkey() function if changed
+								// during run time.
 	HotkeyCriterion *mHotCriterion;
 	HotkeyVariant *mNextVariant;
 	DWORD mRunAgainTime;

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -1574,7 +1574,8 @@ UINT Script::LoadFromFile()
 	if (!PreprocessLocalVars(mFuncs)
 		|| !PreprocessLocalVars(mHotFuncs))
 		return LOADING_FAILED;
-
+	if (mHotFuncs.mItem)
+		free(mHotFuncs.mItem);
 	// Resolve any unresolved base classes.
 	if (mUnresolvedClasses)
 	{

--- a/source/script.h
+++ b/source/script.h
@@ -2871,7 +2871,8 @@ private:
 	FuncList mHotFuncs;			// All implicit hotkey funcs are stored here for variable processing.
 								// This list is not sorted, all insertions are done at the end.
 								// In particular, note that DefineFunc and CreateHotFunc directly
-								// changes mCount.
+								// changes mCount. This list's member mItem is freed after being
+								// passed to PreprocessLocalVars. Do not use this list after that. 
 
 	Var **mVar, **mLazyVar; // Array of pointers-to-variable, allocated upon first use and later expanded as needed.
 	int mVarCount, mVarCountMax, mLazyVarCount; // Count of items in the above array as well as the maximum capacity.


### PR DESCRIPTION
Leaves `Script::mHotFuncs` in an unsafe state for brevity, comment added to warn.

Also comment fix.