### PR TITLE
Adding handling of ACT_CASE to warn unreachable code.

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8209,6 +8209,7 @@ Line *Script::PreparseCommands(Line *aStartingLine)
 			{
 			case ACT_EXIT: // v2: It's from an automatic AddLine(), so should be excluded.
 			case ACT_BLOCK_END: // There's nothing following this line in the same block.
+			case ACT_CASE:
 				continue;
 			}
 			if (IsLabelTarget(next_line))


### PR DESCRIPTION
__Reason__, avoid warning when a _switch-case_ is preceded by a _return_ or similar.

Issue example,
```autohotkey
switch 2 {
	case 1: return
	case 2: msgbox ; a114: warn unreachable. This branch: no warning
}
```