### PR TITLE
Renaming some objects with "label" in their name.

### DIFF
--- a/source/application.cpp
+++ b/source/application.cpp
@@ -1257,7 +1257,7 @@ bool MsgSleep(int aSleepDuration, MessageMode aMode)
 			case AHK_INPUT_END:
 			{
 				ExprTokenType param = input_hook->ScriptObject;
-				LabelPtr(input_hook->ScriptObject->onEnd)->ExecuteInNewThread(_T("InputHook"), &param, 1);
+				IObjectPtr(input_hook->ScriptObject->onEnd)->ExecuteInNewThread(_T("InputHook"), &param, 1);
 				input_hook->ScriptObject->Release();
 				break;
 			}
@@ -1271,7 +1271,7 @@ bool MsgSleep(int aSleepDuration, MessageMode aMode)
 					__int64(vk_type(msg.lParam)),
 					__int64(sc_type(msg.lParam >> 16)),
 				};
-				LabelPtr onKey = msg.message == AHK_INPUT_KEYDOWN ? input_hook->ScriptObject->onKeyDown : input_hook->ScriptObject->onKeyUp;
+				IObjectPtr onKey = msg.message == AHK_INPUT_KEYDOWN ? input_hook->ScriptObject->onKeyDown : input_hook->ScriptObject->onKeyUp;
 				onKey->ExecuteInNewThread(_T("InputHook"), params, _countof(params));
 				break;
 			}
@@ -1284,7 +1284,7 @@ bool MsgSleep(int aSleepDuration, MessageMode aMode)
 					input_hook->ScriptObject,
 					chars
 				};
-				LabelPtr(input_hook->ScriptObject->onChar)->ExecuteInNewThread(_T("InputHook"), params, _countof(params));
+				IObjectPtr(input_hook->ScriptObject->onChar)->ExecuteInNewThread(_T("InputHook"), params, _countof(params));
 				break;
 			}
 

--- a/source/hotkey.cpp
+++ b/source/hotkey.cpp
@@ -2380,7 +2380,7 @@ void Hotstring::DoReplace(LPARAM alParam)
 
 
 
