### PR TITLE
v1: IsSet()

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8661,6 +8661,12 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 0;
 		max_params = 3;
 	}
+	else if (!_tcsicmp(func_name, _T("IsSet")))
+	{
+		bif = BIF_IsSet;
+		min_params = 1;
+		max_params = 1;
+	}
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3305,6 +3305,7 @@ BIF_DECL(BIF_IsLabel);
 BIF_DECL(BIF_IsFunc);
 BIF_DECL(BIF_Func);
 BIF_DECL(BIF_IsByRef);
+BIF_DECL(BIF_IsSet);
 BIF_DECL(BIF_GetKeyState);
 BIF_DECL(BIF_GetKeyName);
 BIF_DECL(BIF_VarSetCapacity);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -16029,6 +16029,20 @@ BIF_DECL(BIF_IsByRef)
 
 
 
+BIF_DECL(BIF_IsSet)
+{
+	if (aParam[0]->symbol != SYM_VAR)
+	{
+		aResultToken.symbol = SYM_STRING;
+		aResultToken.marker = _T("");
+		_f_throw(ERR_PARAM1_INVALID);
+	}
+	else
+		aResultToken.value_int64 = !(aParam[0]->var->IsUninitializedNormalVar());
+}
+
+
+
 BIF_DECL(BIF_GetKeyState)
 {
 	TCHAR key_name_buf[MAX_NUMBER_SIZE]; // Because aResultToken.buf is used for something else below.


### PR DESCRIPTION
IsSet for AHK v1.1.

For reference: the v2 commit: [Added IsSet(Var)](https://github.com/Lexikos/AutoHotkey_L/commit/916fe75fb3670a9884276ba2c0f88d39808f6d9f).

Btw, I noticed that in AHK v2, the Exception.What property contains the function name, but not so in AHK v1.1.
E.g. try the Hotstring function.