### PR TITLE
Removing unnecessary parameter for Hotkey::PerformInNewThreadMadeByCaller

### DIFF
--- a/source/application.cpp
+++ b/source/application.cpp
@@ -1295,7 +1295,7 @@ bool MsgSleep(int aSleepDuration, MessageMode aMode)
 				g.hWndLastUsed = criterion_found_hwnd; // v1.0.42. Even if the window is invalid for some reason, IsWindow() and such are called whenever the script accesses it (GetValidLastUsedWindow()).
 				g.SendLevel = variant->mInputLevel;
 				g.HotCriterion = variant->mHotCriterion; // v2: Let the Hotkey command use the criterion of this hotkey variant by default.
-				hk->PerformInNewThreadMadeByCaller(*variant, hk->mName);
+				hk->PerformInNewThreadMadeByCaller(*variant);
 				
 			}
 

--- a/source/hotkey.cpp
+++ b/source/hotkey.cpp
@@ -841,7 +841,7 @@ void Hotkey::TriggerJoyHotkeys(int aJoystickID, DWORD aButtonsNewlyDown)
 
 
 
-void Hotkey::PerformInNewThreadMadeByCaller(HotkeyVariant &aVariant, LPTSTR aName)
+void Hotkey::PerformInNewThreadMadeByCaller(HotkeyVariant &aVariant)
 // Caller is responsible for having called PerformIsAllowed() before calling us.
 // Caller must have already created a new thread for us, and must close the thread when we return.
 {
@@ -921,7 +921,7 @@ void Hotkey::PerformInNewThreadMadeByCaller(HotkeyVariant &aVariant, LPTSTR aNam
 	// LAUNCH HOTKEY SUBROUTINE:
 	++aVariant.mExistingThreads;  // This is the thread count for this particular hotkey only.
 
-	ExprTokenType params = { aName };
+	ExprTokenType params = { mName };
 	ResultType result = aVariant.mJumpToLabel->ExecuteInNewThread(g_script.mThisHotkeyName, &params, 1);
 	
 	--aVariant.mExistingThreads;

--- a/source/hotkey.h
+++ b/source/hotkey.h
@@ -226,7 +226,7 @@ public:
 		, UCHAR &aNoSuppress, bool &aFireWithNoSuppress, LPTSTR aSingleChar);
 	static modLR_type HotkeyRequiresModLR(HotkeyIDType aHotkeyIDwithoutflags, modLR_type aModLR);
 	static void TriggerJoyHotkeys(int aJoystickID, DWORD aButtonsNewlyDown);
-	void PerformInNewThreadMadeByCaller(HotkeyVariant &aVariant, LPTSTR aName);
+	void PerformInNewThreadMadeByCaller(HotkeyVariant &aVariant);
 	static void ManifestAllHotkeysHotstringsHooks();
 	static void RequireHook(HookType aWhichHook) {sWhichHookAlways |= aWhichHook;}
 	static void MaybeUninstallHook();


### PR DESCRIPTION
Specifically `LPTSTR aName`.

__Reason__, this name is already available through `mName` in the method.

Blame: #177 