-ResultType Hotstring::AddHotstring(LPTSTR aName, LabelPtr aJumpToLabel, LPTSTR aOptions, LPTSTR aHotstring
+ResultType Hotstring::AddHotstring(LPTSTR aName, IObjectPtr aJumpToLabel, LPTSTR aOptions, LPTSTR aHotstring
 		, LPTSTR aReplacement, bool aHasContinuationSection, UCHAR aSuspend)
 // Caller provides aJumpToLabel rather than a Line* because at the time a hotkey or hotstring
 // is created, the label's destination line is not yet known.  So the label is used a placeholder.
@@ -2429,7 +2429,7 @@ ResultType Hotstring::AddHotstring(LPTSTR aName, LabelPtr aJumpToLabel, LPTSTR a
 
 
 
-Hotstring::Hotstring(LPTSTR aName, LabelPtr aJumpToLabel, LPTSTR aOptions, LPTSTR aHotstring, LPTSTR aReplacement
+Hotstring::Hotstring(LPTSTR aName, IObjectPtr aJumpToLabel, LPTSTR aOptions, LPTSTR aHotstring, LPTSTR aReplacement
 	, bool aHasContinuationSection, UCHAR aSuspend)
 	: mJumpToLabel(aJumpToLabel)  // Any NULL value will cause failure further below.
 	, mName(aName)
@@ -2696,7 +2696,7 @@ BIF_DECL(BIF_Hotstring)
 		// Update the replacement string or function/label, if specified.
 		if (action_obj || *action)
 		{
-			LabelPtr new_label = action_obj ? action_obj : g_script.mPlaceholderLabel; // Other parts may rely on mJumpToLabel always being non-NULL.
+			IObjectPtr new_label = action_obj ? action_obj : g_script.mPlaceholderLabel; // Other parts may rely on mJumpToLabel always being non-NULL.
 			LPTSTR new_replacement = NULL; // Set default: not auto-replace.
 			if (!action_obj) // Caller specified a replacement string ('E' option was handled above).
 			{

--- a/source/hotkey.h
+++ b/source/hotkey.h
@@ -76,7 +76,7 @@ HotkeyCriterion *FindHotkeyIfExpr(LPTSTR aExpr);
 
 struct HotkeyVariant
 {
-	IObjectRef mJumpToLabel;
+	IObjectRef mCallback;
 	IObjectPtr mOriginalCallback;	// This is the callback set at load time. 
 								// Keep it to allow restoring it via hotkey() function if changed
 								// during run time.
@@ -154,7 +154,7 @@ private:
 
 	// For now, constructor & destructor are private so that only static methods can create new
 	// objects.  This allow proper tracking of which OS hotkey IDs have been used.
-	Hotkey(HotkeyIDType aID, IObject *aJumpToLabel, HookActionType aHookAction, LPTSTR aName, bool aSuffixHasTilde);
+	Hotkey(HotkeyIDType aID, IObject *aCallback, HookActionType aHookAction, LPTSTR aName, bool aSuffixHasTilde);
 	~Hotkey() {if (mIsRegistered) Unregister();}
 
 public:
@@ -214,11 +214,11 @@ public:
 	#define HOTKEY_EL_MEM                99
 	static ResultType IfExpr(LPTSTR aExpr, IObject *aExprObj, ResultToken &aResultToken);
 	static ResultType Dynamic(LPTSTR aHotkeyName, LPTSTR aLabelName, LPTSTR aOptions
-		, IObject *aJumpToLabel, HookActionType aHookAction, ResultToken &aResultToken);
+		, IObject *aCallback, HookActionType aHookAction, ResultToken &aResultToken);
 
-	static Hotkey *AddHotkey(IObject *aJumpToLabel, HookActionType aHookAction, LPTSTR aName, bool aSuffixHasTilde);
+	static Hotkey *AddHotkey(IObject *aCallback, HookActionType aHookAction, LPTSTR aName, bool aSuffixHasTilde);
 	HotkeyVariant *FindVariant();
-	HotkeyVariant *AddVariant(IObject *aJumpToLabel, bool aSuffixHasTilde);
+	HotkeyVariant *AddVariant(IObject *aCallback, bool aSuffixHasTilde);
 	static bool PrefixHasNoEnabledSuffixes(int aVKorSC, bool aIsSC);
 	HotkeyVariant *CriterionAllowsFiring(HWND *aFoundHWND = NULL);
 	static HotkeyVariant *CriterionAllowsFiring(HotkeyIDType aHotkeyID, HWND &aFoundHWND);
@@ -348,7 +348,7 @@ public:
 	static HotstringIDType sHotstringCountMax;
 	static UINT sEnabledCount; // v1.1.28.00: For performance, such as avoiding calling ToAsciiEx() in the hook.
 
-	IObjectRef mJumpToLabel;
+	IObjectRef mCallback;
 	LPTSTR mName;
 	LPTSTR mString, mReplacement;
 	HotkeyCriterion *mHotCriterion;
@@ -371,7 +371,7 @@ public:
 	ResultType PerformInNewThreadMadeByCaller();
 	void DoReplace(LPARAM alParam);
 	static Hotstring *FindHotstring(LPTSTR aHotstring, bool aCaseSensitive, bool aDetectWhenInsideWord, HotkeyCriterion *aHotCriterion);
-	static ResultType AddHotstring(LPTSTR aName, IObjectPtr aJumpToLabel, LPTSTR aOptions, LPTSTR aHotstring
+	static ResultType AddHotstring(LPTSTR aName, IObjectPtr aCallback, LPTSTR aOptions, LPTSTR aHotstring
 		, LPTSTR aReplacement, bool aHasContinuationSection, UCHAR aSuspend = FALSE);
 	static void ParseOptions(LPTSTR aOptions, int &aPriority, int &aKeyDelay, SendModes &aSendMode
 		, bool &aCaseSensitive, bool &aConformToCase, bool &aDoBackspace, bool &aOmitEndChar, SendRawType &aSendRaw
@@ -379,7 +379,7 @@ public:
 	void ParseOptions(LPTSTR aOptions);
 
 	// Constructor & destructor:
-	Hotstring(LPTSTR aName, IObjectPtr aJumpToLabel, LPTSTR aOptions, LPTSTR aHotstring, LPTSTR aReplacement
+	Hotstring(LPTSTR aName, IObjectPtr aCallback, LPTSTR aOptions, LPTSTR aHotstring, LPTSTR aReplacement
 		, bool aHasContinuationSection, UCHAR aSuspend);
 	~Hotstring() {}  // Note that mReplacement is sometimes malloc'd, sometimes from SimpleHeap, and sometimes the empty string.
 

--- a/source/hotkey.h
+++ b/source/hotkey.h
@@ -76,8 +76,8 @@ HotkeyCriterion *FindHotkeyIfExpr(LPTSTR aExpr);
 
 struct HotkeyVariant
 {
-	LabelRef mJumpToLabel;
-	LabelPtr mOriginalCallback;	// This is the callback set at load time. 
+	IObjectRef mJumpToLabel;
+	IObjectPtr mOriginalCallback;	// This is the callback set at load time. 
 								// Keep it to allow restoring it via hotkey() function if changed
 								// during run time.
 	HotkeyCriterion *mHotCriterion;
@@ -348,7 +348,7 @@ public:
 	static HotstringIDType sHotstringCountMax;
 	static UINT sEnabledCount; // v1.1.28.00: For performance, such as avoiding calling ToAsciiEx() in the hook.
 
-	LabelRef mJumpToLabel;
+	IObjectRef mJumpToLabel;
 	LPTSTR mName;
 	LPTSTR mString, mReplacement;
 	HotkeyCriterion *mHotCriterion;
@@ -371,7 +371,7 @@ public:
 	ResultType PerformInNewThreadMadeByCaller();
 	void DoReplace(LPARAM alParam);
 	static Hotstring *FindHotstring(LPTSTR aHotstring, bool aCaseSensitive, bool aDetectWhenInsideWord, HotkeyCriterion *aHotCriterion);
-	static ResultType AddHotstring(LPTSTR aName, LabelPtr aJumpToLabel, LPTSTR aOptions, LPTSTR aHotstring
+	static ResultType AddHotstring(LPTSTR aName, IObjectPtr aJumpToLabel, LPTSTR aOptions, LPTSTR aHotstring
 		, LPTSTR aReplacement, bool aHasContinuationSection, UCHAR aSuspend = FALSE);
 	static void ParseOptions(LPTSTR aOptions, int &aPriority, int &aKeyDelay, SendModes &aSendMode
 		, bool &aCaseSensitive, bool &aConformToCase, bool &aDoBackspace, bool &aOmitEndChar, SendRawType &aSendRaw
@@ -379,7 +379,7 @@ public:
 	void ParseOptions(LPTSTR aOptions);
 
 	// Constructor & destructor:
-	Hotstring(LPTSTR aName, LabelPtr aJumpToLabel, LPTSTR aOptions, LPTSTR aHotstring, LPTSTR aReplacement
+	Hotstring(LPTSTR aName, IObjectPtr aJumpToLabel, LPTSTR aOptions, LPTSTR aHotstring, LPTSTR aReplacement
 		, bool aHasContinuationSection, UCHAR aSuspend);
 	~Hotstring() {}  // Note that mReplacement is sometimes malloc'd, sometimes from SimpleHeap, and sometimes the empty string.
 

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -11046,7 +11046,7 @@ ResultType HotkeyCriterion::Eval(LPTSTR aHotkeyName)
 	// CALL THE CALLBACK
 	ExprTokenType param = aHotkeyName;
 	__int64 retval;
-	result = LabelPtr(Callback)->ExecuteInNewThread(_T("#HotIf"), &param, 1, &retval);
+	result = IObjectPtr(Callback)->ExecuteInNewThread(_T("#HotIf"), &param, 1, &retval);
 	if (result != FAIL)
 		result = retval ? CONDITION_TRUE : CONDITION_FALSE;
 	

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -6247,9 +6247,9 @@ ResultType Script::DefineFunc(LPTSTR aBuf, Var *aFuncGlobalVar[], bool aStatic, 
 		for (int i = 0; i < Hotkey::sHotkeyCount; ++i)
 		{
 			for (HotkeyVariant* v = Hotkey::shk[i]->mFirstVariant; v; v = v->mNextVariant)
-				if (v->mJumpToLabel == last_hotfunc)
+				if (v->mCallback == last_hotfunc)
 				{
-					v->mJumpToLabel = &func;
+					v->mCallback = &func;
 					v->mOriginalCallback = &func;	// To make scripts more maintainable and to
 													// make the hotkey() function more consistent.
 													// For example,
@@ -6268,12 +6268,12 @@ ResultType Script::DefineFunc(LPTSTR aBuf, Var *aFuncGlobalVar[], bool aStatic, 
 		// Check hotstrings as well (even if a hotkey was found):
 		for (int i = Hotstring::sHotstringCount - 1; i >= 0; --i) // Start with the last one defined, for performance.
 		{
-			if (Hotstring::shs[i]->mJumpToLabel != last_hotfunc)
+			if (Hotstring::shs[i]->mCallback != last_hotfunc)
 				// This hotstring has a function or is auto-replace.
 				// Since hotstrings are listed in order of definition and we're iterating in
 				// the reverse order, there's no need to continue.
 				break;
-			Hotstring::shs[i]->mJumpToLabel = &func;
+			Hotstring::shs[i]->mCallback = &func;
 		}
 
 		if (func.mMinParams > 1 || (func.mParamCount == 0 && !func.mIsVariadic))

--- a/source/script.h
+++ b/source/script.h
@@ -1442,53 +1442,52 @@ public:
 // hotkey, etc.  It provides common functionality that wouldn't be suitable for the
 // base IObject interface, but is needed for detection of "Suspend" or "Critical"
 // prior to calling the sub or function.
-class LabelPtr
+class IObjectPtr
 {
 protected:
 	IObject *mObject;
 	
 public:
-	LabelPtr() : mObject(NULL) {}
-	LabelPtr(IObject *object) : mObject(object) {}
+	IObjectPtr() : mObject(NULL) {}
+	IObjectPtr(IObject *object) : mObject(object) {}
 	ResultType ExecuteInNewThread(TCHAR *aNewThreadDesc
 		, ExprTokenType *aParamValue = NULL, int aParamCount = 0, __int64 *aRetVal = NULL) const;
-	const LabelPtr* operator-> () { return this; } // Act like a pointer.
+	const IObjectPtr* operator-> () { return this; } // Act like a pointer.
 	operator void *() const { return mObject; } // For comparisons and boolean eval.
 
 	// Caller beware: does not check for NULL.
-	Label *ToLabel() const;
 	Func *ToFunc() const;
 	IObject *ToObject() const { return mObject; }
 	
 	// True if it is a dynamically-allocated object, not a Label or Func.
-	bool IsLiveObject() const { return mObject && !(ToFunc() || ToLabel()); }
+	bool IsLiveObject() const { return mObject && !ToFunc(); }
 	
 	// Currently only used by ListLines, listing active timers.
 	LPCTSTR Name() const;
 };
 
-// LabelPtr with automatic reference-counting, for storing an object safely,
+// IObjectPtr with automatic reference-counting, for storing an object safely,
 // such as in a HotkeyVariant, UserMenuItem, etc.  Its specific purpose is to
 // work with old code that wasn't concerned with reference counting.
-class LabelRef : public LabelPtr
+class IObjectRef : public IObjectPtr
 {
 private:
-	LabelRef(const LabelRef &); // Disable default copy constructor.
-	LabelRef & operator = (const LabelRef &); // ...and copy assignment.
+	IObjectRef(const IObjectRef &); // Disable default copy constructor.
+	IObjectRef & operator = (const IObjectRef &); // ...and copy assignment.
 
 public:
-	LabelRef() : LabelPtr() {}
-	LabelRef(IObject *object) : LabelPtr(object)
+	IObjectRef() : IObjectPtr() {}
+	IObjectRef(IObject *object) : IObjectPtr(object)
 	{
 		if (object)
 			object->AddRef();
 	}
-	LabelRef(const LabelPtr &other) : LabelPtr(other)
+	IObjectRef(const IObjectPtr &other) : IObjectPtr(other)
 	{
 		if (mObject)
 			mObject->AddRef();
 	}
-	LabelRef & operator = (IObject *object)
+	IObjectRef & operator = (IObject *object)
 	{
 		if (object)
 			object->AddRef();
@@ -1497,11 +1496,11 @@ public:
 		mObject = object;
 		return *this;
 	}
-	LabelRef & operator = (const LabelPtr &other)
+	IObjectRef & operator = (const IObjectPtr &other)
 	{
 		return *this = other.ToObject();
 	}
-	~LabelRef()
+	~IObjectRef()
 	{
 		if (mObject)
 			mObject->Release();
@@ -1980,7 +1979,7 @@ public:
 class ScriptTimer
 {
 public:
-	LabelRef mCallback;
+	IObjectRef mCallback;
 	DWORD mPeriod; // v1.0.36.33: Changed from int to DWORD to double its capacity.
 	DWORD mTimeLastRun;  // TickCount
 	int mPriority;  // Thread priority relative to other threads, default 0.
@@ -2198,7 +2197,7 @@ class UserMenuItem
 public:
 	LPTSTR mName;  // Dynamically allocated.
 	size_t mNameCapacity;
-	LabelRef mCallback;
+	IObjectRef mCallback;
 	UserMenu *mSubmenu;
 	UserMenu *mMenu;  // The menu to which this item belongs.  Needed to support script var A_ThisMenu.
 	UINT mMenuID;

--- a/source/script_menu.cpp
+++ b/source/script_menu.cpp
@@ -638,7 +638,7 @@ UserMenuItem::~UserMenuItem()
 {
 	if (mName != Var::sEmptyString)
 		free(mName);
-	// mCallback is handled by ~LabelRef().
+	// mCallback is handled by ~IObjectRef().
 	if (mSubmenu)
 		mSubmenu->Release();
 }

--- a/source/script_object.cpp
+++ b/source/script_object.cpp
@@ -2598,7 +2598,7 @@ ResultType Label::Invoke(IObject_Invoke_PARAMS_DECL)
 	return Execute();
 }
 
-ResultType LabelPtr::ExecuteInNewThread(TCHAR *aNewThreadDesc, ExprTokenType *aParamValue, int aParamCount, __int64 *aRetVal) const
+ResultType IObjectPtr::ExecuteInNewThread(TCHAR *aNewThreadDesc, ExprTokenType *aParamValue, int aParamCount, __int64 *aRetVal) const
 {
 	DEBUGGER_STACK_PUSH(aNewThreadDesc)
 	ResultType result = CallMethod(mObject, mObject, nullptr, aParamValue, aParamCount, aRetVal);
@@ -2606,28 +2606,16 @@ ResultType LabelPtr::ExecuteInNewThread(TCHAR *aNewThreadDesc, ExprTokenType *aP
 	return result;
 }
 
-
-Label *LabelPtr::ToLabel() const
-{
-	// Comparing [[vfptr]] produces smaller code and is perhaps 10% faster than dynamic_cast<>.
-	void *vfptr = *(void **)mObject;
-	if (vfptr == *(void **)g_script.mPlaceholderLabel)
-		return (Label *)mObject;
-	return nullptr;
-}
-
-Func *LabelPtr::ToFunc() const
+Func *IObjectPtr::ToFunc() const
 {
 	return dynamic_cast<Func *>(mObject);
 }
 
-LPCTSTR LabelPtr::Name() const
+LPCTSTR IObjectPtr::Name() const
 {
 	if (auto func = ToFunc()) return func->mName;
-	if (auto lbl = ToLabel()) return lbl->mName;
 	return mObject->Type();
 }
-
 
 
 ResultType MsgMonitorList::Call(ExprTokenType *aParamValue, int aParamCount, int aInitNewThreadIndex, __int64 *aRetVal)


### PR DESCRIPTION
__New__

* `class LabelRef` renamed to `IObjectRef`.
* `class LabelPtr` renamed to `IObjectPtr`.
* all `aJumpToLabel` renamed to `aCallback`.
* all `mJumpToLabel` renamed to `mCallback`.

__About__

`LabelPtr/Ref` and `mJumpToLabel` was renamed by VS' __Rename__ feature. `aJumpToLabel` was renamed by VS' __Find and replace__. Also removed `LabelPtr::ToLabel()`.

__Reason__

These objects doesn't reference labels.