### PR TITLE
Changing SimpleHeap::Malloc to terminate the program on allocation failure

### DIFF
--- a/source/SimpleHeap.h
+++ b/source/SimpleHeap.h
@@ -55,6 +55,10 @@ public:
 //	static UINT GetBlockCount() {return sBlockCount;}
 	static LPTSTR Malloc(LPTSTR aBuf, size_t aLength = -1); // Return a block of memory to the caller and copy aBuf into it.
 	static void* Malloc(size_t aSize); // Return a block of memory to the caller.
+	
+	static LPTSTR Alloc(LPTSTR aBuf, size_t aLength = -1); // Return a block of memory to the caller and copy aBuf into it.
+	static void* Alloc(size_t aSize); // Return a block of memory to the caller.
+
 	static void Delete(void *aPtr);
 	//static void DeleteAll();
 };

--- a/source/WinGroup.cpp
+++ b/source/WinGroup.cpp
@@ -52,13 +52,13 @@ ResultType WinGroup::AddWindow(LPTSTR aTitle, LPTSTR aText, LPTSTR aExcludeTitle
 				&& !_tcscmp(win->mExcludeTitle, aExcludeTitle) && !_tcscmp(win->mExcludeText, aExcludeText))
 				return OK;
 
-	// SimpleHeap::Malloc() will set these new vars to the constant empty string if their
+	// SimpleHeap::Alloc() will set these new vars to the constant empty string if their
 	// corresponding params are blank:
 	LPTSTR new_title, new_text, new_exclude_title, new_exclude_text;
-	if (!(new_title = SimpleHeap::Malloc(aTitle))) return FAIL; // It already displayed the error for us.
-	if (!(new_text = SimpleHeap::Malloc(aText)))return FAIL;
-	if (!(new_exclude_title = SimpleHeap::Malloc(aExcludeTitle))) return FAIL;
-	if (!(new_exclude_text = SimpleHeap::Malloc(aExcludeText)))   return FAIL;
+	if (!(new_title = SimpleHeap::Alloc(aTitle))) return FAIL; // It already displayed the error for us.
+	if (!(new_text = SimpleHeap::Alloc(aText)))return FAIL;
+	if (!(new_exclude_title = SimpleHeap::Alloc(aExcludeTitle))) return FAIL;
+	if (!(new_exclude_text = SimpleHeap::Alloc(aExcludeText)))   return FAIL;
 
 	// The precise method by which the follows steps are done should be thread-safe even if
 	// some other thread calls IsMember() in the middle of the operation.  But any changes
@@ -367,7 +367,7 @@ inline ResultType WinGroup::Update(bool aIsModeActivate)
 		// Getting it from SimpleHeap reduces overhead for the avg. case (i.e. the first
 		// block of SimpleHeap is usually never fully used, and this array won't even
 		// be allocated for short scripts that don't even using window groups.
-		if (   !(sAlreadyVisited = (HWND *)SimpleHeap::Malloc(MAX_ALREADY_VISITED * sizeof(HWND)))   )
+		if (   !(sAlreadyVisited = (HWND *)SimpleHeap::Alloc(MAX_ALREADY_VISITED * sizeof(HWND)))   )
 			return FAIL;  // It already displayed the error for us.
 	return OK;
 }

--- a/source/WinGroup.h
+++ b/source/WinGroup.h
@@ -40,8 +40,8 @@ public:
 		: mTitle(aTitle), mText(aText), mExcludeTitle(aExcludeTitle), mExcludeText(aExcludeText)
 		, mNextWindow(NULL) // mNextWindow(NULL) is also required for thread-safety.
 	{}
-	void *operator new(size_t aBytes) {return SimpleHeap::Malloc(aBytes);}
-	void *operator new[](size_t aBytes) {return SimpleHeap::Malloc(aBytes);}
+	void *operator new(size_t aBytes) {return SimpleHeap::Alloc(aBytes);}
+	void *operator new[](size_t aBytes) {return SimpleHeap::Alloc(aBytes);}
 	void operator delete(void *aPtr) {}
 	void operator delete[](void *aPtr) {}
 };
