### PR TITLE
Removing HOT_IF_EXPR

### DIFF
--- a/source/defines.h
+++ b/source/defines.h
@@ -796,20 +796,17 @@ inline bool SendLevelIsValid(int level) { return level >= 0 && level <= SendLeve
 class Line; // Forward declaration.
 typedef UCHAR HotCriterionType;
 enum HotCriterionEnum {HOT_NO_CRITERION, HOT_IF_ACTIVE, HOT_IF_NOT_ACTIVE, HOT_IF_EXIST, HOT_IF_NOT_EXIST // HOT_NO_CRITERION must be zero.
-	, HOT_IF_EXPR, HOT_IF_CALLBACK}; // Keep the last two in this order for the macro below.
-#define HOT_IF_REQUIRES_EVAL(type) ((type) >= HOT_IF_EXPR)
+	, HOT_IF_CALLBACK};
+#define HOT_IF_REQUIRES_EVAL(type) ((type) == HOT_IF_CALLBACK)
 struct HotkeyCriterion
 {
 	HotCriterionType Type;
 	LPTSTR WinTitle, WinText;
-	union
-	{
-		Line *ExprLine;
-		IObject *Callback;
-	};
+	LPTSTR OriginalExpr; // For finding expr in #HotIf expr
+	IObject *Callback;
 	HotkeyCriterion *NextCriterion, *NextExpr;
 
-	ResultType Eval(LPTSTR aHotkeyName); // For HOT_IF_EXPR and HOT_IF_CALLBACK.
+	ResultType Eval(LPTSTR aHotkeyName); // For HOT_IF_CALLBACK.
 };
 
 

--- a/source/script.h
+++ b/source/script.h
@@ -952,7 +952,6 @@ public:
 		, Var **aArgVar = NULL);
 	ResultType ExpandSingleArg(int aArgIndex, ResultToken &aResultToken, LPTSTR &aDerefBuf, size_t &aDerefBufSize);
 	ResultType ExpressionToPostfix(ArgStruct &aArg);
-	ResultType EvaluateHotCriterionExpression(); // Called by HotkeyCriterion::Eval().
 
 	ResultType ValueIsType(ExprTokenType &aResultToken, ExprTokenType &aValue, LPTSTR aValueStr, ExprTokenType &aType, LPTSTR aTypeStr);
 


### PR DESCRIPTION
`#HotIf expr` now uses `HOT_IF_CALLBACK`, with callback

```autohotkey
<hotkey>(ThisHotkey) {
    return expr
}
```

The function is assume local for consistency with hotkeys. 

__Reason__, `HOT_IF_CALLBACK` can pass parameters. Removes the need (and limitation) for `A_ThisHotkey`.


## About

`#HotIf var` is not optimized for brevity, questionable benefit and for consitent behaviour. Example,

```autohotkey
; Behaviour if it was optimised (as before):
var := 'abc'
#hotIf var      ; var is seen, 'abc' is considered true.
x::msgbox var   ; var is not seen
#hotIf 'abc'    ; never true (must be numeric)
```

`LPTSTR HotkeyCrieterion::OriginalExpr` is added for storing the original expression, so it can be found again. Alternatively, I guess, `HotkeyCriterion::ExprLine` could be kept for `HOT_IF_ACTIVE/EXIST` and `WinTitle` could be used for `HOT_IF_CALLBACK` (added via `#hotIf`). But it seems more maintainable and readable to have only one (clear) way of finding the original expression. Only downside is one more pointer member per `HotkeyCriterion`, I don't think it matters much.

I did not use fat-arrow since that would require working around fat-arrows using assume global. 

Removed `EvaluateHotCriterionExpression()`, because it is not called anymore.