### PR TITLE
v1: StrRept()

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8661,6 +8661,12 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 0;
 		max_params = 3;
 	}
+	else if (!_tcsicmp(func_name, _T("StrRept")))
+	{
+		bif = BIF_StrRept;
+		min_params = 2;
+		max_params = 2;
+	}
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3356,6 +3356,7 @@ BIF_DECL(BIF_Trim); // L31: Also handles LTrim and RTrim.
 
 BIF_DECL(BIF_Hotstring);
 BIF_DECL(BIF_InputHook);
+BIF_DECL(BIF_StrRept);
 
 
 BIF_DECL(BIF_IsObject);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -18790,6 +18790,36 @@ BIF_DECL(BIF_Exception)
 
 
 
+BIF_DECL(BIF_StrRept)
+{
+	aResultToken.symbol = SYM_STRING;
+	int len = (int)_tcslen(ParamIndexToString(0));
+	int count = (int)ParamIndexToInt64(1);
+	if (len == 0 || count < 1)
+	{
+		aResultToken.marker = _T("");
+		return;
+	}
+
+	LPTSTR output = tmalloc(len*count+1); // +1 for zero terminator.
+	tmemcpy(output, ParamIndexToString(0), len);
+
+	int len_temp = len;
+	while (len_temp*2 <= len*count)
+	{
+		tmemcpy(output+len_temp, output, len_temp);
+		len_temp *= 2;
+	}
+
+	int count_trail = count - (len_temp/len);
+	tmemcpy(output+len_temp, output, len*count_trail);
+
+	*(output+len*count) = '\0';
+	aResultToken.marker = output;
+}
+
+
+
 ////////////////////////////////////////////////////////
 // HELPER FUNCTIONS FOR TOKENS AND BUILT-IN FUNCTIONS //
 ////////////////////////////////////////////////////////


### PR DESCRIPTION
`NewStr := StrRept(String, Count)`

Repeat a string n times.
Code appends text via repeated doubling, then appends the remainder.

## Examples
`MsgBox, % StrJoin("abc_", 4) ;abc_abc_abc_abc_`

## Alternative approach
A slightly less fast, but built-in approach:
The custom FastStrRepeat function, [here](https://autohotkey.com/boards/viewtopic.php?f=5&t=71658), uses wcsncat.
However, the ANSI equivalent, strncat, appears to have a bug.
So I'd suggest wcsncat_s and strncat_s.