### PR TITLE
v1: Added Range() and Range class.

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8661,6 +8661,12 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 0;
 		max_params = 3;
 	}
+	else if (!_tcsicmp(func_name, _T("Range")))
+	{
+		bif = BIF_Range;
+		min_params = 1;
+		max_params = 3;
+	}
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3356,6 +3356,7 @@ BIF_DECL(BIF_Trim); // L31: Also handles LTrim and RTrim.
 
 BIF_DECL(BIF_Hotstring);
 BIF_DECL(BIF_InputHook);
+BIF_DECL(BIF_Range);
 
 
 BIF_DECL(BIF_IsObject);

--- a/source/script_object.h
+++ b/source/script_object.h
@@ -445,3 +445,29 @@ public:
 	void DebugWriteProperty(IDebugProperties *, int aPage, int aPageSize, int aDepth);
 #endif
 };
+
+
+//
+// RangeObject
+//
+
+class RangeObject : public ObjectBase
+{
+	bool mHasFloats;
+	__int64 miStart, miEnd, miStep;
+	double mfStart, mfEnd, mfStep;
+	__int64 mCount, mIndex;
+
+	RangeObject() : mHasFloats(false), miStart(0), miEnd(0), miStep(0), mfStart(0), mfEnd(0), mfStep(0), mCount(0), mIndex(0) {}
+
+	~RangeObject()
+	{
+	}
+	
+public:
+	static RangeObject *Create(__int64 aStart, __int64 aEnd, __int64 aStep);
+	static RangeObject *Create(double aStart, double aEnd, double aStep);
+
+	ResultType STDMETHODCALLTYPE Invoke(ExprTokenType &aResultToken, ExprTokenType &aThisToken, int aFlags, ExprTokenType *aParam[], int aParamCount);
+	IObject_Type_Impl("Range")
+};


### PR DESCRIPTION
Replaces #193.

## Documentation

```
Range(End) [with Start:=1, Step:=1]
Range(Start, End, Step:=1)
```

The function creates a Range object, which generates numeric values on-the-fly.

Start/End determine the endpoints, and are inclusive.
Step determines the size and direction of the gap between items.
Step cannot be 0.
The sign of Step must be consistent with Start and End.
If any of the parameters is a float, the object will return floats. Otherwise, the object will return integers.

(Start and End can be equal.)
(When Start and End are equal, Step can be any number except 0.)

Properties (read-only):
Start
End
Step
Length
Count (equivalent to Length)

Methods:
ToArray()

Methods (AHK v1 only):
Length()
Count() (equivalent to Length())

Keys (read-only):
The nth value can be obtained via `obj[n]` syntax, where n is between 1 and Count, or where n is between -Count and -1 (to retrieve values from the end).

## Implementation

The code can be significantly reorganised if desired.
(I would rather the code be consistent with other object classes, i.e. 'exactly in the Lexikos style'.)
(Major or minor changes, such as using 0 or 1-based indexes internally, all are welcome.)

The 1-parameter `Range(End)` mode can be removed if desired.

## Length v. Count

The Range object is Array-like, so Length makes sense.
Since there will never be gaps in a Range object, Count also makes sense.

It may be good to have Count for ranges *and arrays* in AHK v2.
Thus, arrays/ranges/maps would all have a Count property.
And, arrays/ranges would both have a Length property.

## Examples
```
Range(5).ToArray() ;[1, 2, 3, 4, 5]

Range(1, 5).ToArray() ;[1, 2, 3, 4, 5]
Range(1, 5, 2).ToArray() ;[1, 3, 5]

Range(5, 1, -1).ToArray() ;[5, 4, 3, 2, 1]
Range(5, 1, -2).ToArray() ;[5, 3, 1]

Range(2, -2, -1).ToArray() ;[2, 1, 0, -1, -2]
Range(1, -1, -0.5).ToArray() ;[1.0, 0.5, 0.0, -0.5, -1.0]

MsgBox, % Range(-10, 10, 0.5).Count() ;41 [AHK v1 only]
MsgBox, % Range(-10, 10, 0.5).Count ;41

for key, value in Range(-10, 10, 0.5)
	MsgBox, % key " " value

for _, year in Range(2000, 2020)
	MsgBox, % year

for _, num in Range(6, 9)
	MsgBox, % num

for _, num in Range(0, 255)
	MsgBox, % num

oArray := Range(1, 100).ToArray()

;at the time of writing, AHK does not have this or similar functionality built-in:
;oArray := Range(1, 100).ToArray().Shuffled()
;oArray.Shuffle()

Loop 10
	MsgBox, % oArray.Pop()
```