### PR TITLE
v1: Backported IsSet() from alpha branch.

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8661,6 +8661,8 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 0;
 		max_params = 3;
 	}
+	else if (!_tcsicmp(func_name, _T("IsSet")))
+		bif = BIF_IsSet;
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3305,6 +3305,7 @@ BIF_DECL(BIF_IsLabel);
 BIF_DECL(BIF_IsFunc);
 BIF_DECL(BIF_Func);
 BIF_DECL(BIF_IsByRef);
+BIF_DECL(BIF_IsSet);
 BIF_DECL(BIF_GetKeyState);
 BIF_DECL(BIF_GetKeyName);
 BIF_DECL(BIF_VarSetCapacity);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -16029,6 +16029,20 @@ BIF_DECL(BIF_IsByRef)
 
 
 
+BIF_DECL(BIF_IsSet)
+{
+	if (aParam[0]->symbol != SYM_VAR)
+	{
+		aResultToken.symbol = SYM_STRING;
+		aResultToken.marker = _T("");
+		_f_throw(ERR_PARAM1_INVALID);
+	}
+	else
+		aResultToken.value_int64 = !(aParam[0]->var->IsUninitializedNormalVar());
+}
+
+
+
 BIF_DECL(BIF_GetKeyState)
 {
 	TCHAR key_name_buf[MAX_NUMBER_SIZE]; // Because aResultToken.buf is used for something else below.


### PR DESCRIPTION
Replaces #185. The commit is now stored in its own branch.

# IsSet
IsSet for AHK v1.1.

For reference:
The v2 commit: [Added IsSet(Var)](https://github.com/Lexikos/AutoHotkey_L/commit/916fe75fb3670a9884276ba2c0f88d39808f6d9f).
The v2 documentation: [IsSet](https://lexikos.github.io/v2/docs/commands/IsSet.htm).

Btw, I noticed that in AHK v2, the Exception.What property contains the function name, but not so in AHK v1.1.
E.g. try the Hotstring function.

# Test code

```
;==================================================

;test code: IsSet (AHK v1)

;==================================================

var := 123
MsgBox, % IsSet(notavar) ;0
MsgBox, % IsSet(var) ;1

;==================================================
```

# Future functions
I intend to post (all AHK v1.1):
StrCount.
StrRept. (By repeated doubling, then the remainder.)
StrJoin. (Accepts an array for an alternating join string.)
Range. (Returns an array of int64s/doubles.) (Performance with a for loop was fine for 100,000 items.)
[Base64Get/Base64Put and HexGet/HexPut](https://autohotkey.com/boards/viewtopic.php?f=75&t=64694). (The code, as is.)