### PR TITLE
v1: Added StrSplitLen().

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8661,6 +8661,12 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 0;
 		max_params = 3;
 	}
+	else if (!_tcsicmp(func_name, _T("StrSplitLen")))
+	{
+		bif = BIF_StrSplitLen;
+		min_params = 2;
+		max_params = 2;
+	}
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3356,6 +3356,7 @@ BIF_DECL(BIF_Trim); // L31: Also handles LTrim and RTrim.
 
 BIF_DECL(BIF_Hotstring);
 BIF_DECL(BIF_InputHook);
+BIF_DECL(BIF_StrSplitLen);
 
 
 BIF_DECL(BIF_IsObject);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -18791,6 +18791,40 @@ BIF_DECL(BIF_Exception)
 
 
 
+BIF_DECL(BIF_StrSplitLen)
+{
+	LPTSTR aInputString = TokenToString(*aParam[0], aResultToken.buf);
+	int slice_len = (int)TokenToInt64(*aParam[1]);
+	if (slice_len < 1)
+		_f_throw(ERR_PARAM2_INVALID);
+
+	int count = _tcslen(aInputString) / slice_len;
+	Object *output_array = Object::Create();
+
+	for (int i = 0; i < count; ++i)
+	{
+		if (!output_array->Append(aInputString, slice_len))
+			goto outofmem;
+		aInputString += slice_len;
+	}
+	if (*aInputString) // If not null, one item remains.
+	{
+		if (!output_array->Append(aInputString, _tcslen(aInputString)))
+			goto outofmem;
+	}
+	
+	aResultToken.symbol = SYM_OBJECT;
+	aResultToken.object = output_array;
+	return;
+
+outofmem:
+	output_array->Release(); // Since we're not returning it.
+	aResultToken.symbol = SYM_STRING;
+	aResultToken.marker = _T("");
+}
+
+
+
 ////////////////////////////////////////////////////////
 // HELPER FUNCTIONS FOR TOKENS AND BUILT-IN FUNCTIONS //
 ////////////////////////////////////////////////////////


### PR DESCRIPTION
`Array := StrSplitLen(String, Length)`
Separates a string into an array of substrings based on the Length parameter.
The final substring may be shorter than Length.

The function name, StrSplitLen, can be changed if desired.
The handling for blank strings, can be changed if desired. As with StrSplit, if String is blank, an empty array is created.