### PR TITLE
Adding IsUninitializedNormalVar() check in Array::FromEnumerable

### DIFF
--- a/source/script_object.cpp
+++ b/source/script_object.cpp
@@ -366,7 +366,10 @@ Array *Array::FromEnumerable(ExprTokenType &aEnumerable)
 		if (result != CONDITION_TRUE)
 			break;
 		ExprTokenType value;
-		var.ToTokenSkipAddRef(value);
+		if (var.IsUninitializedNormalVar())
+			value.symbol = SYM_MISSING;
+		else
+			var.ToTokenSkipAddRef(value);
 		vargs->Append(value);
 	}
 	var.Free();


### PR DESCRIPTION
__Reason__, to allow `not_an_array*` to _omit_ the output variable for consistency with `aArray*`.

Example,
```autohotkey
f(a:=1,b:=2)=>msgbox(a b)
i:=1
f ((byref o)=>i==1?i--:!i?(o:=3,--i):0)*
``` 
which currently shows a warning for an unnamed global variable, and passes a blank string for parameter `a`. In this branch it yields the same result as `f [,3]*`
