### PR TITLE
v1: StrJoin()

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8661,6 +8661,12 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 0;
 		max_params = 3;
 	}
+	else if (!_tcsicmp(func_name, _T("StrJoin")))
+	{
+		bif = BIF_StrJoin;
+		min_params = 2;
+		max_params = 10000; // An arbitrarily high limit that will never realistically be reached.
+	}
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3356,6 +3356,7 @@ BIF_DECL(BIF_Trim); // L31: Also handles LTrim and RTrim.
 
 BIF_DECL(BIF_Hotstring);
 BIF_DECL(BIF_InputHook);
+BIF_DECL(BIF_StrJoin);
 
 
 BIF_DECL(BIF_IsObject);


### PR DESCRIPTION
`NewStr := StrJoin(PadStrings, String1 [, String2, ..., StringN])`

Code based on StrSplit.

## Examples
`MsgBox, % StrJoin(",", "a", "b", "c", "d", "e", "f") ;a,b,c,d,e,f`

`oArray := ["a", "b", "c", "d", "e", "f"]`
`MsgBox, % StrJoin([":", ","], oArray*) ;a:b,c:d,e:f`

## Error Handling
This function treats missing array values as blank strings.
Although I'd be fine with treating this as an error.
[EDIT:] It appears that when an array is used for param 1, any keys without a value are treated as though they don't exist. And that if the array is empty, the function silently fails.