### PR TITLE
Disabling __try __except in MainExecuteScript for debug builds.

### DIFF
--- a/source/AutoHotkey.cpp
+++ b/source/AutoHotkey.cpp
@@ -281,7 +281,10 @@ int WINAPI _tWinMain (HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmd
 
 int MainExecuteScript()
 {
+	
+#ifndef _DEBUG
 	__try
+#endif
 	{
 		// Run the auto-execute part at the top of the script (this call might never return):
 		if (!g_script.AutoExecSection()) // Can't run script at all. Due to rarity, just abort.
@@ -296,6 +299,7 @@ int MainExecuteScript()
 		// return (and we never want this to return):
 		MsgSleep(SLEEP_INTERVAL, WAIT_FOR_MESSAGES);
 	}
+#ifndef _DEBUG
 	__except (EXCEPTION_EXECUTE_HANDLER)
 	{
 		LPCTSTR msg;
@@ -314,5 +318,6 @@ int MainExecuteScript()
 		g_script.CriticalError(buf);
 		return ecode;
 	}
+#endif 
 	return 0; // Never executed; avoids compiler warning.
 }


### PR DESCRIPTION
__Reason__, when debugging in VS the message box in the `__except` block is less helpful than VS' exception info.

For example, run this in db,

```c++
BIF_DECL(BIF_Abs)
{
	auto x = aParam[111111111];
```
VS will point to the above line if we remove the `__try` block, else you get the access violation message box.