### PR TITLE
v2: Added StrCount().

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -313,6 +313,7 @@ FuncEntry g_BIF[] =
 	BIF1(StatusBarGetText, 0, 5),
 	BIF1(StatusBarWait, 0, 8),
 	BIF1(StrCompare, 2, 3),
+	BIF1(StrCount, 2, 4),
 	BIFn(StrGet, 1, 3, BIF_StrGetPut),
 	BIF1(StrLen, 1, 1),
 	BIFn(StrLower, 1, 2, BIF_StrCase),

--- a/source/script.h
+++ b/source/script.h
@@ -3266,6 +3266,7 @@ BIF_DECL(BIF_String);
 BIF_DECL(BIF_StrLen);
 BIF_DECL(BIF_SubStr);
 BIF_DECL(BIF_InStr);
+BIF_DECL(BIF_StrCount);
 BIF_DECL(BIF_StrCase);
 BIF_DECL(BIF_StrSplit);
 BIF_DECL(BIF_StrReplace);


### PR DESCRIPTION
Replaces #190. This PR is for v2, whereas the previous PR was for v1.

`Count := StrCount(Haystack, Needle [, CaseSensitive := false, StartingPos := 1])`

Parameters match InStr.

These should be equivalent:
`Count := StrCount(Haystack, Needle)`
`StrReplace(Haystack, Needle,,, &Count)`

As should these:
`Count := StrCount(Haystack, Needle, CaseSense)`
`StrReplace(Haystack, Needle,, CaseSense, &Count)`