### PR TITLE
Changing Script::DefineFunc to set HotkeyVariant::mOriginalCallback to the new func

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -6214,7 +6214,18 @@ ResultType Script::DefineFunc(LPTSTR aBuf, Var *aFuncGlobalVar[], bool aStatic, 
 				if (v->mJumpToLabel == last_hotfunc)
 				{
 					v->mJumpToLabel = &func;
-					v->mOriginalCallback = nullptr; // To avoid bugs.
+					v->mOriginalCallback = &func;	// To make scripts more maintainable and to
+													// make the hotkey() function more consistent.
+													// For example,
+													// x::{
+													// }
+													// Hotkey 'x', 'x', 'off'
+													// should be valid if the script is changed to,
+													// x::
+													// myFunc(){
+													// }
+													// Hotkey 'x', 'x', 'off'
+
 					break;	// Only one variant possible, per hotkey.
 				}
 		}


### PR DESCRIPTION
Reason, more consistent behaviour for the `Hotkey()` function and makes script more maintainable.

Allows the `hotkey()` function to refer to the hotkey name even if the hotkey named its callback.
