### PR TITLE
v1: Range()

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8661,6 +8661,12 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 0;
 		max_params = 3;
 	}
+	else if (!_tcsicmp(func_name, _T("Range")))
+	{
+		bif = BIF_Range;
+		min_params = 1;
+		max_params = 3;
+	}
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3356,6 +3356,7 @@ BIF_DECL(BIF_Trim); // L31: Also handles LTrim and RTrim.
 
 BIF_DECL(BIF_Hotstring);
 BIF_DECL(BIF_InputHook);
+BIF_DECL(BIF_Range);
 
 
 BIF_DECL(BIF_IsObject);


### PR DESCRIPTION
```
Range(end)
Range(start, end)
Range(start, end, stepsize)
```

The function creates an array containing a sequence of numbers.
The start/end parameters determine the endpoints, and are inclusive.
The stepsize parameter determines the size of the gap between items.
If any of the parameters is a float, the array will contain all floats. Otherwise, the array will contain all integers.

## Examples
```
Range(5) ;[1, 2, 3, 4, 5]

Range(1, 5) ;[1, 2, 3, 4, 5]
Range(1, 5, 2) ;[1, 3, 5]

Range(5, 1) ;[5, 4, 3, 2, 1]
Range(5, 1, 2) ;[5, 3, 1] [sign of step is ignored]

Range(2, -2, 1) ;[2, 1, 0, -1, -2] [sign of step is ignored]
Range(1, -1, 0.5) ;[1.0, 0.5, 0.0, -0.5, -1.0] [sign of step is ignored]

MsgBox, % Range(-10, 10, 0.5).Length() ;41

for key, value in Range(-10, 10, 0.5)
	MsgBox, % key " " value

for _, year in Range(2000, 2020)
	MsgBox, % year

for _, num in Range(6, 9)
	MsgBox, % num
```

## More restrictive?
To add clarity / avoid bugs:
Potentially Range(end) could be removed.
Potentially stepsize could become step, i.e. the sign of step would have to match the direction of start to end.
I would be fine with such changes.

## Silently failing?
At around 200,000 items, it appeared that AHK was silently failing. Perhaps a memory allocation issue?
Any amendments to this or any other of my pull requests, to prevent silent fails, would be welcome.

## Optimisation?
IIRC people have suggested that if `for` and `Range` were seen together, AHK could generate numbers on-the-fly, rather than create an array first. I would be fine with that, however, I am not asking for this.