### PR TITLE
Unpredictable behavior on associative array enumeration

### DIFF
--- a/source/script_com.cpp
+++ b/source/script_com.cpp
@@ -1442,7 +1442,7 @@ HRESULT ComArrayEnum::Begin(ComObject *aArrayObject, ComArrayEnum *&aEnum)
 	{
 		VARTYPE arrayType = aArrayObject->mVarType & VT_TYPEMASK;
 		UINT elemSize = SafeArrayGetElemsize(psa);
-		arrayEnd = arrayData + (ubound - lbound) * elemSize;
+		arrayEnd = arrayData + (ubound - lbound) * (long)elemSize; // Must cast to signed long for correct result when array is empty (ubound - lbound == -1).
 		if (aEnum = new ComArrayEnum(aArrayObject, arrayData, arrayEnd, elemSize, arrayType))
 		{
 			aArrayObject->AddRef(); // Keep obj alive until enumeration completes.

--- a/source/script_gui.cpp
+++ b/source/script_gui.cpp
@@ -2716,7 +2716,9 @@ ResultType GuiType::AddControl(GuiControls aControlType, LPTSTR aOptions, LPTSTR
 				extra_width = 2 * GetSystemMetrics(SM_CXBORDER);
 				extra_height = 2 * GetSystemMetrics(SM_CYBORDER);
 			}
-			if (opt.width != COORD_UNSPECIFIED) // Since a width was given, auto-expand the height via word-wrapping.
+			if (   opt.width != COORD_UNSPECIFIED // Since a width was given, auto-expand the height via word-wrapping,
+				&& ( !(aControlType == GUI_CONTROL_BUTTON || aControlType == GUI_CONTROL_CHECKBOX || aControlType == GUI_CONTROL_RADIO)
+					|| (style & BS_MULTILINE) )   ) // except when -Wrap is used on a Button, Checkbox or Radio.
 				draw_format |= DT_WORDBREAK;
 
 			RECT draw_rect;


### PR DESCRIPTION
With following code
```AutoHotkey
vKeys := [{WEP: "vk52", Func: "CapControl"}
	, {SYS: "vk57", Func: "CapControl"}
	, {ENG: "vk41", Func: "CapControl"}
	, {HL: "MButton", Func: "HeadLook"}
	, {FA: "vkA5", Func: "HeadLook"}
	, {AX: "vk5D", Func: "AbsXmode"}
	, {RWin: "vk5C", Func: "RWBlock"}]

For n, vkObj in vKeys {
	For k, v in vkObj {
		Switch (A_Index) {
		Case 2:
			vKeyName := k, vKeyValue := v
		Case 1:
			vFuncName := k, vFuncValue := v
		}
	}
	OutputDebug, % "vKey: [" vKeyName "]`t" vKeyValue "    `tvFunc: [" vFuncName "]`t" vFuncValue
}
```
I got this result
```
vKey: [WEP]	vk52    	vFunc: [Func]	CapControl
vKey: [SYS]	vk57    	vFunc: [Func]	CapControl
vKey: [Func]	CapControl    	vFunc: [ENG]	vk41
vKey: [HL]	MButton    	vFunc: [Func]	HeadLook
vKey: [Func]	HeadLook    	vFunc: [FA]	vkA5
vKey: [Func]	AbsXmode    	vFunc: [AX]	vk5D
vKey: [RWin]	vk5C    	vFunc: [Func]	RWBlock
```
Of course I can change Switch firing by the "Func" substring
```AutoHotkey
For n, vkObj in vKeys {
	For k, v in vkObj {
		Switch (k) {
		Default:
			vKeyName := k, vKeyValue := v
		Case "Func":
			vFuncName := k, vFuncValue := v
		}
	}
	OutputDebug, % "vKey: [" vKeyName "]`t" vKeyValue "    `tvFunc: [" vFuncName "]`t" vFuncValue
}
```
and get correct result
```
vKey: [WEP]	vk52    	vFunc: [Func]	CapControl
vKey: [SYS]	vk57    	vFunc: [Func]	CapControl
vKey: [ENG]	vk41    	vFunc: [Func]	CapControl
vKey: [HL]	MButton    	vFunc: [Func]	HeadLook
vKey: [FA]	vkA5    	vFunc: [Func]	HeadLook
vKey: [AX]	vk5D    	vFunc: [Func]	AbsXmode
vKey: [RWin]	vk5C    	vFunc: [Func]	RWBlock
```
But at first time, such unpredictable behavior is confusing for a while (documentation does not say about such unpredictable behavior when enumerating), and I think it's not good.