@@ -96,8 +96,8 @@ public:
 		, mNextGroup(NULL) // v1.0.41: Required for thread-safety, but also for maintainability.
 		, mIsModeActivate(true) // arbitrary default.
 	{}
-	void *operator new(size_t aBytes) {return SimpleHeap::Malloc(aBytes);}
-	void *operator new[](size_t aBytes) {return SimpleHeap::Malloc(aBytes);}
+	void *operator new(size_t aBytes) {return SimpleHeap::Alloc(aBytes);}
+	void *operator new[](size_t aBytes) {return SimpleHeap::Alloc(aBytes);}
 	void operator delete(void *aPtr) {}
 	void operator delete[](void *aPtr) {}
 };

--- a/source/hotkey.cpp
+++ b/source/hotkey.cpp
@@ -100,20 +100,20 @@ HotkeyCriterion *FindHotkeyCriterion(HotCriterionType aType, LPTSTR aWinTitle, L
 HotkeyCriterion *AddHotkeyCriterion(HotCriterionType aType, LPTSTR aWinTitle, LPTSTR aWinText)
 {
 	HotkeyCriterion *cp;
-	if (   !(cp = (HotkeyCriterion *)SimpleHeap::Malloc(sizeof(HotkeyCriterion)))   )
+	if (   !(cp = (HotkeyCriterion *)SimpleHeap::Alloc(sizeof(HotkeyCriterion)))   )
 		return NULL;
 	cp->Type = aType;
 	cp->OriginalExpr = nullptr;
 	if (*aWinTitle)
 	{
-		if (   !(cp->WinTitle = SimpleHeap::Malloc(aWinTitle))   )
+		if (   !(cp->WinTitle = SimpleHeap::Alloc(aWinTitle))   )
 			return NULL;
 	}
 	else
 		cp->WinTitle = _T("");
 	if (*aWinText)
 	{
-		if (   !(cp->WinText = SimpleHeap::Malloc(aWinText))   )
+		if (   !(cp->WinText = SimpleHeap::Alloc(aWinText))   )
 			return NULL;
 	}
 	else
@@ -140,7 +140,7 @@ HotkeyCriterion *AddHotkeyCriterion(HotkeyCriterion *cp)
 HotkeyCriterion *AddHotkeyIfExpr()
 {
 	HotkeyCriterion *cp;
-	if (   !(cp = (HotkeyCriterion *)SimpleHeap::Malloc(sizeof(HotkeyCriterion)))   )
+	if (   !(cp = (HotkeyCriterion *)SimpleHeap::Alloc(sizeof(HotkeyCriterion)))   )
 		return NULL;
 	cp->NextExpr = NULL;
 	cp->OriginalExpr = nullptr;
@@ -1474,7 +1474,7 @@ Hotkey::Hotkey(HotkeyIDType aID, IObject *aJumpToLabel, HookActionType aHookActi
 	// If mKeybdHookMandatory==true, ManifestAllHotkeysHotstringsHooks() will set mType to HK_KEYBD_HOOK for us.
 
 	// To avoid memory leak, this is done only when it is certain the hotkey will be created:
-	if (   !(mName = aName ? SimpleHeap::Malloc(aName) : hotkey_name)
+	if (   !(mName = aName ? SimpleHeap::Alloc(aName) : hotkey_name)
 		|| !(AddVariant(aJumpToLabel, aSuffixHasTilde))   ) // Too rare to worry about freeing the other if only one fails.
 	{
 		g_script.ScriptError(ERR_OUTOFMEM);
@@ -1511,7 +1511,7 @@ HotkeyVariant *Hotkey::AddVariant(IObject *aJumpToLabel, bool aSuffixHasTilde)
 // The caller is responsible for calling ManifestAllHotkeysHotstringsHooks(), if appropriate.
 {
 	HotkeyVariant *vp;
-	if (   !(vp = (HotkeyVariant *)SimpleHeap::Malloc(sizeof(HotkeyVariant)))   )
+	if (   !(vp = (HotkeyVariant *)SimpleHeap::Alloc(sizeof(HotkeyVariant)))   )
 		return NULL;
 	ZeroMemory(vp, sizeof(HotkeyVariant));
 	// The following members are left at 0/NULL by the above:
@@ -2454,9 +2454,9 @@ Hotstring::Hotstring(LPTSTR aName, LabelPtr aJumpToLabel, LPTSTR aOptions, LPTST
 		, mOmitEndChar, mSendRaw, mEndCharRequired, mDetectWhenInsideWord, mDoReset, execute_action);
 	
 	// To avoid memory leak, this is done only when it is certain the hotstring will be created:
-	if (   !(mString = SimpleHeap::Malloc(aHotstring))   )
+	if (   !(mString = SimpleHeap::Alloc(aHotstring))   )
 		return; // ScriptError() was already called by Malloc().
-	if (   g_script.mIsReadyToExecute && !(mName = SimpleHeap::Malloc(aName))   ) // mName already contains persistent memory when we're called at load time.
+	if (   g_script.mIsReadyToExecute && !(mName = SimpleHeap::Alloc(aName))   ) // mName already contains persistent memory when we're called at load time.
 	{
 		SimpleHeap::Delete(mString); // SimpleHeap allows deletion of most recently added item.
 		return;

--- a/source/hotkey.h
+++ b/source/hotkey.h
@@ -147,8 +147,8 @@ private:
 	ResultType Register();
 	ResultType Unregister();
 
-	void *operator new(size_t aBytes) {return SimpleHeap::Malloc(aBytes);}
-	void *operator new[](size_t aBytes) {return SimpleHeap::Malloc(aBytes);}
+	void *operator new(size_t aBytes) {return SimpleHeap::Alloc(aBytes);}
+	void *operator new[](size_t aBytes) {return SimpleHeap::Alloc(aBytes);}
 	void operator delete(void *aPtr) {SimpleHeap::Delete(aPtr);}  // Deletes aPtr if it was the most recently allocated.
 	void operator delete[](void *aPtr) {SimpleHeap::Delete(aPtr);}
 
@@ -383,8 +383,8 @@ public:
 		, bool aHasContinuationSection, UCHAR aSuspend);
 	~Hotstring() {}  // Note that mReplacement is sometimes malloc'd, sometimes from SimpleHeap, and sometimes the empty string.
 
-	void *operator new(size_t aBytes) {return SimpleHeap::Malloc(aBytes);}
-	void *operator new[](size_t aBytes) {return SimpleHeap::Malloc(aBytes);}
+	void *operator new(size_t aBytes) {return SimpleHeap::Alloc(aBytes);}
+	void *operator new[](size_t aBytes) {return SimpleHeap::Alloc(aBytes);}
 	void operator delete(void *aPtr) {SimpleHeap::Delete(aPtr);}  // Deletes aPtr if it was the most recently allocated.
 	void operator delete[](void *aPtr) {SimpleHeap::Delete(aPtr);}
 };

--- a/source/script.h
+++ b/source/script.h
@@ -1842,8 +1842,8 @@ public:
 
 	bool Call(ResultToken &aResultToken, ExprTokenType *aParam[], int aParamCount, IObject *aParamObj) override;
 
-	void *operator new(size_t aBytes) {return SimpleHeap::Malloc(aBytes);}
-	void *operator new[](size_t aBytes) {return SimpleHeap::Malloc(aBytes);}
+	void *operator new(size_t aBytes) {return SimpleHeap::Alloc(aBytes);}
+	void *operator new[](size_t aBytes) {return SimpleHeap::Alloc(aBytes);}
 	void operator delete(void *aPtr) {}
 	void operator delete[](void *aPtr) {}
 };

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -4753,19 +4753,14 @@ UserFunc* Script::CreateHotFunc(Var* aFuncGlobalVar[], int aGlobalVarCount)
 	static LPCTSTR sName = _T("<Hotkey>");
 	auto func = new UserFunc(sName);
 	
-	if (!func)
-	{
-		ScriptError(ERR_OUTOFMEM);
-		return nullptr;
-	}
 	func->mGlobalVar = aFuncGlobalVar;
 	mGlobalVarCountMax = aGlobalVarCount;
 	
 	g->CurrentFunc = func; // Must do this before calling FindOrAddVar
 
 	// Add one parameter to hold the name of the hotkey/hotstring when triggered:
-	if (	!(func->mParam = (FuncParam*)SimpleHeap::Malloc(sizeof FuncParam))
-		||	!(func->mParam[0].var = FindOrAddVar(_T("ThisHotkey"), 10, VAR_DECLARE_LOCAL | VAR_LOCAL_FUNCPARAM)) )
+	func->mParam = (FuncParam*)SimpleHeap::Malloc(sizeof FuncParam);
+	if (!(func->mParam[0].var = FindOrAddVar(_T("ThisHotkey"), 10, VAR_DECLARE_LOCAL | VAR_LOCAL_FUNCPARAM)) )
 		return nullptr;
 
 	func->mParam[0].default_type = PARAM_DEFAULT_NONE;
@@ -9610,7 +9605,7 @@ void Script::SetTrayTip(LPTSTR aText)
 	// it will override the use of mFileName as the tray tip text.
 	// This allows the script to completely disable the tray tooltip.
 	if (!mTrayIconTip)
-		mTrayIconTip = (LPTSTR) SimpleHeap::Malloc(sizeof(mNIC.szTip)); // SimpleHeap improves avg. case mem load.
+		mTrayIconTip = (LPTSTR) SimpleHeap::Alloc(sizeof(mNIC.szTip)); // SimpleHeap improves avg. case mem load.
 	if (mTrayIconTip)
 		tcslcpy(mTrayIconTip, aText, _countof(mNIC.szTip));
 	if (mNIC.hWnd) // i.e. only update the tip if the tray icon exists (can't work otherwise).

--- a/source/var.cpp
+++ b/source/var.cpp
@@ -477,7 +477,7 @@ ResultType Var::AssignString(LPCTSTR aBuf, VarSizeType aLength, bool aExactSize)
 				// In the case of mHowAllocated==ALLOC_SIMPLE, the following will allocate another block
 				// from SimpleHeap even though the var already had one. This is by design because it can
 				// happen only a limited number of times per variable. See comments further above for details.
-				if (   !(new_mem = (char *) SimpleHeap::Malloc(new_size))   )
+				if (   !(new_mem = (char *) SimpleHeap::Alloc(new_size))   )
 					return FAIL; // It already displayed the error. Leave all var members unchanged so that they're consistent with each other. Don't bother making the var blank and its length zero for reasons described higher above.
 				mHowAllocated = ALLOC_SIMPLE;  // In case it was previously ALLOC_NONE. This step must be done only after the alloc succeeded.
 				break;

--- a/source/var.h
+++ b/source/var.h
@@ -900,9 +900,9 @@ public:
 	{
 	}
 
-	void *operator new(size_t aBytes) {return SimpleHeap::Malloc(aBytes);}
+	void *operator new(size_t aBytes) {return SimpleHeap::Alloc(aBytes);}
 	void *operator new(size_t aBytes, void *p) {return p;}
-	void *operator new[](size_t aBytes) {return SimpleHeap::Malloc(aBytes);}
+	void *operator new[](size_t aBytes) {return SimpleHeap::Alloc(aBytes);}
 	void operator delete(void *aPtr) {}
 	void operator delete(void *aPtr, void *) {}
 	void operator delete[](void *aPtr) {}


### PR DESCRIPTION
__New__

Use `SimpleHeap:Malloc` (and do not verify the return value) when it is acceptable that the program terminates on failure. Else call `SimpleHeap::Alloc`, and verify the return value.

__About__

Calls `g_script.TerminateApp(EXIT_DESTROY, CRITICAL_ERROR)` to terminate the script. `Malloc` _shouldn't_ be called during run time.

__Reasons__

Brevity, convenience, maintainability and presumably (future?) code size.

__Misc__

Also fixes potential undefined behaviour,

* in `CreateClass/DefineMembers` which didn't verify return from `operator new`.
* when `DefineMethod` is called via `CreateRootPrototypes`.

I'll change the method names `Malloc/Alloc` if desired.