### PR TITLE
v1: StrCount()

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8661,6 +8661,12 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 0;
 		max_params = 3;
 	}
+	else if (!_tcsicmp(func_name, _T("StrCount")))
+	{
+		bif = BIF_StrCount;
+		min_params = 2;
+		max_params = 4;
+	}
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3356,6 +3356,7 @@ BIF_DECL(BIF_Trim); // L31: Also handles LTrim and RTrim.
 
 BIF_DECL(BIF_Hotstring);
 BIF_DECL(BIF_InputHook);
+BIF_DECL(BIF_StrCount);
 
 
 BIF_DECL(BIF_IsObject);


### PR DESCRIPTION
`Count := StrCount(Haystack, Needle [, CaseSensitive := false, StartingPos := 1])`

Parameters based on InStr.
Code based on StrReplace's count functionality.
StartingPos is handled as in AHK v2. (I.e. AHK v2: -1 is the last character, AHK v1: 0 is the last character.)

## Error Handling
In AHK v2, InStr (currently) does not throw when given a non-numeric or 0 for StartingPos.
This function does not throw either. Although I'd be happy if throw support were added.