### PR TITLE
Removing Gosub

### DIFF
--- a/source/Debugger.h
+++ b/source/Debugger.h
@@ -278,7 +278,7 @@ public:
 	}
 
 	
-	// Stack - keeps track of threads, function calls and gosubs.
+	// Stack - keeps track of threads and function calls.
 	DbgStack mStack;
 
 private:

--- a/source/defines.h
+++ b/source/defines.h
@@ -536,8 +536,8 @@ enum enum_act {
 , ACT_LOOP, ACT_LOOP_FILE, ACT_LOOP_REG, ACT_LOOP_READ, ACT_LOOP_PARSE
 , ACT_FOR, ACT_WHILE, ACT_UNTIL // Keep LOOP, FOR, WHILE and UNTIL together and in this order for range checks in various places.
 , ACT_BREAK, ACT_CONTINUE
-, ACT_GOTO, ACT_GOSUB
-, ACT_FIRST_JUMP = ACT_BREAK, ACT_LAST_JUMP = ACT_GOSUB // Actions which accept a label name.
+, ACT_GOTO
+, ACT_FIRST_JUMP = ACT_BREAK, ACT_LAST_JUMP = ACT_GOTO // Actions which accept a label name.
 , ACT_RETURN
 , ACT_TRY, ACT_CATCH, ACT_FINALLY, ACT_THROW // Keep TRY, CATCH and FINALLY together and in this order for range checks.
 , ACT_SWITCH, ACT_CASE
@@ -840,7 +840,6 @@ struct global_struct
 	int MouseDelay;     // negative values may be used as special flags.
 	int MouseDelayPlay; //
 	UserFunc *CurrentFunc; // v1.0.46.16: The function whose body is currently being processed at load-time, or being run at runtime (if any).
-	UserFunc *CurrentFuncGosub; // v1.0.48.02: Allows A_ThisFunc to work even when a function Gosubs an external subroutine.
 	Label *CurrentLabel; // The label that is currently awaiting its matching "return" (if any).
 	ScriptTimer *CurrentTimer; // The timer that launched this thread (if any).
 	HWND hWndLastUsed;  // In many cases, it's better to use GetValidLastUsedWindow() when referring to this.
@@ -892,7 +891,6 @@ inline void global_clear_state(global_struct &g)
 // future threads if it occurs in the auto-execute section, but A_ThisFunc shouldn't).
 {
 	g.CurrentFunc = NULL;
-	g.CurrentFuncGosub = NULL;
 	g.CurrentLabel = NULL;
 	g.hWndLastUsed = NULL;
 	//g.hWndToRestore = NULL;

--- a/source/globaldata.cpp
+++ b/source/globaldata.cpp
@@ -267,8 +267,7 @@ Action g_act[] =
 	, {_T("While"), 1, 1, false, {1, 0}} // LoopCondition.  v1.0.48: Lexikos: Added g_act entry for ACT_WHILE.
 	, {_T("Until"), 1, 1, false, {1, 0}} // Until expression (follows a Loop)
 	, {_T("Break"), 0, 1, false, NULL}, {_T("Continue"), 0, 1, false, NULL}
-	, {_T("Goto"), 1, 1, false, NULL}
-	, {_T("Gosub"), 1, 1, false, NULL}   // Label (or dereference that resolves to a label).
+	, {_T("Goto"), 1, 1, false, NULL}	// Label (or dereference that resolves to a label).
 	, {_T("Return"), 0, 1, false, {1, 0}}
 	, {_T("Try"), 0, 0, false, NULL}
 	, {_T("Catch"), 0, 1, false, NULL} // fincs: seems best to allow catch without a parameter

--- a/source/script.h
+++ b/source/script.h
@@ -1713,7 +1713,7 @@ public:
 
 	ResultType Execute(ResultToken *aResultToken)
 	{
-		// Launch the function similar to Gosub (i.e. not as a new quasi-thread):
+		// Launch the function (not as a new quasi-thread):
 		// The performance gain of conditionally passing NULL in place of result (when this is the
 		// outermost function call of a line consisting only of function calls, namely ACT_EXPRESSION)
 		// would not be significant because the Return command's expression (arg1) must still be evaluated
@@ -1726,8 +1726,7 @@ public:
 		// 2) The fact that any return encountered after the Goto cannot provide a return value for
 		//    the function because load-time validation checks for this (it's preferable not to
 		//    give up this check, since it is an informative error message and might also help catch
-		//    bugs in the script).  Gosub does not suffer from this because the return that brings it
-		//    back into the function body belongs to the Gosub and not the function itself.
+		//    bugs in the script).
 		// 3) More difficult to maintain because we have handle jump_to_line the same way ExecUntil() does,
 		//    checking aResult the same way it does, then checking jump_to_line the same way it does, etc.
 		// Fix for v1.0.31.05: g->mLoopFile and the other g_script members that follow it are

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -9024,7 +9024,6 @@ Label *Line::GetJumpTarget(bool aIsDereferenced)
 	if (!aIsDereferenced)
 		mRelatedLine = (Line *)label; // The script loader has ensured that label->mJumpToLine isn't NULL.
 	// else don't update it, because that would permanently resolve the jump target, and we want it to stay dynamic.
-	// Seems best to do this even for GOSUBs even though it's a bit weird:
 	return IsJumpValid(*label);
 	// Any error msg was already displayed by the above call.
 }
@@ -9036,7 +9035,7 @@ Label *Line::IsJumpValid(Label &aTargetLabel, bool aSilent)
 {
 	// aTargetLabel can be NULL if this Goto's target is the physical end of the script.
 	// And such a destination is always valid, regardless of where aOrigin is.
-	// UPDATE: It's no longer possible for the destination of a Goto or Gosub to be
+	// UPDATE: It's no longer possible for the destination of a Goto to be
 	// NULL because the script loader has ensured that the end of the script always has
 	// an extra ACT_EXIT that serves as an anchor for any final labels in the script:
 	//if (aTargetLabel == NULL)
@@ -9045,11 +9044,11 @@ Label *Line::IsJumpValid(Label &aTargetLabel, bool aSilent)
 
 	Line *parent_line_of_label_line;
 	if (   !(parent_line_of_label_line = aTargetLabel.mJumpToLine->mParentLine)   )
-		// A Goto/Gosub can always jump to a point anywhere in the outermost layer
+		// A Goto can always jump to a point anywhere in the outermost layer
 		// (i.e. outside all blocks) without restriction:
 		return &aTargetLabel; // Indicate success.
 
-	// So now we know this Goto/Gosub is attempting to jump into a block somewhere.  Is that
+	// So now we know this Goto is attempting to jump into a block somewhere.  Is that
 	// block a legal place to jump?:
 
 	for (Line *ancestor = mParentLine; ancestor != NULL; ancestor = ancestor->mParentLine)
@@ -9061,7 +9060,7 @@ Label *Line::IsJumpValid(Label &aTargetLabel, bool aSilent)
 	// is at a more shallow level but is in some block totally unrelated to it!
 	// Returns FAIL by default, which is what we want because that value is zero:
 	if (!aSilent)
-		LineError(_T("A Goto/Gosub must not jump into a block that doesn't enclose it."));
+		LineError(_T("A Goto must not jump into a block that doesn't enclose it."));
 	return NULL;
 }
 
@@ -10251,8 +10250,6 @@ BIV_DECL_R(BIV_ThisFunc)
 	LPCTSTR name;
 	if (g->CurrentFunc)
 		name = g->CurrentFunc->mName;
-	else if (g->CurrentFuncGosub) // v1.0.48.02: For flexibility and backward compatibility, support A_ThisFunc even when a function Gosubs an external subroutine.
-		name = g->CurrentFuncGosub->mName;
 	else
 		name = _T("");
 	_f_return_p(const_cast<LPTSTR>(name));

--- a/source/script_menu.cpp
+++ b/source/script_menu.cpp
@@ -1262,8 +1262,8 @@ ResultType UserMenu::Display(bool aForceToForeground, int aX, int aY)
 	// The root problem here is that it would not be intuitive to allow the command after
 	// "Menu, MyMenu, Show" should to run before the menu item's subroutine launches as a new thread.
 	// 
-	// You could argue that selecting a menu item should immediately Gosub the selected menu item's
-	// subroutine rather than queuing it up as a new thread.  However, even if that is a better method,
+	// You could argue that selecting a menu item should immediately trigger the selected menu item's
+	// callback rather than queuing it up as a new thread.  However, even if that is a better method,
 	// it would break existing scripts that rely on new-thread behavior (such as fresh default for
 	// SetKeyDelay).
 	//


### PR DESCRIPTION
__Reason__, `gosub` has no benefits over using functions. Imo, `gosub` has been completely unnecessary since the addition of nested functions. The last imaginable excuse for its existence might have been to _call_ hotkey labels, which now isn't possible.


Also updated comments and removed `global_struct::CurrentFuncGosub`.

Cheers.

