### PR TITLE
v1: Added Noop().

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8661,6 +8661,12 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 0;
 		max_params = 3;
 	}
+	else if (!_tcsicmp(func_name, _T("Noop")))
+	{
+		bif = BIF_Noop;
+		min_params = 0;
+		max_params = 10000; // An arbitrarily high limit that will never realistically be reached.
+	}
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3356,6 +3356,7 @@ BIF_DECL(BIF_Trim); // L31: Also handles LTrim and RTrim.
 
 BIF_DECL(BIF_Hotstring);
 BIF_DECL(BIF_InputHook);
+BIF_DECL(BIF_Noop);
 
 
 BIF_DECL(BIF_IsObject);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -18791,6 +18791,14 @@ BIF_DECL(BIF_Exception)
 
 
 
+BIF_DECL(BIF_Noop)
+{
+	aResultToken.symbol = SYM_STRING;
+	aResultToken.marker = _T("");
+}
+
+
+
 ////////////////////////////////////////////////////////
 // HELPER FUNCTIONS FOR TOKENS AND BUILT-IN FUNCTIONS //
 ////////////////////////////////////////////////////////


### PR DESCRIPTION
`Noop()`
It can take an unlimited number of arguments.
It returns a blank string.

I would be OK with the function name NoOp instead.
NoOp is logical, but Noop is far more elegant, and much easier to type.

NOP/Nop is more appropriate for 3-letter instruction sets, and is less expressive.
Also, 'noop' is only generally in the English word 'snoop', whereas searching for 'nop' can bring up a lot of false positives.

Some code examples as arguments for a Noop function:
```
;==============================

;note: requires a Noop *function*:

;one-liners:

(cond) ? MyFunc() : Noop()
(cond) ? MyFunc() : 0 ;confusing as no assignments take place
(cond) ? MyFunc() : "" ;confusing as no assignments take place
(cond) && MyFunc() ;unclear

;for reference:

(cond) ? MyFunc() ;throws in AHK v2, allowed in AHK v1, a 'binary ternary statement'

;==============================

;if/else ladders:

if (cond)
	Noop()
if (cond)
{ ;longer (2 lines)
}
if (cond)
	(0) ;unusual
if (cond)
	Sleep 0 ;side effects

;==============================

;note: requires a Noop *function*:

;a function that can be turned on or off:

oFunc := (cond) ? Func("MyFunc") : Func("Noop")
%oFunc%(args*)

;==============================

;if/else ladders:
;don't reorder the ladder simply to avoid a Noop(), use the natural order:

;a growing number of conditions: more expressive, easier to maintain:
;i.e. here are the conditions we know about, else throw:

if (cond1)
	Func1()
else if (cond2)
	Func2()
else if (cond3)
	Noop()
else
	throw Exception("unhandled", -1)

;a growing number of conditions: less clarity just to avoid a Noop() line:
;and if we later decide cond3 should have consequences, we have to unravel the code a bit:

if (cond1)
	Func1()
else if (cond2)
	Func2()
else if !(cond3)
	throw Exception("unhandled", -1)

;==============================

;if/else ladders:
;the more common the case, the earlier it should be dealt with, sometimes that's a Noop():

if (cond1)
	Noop()
else if (cond2)
	Action2()
else if (cond3)
	Action3()

if (cond1)
	Action1()
else if (cond2)
	Noop()
else if (cond3)
	Action3()

;==============================

;if/else ladders:
;avoiding Noop() may lead to unnecessarily complicated if-conditions:
;just because you can avoid a Noop(), doesn't mean you should:
;always avoid unnecessary causes of bugs:
;increase readability/maintainability:
;e.g. inverting the operators could lead to bugs:

if (simple)
	Noop()
else
	Action()

if (RelativelySimple)
	Noop()
else
	Action()

if (COMPLICATEDCOMPLICATEDCOMPLICATED)
	Action()

;==============================

;3 alternatives:

if LONGLONGLONGLONG
|| LONGLONGLONGLONG
|| LONGLONGLONGLONG
	Noop()
else if (cond)
	Action()
else
	MsgBox("unhandled")

if (cond)
	Action()
else if !(LONGLONGLONGLONG
|| LONGLONGLONGLONG
|| LONGLONGLONGLONG)
	MsgBox("unhandled")

if (cond)
	Action()
else if !LONGLONGLONGLONG
&& !LONGLONGLONGLONG
&& !LONGLONGLONGLONG
	MsgBox("unhandled")

;==============================

;with/without Noop:

	;with Noop:
	if (vLen < 1)
		Noop()
	else if InStr(vPosInfo, "S") ;at start of selection
		SendInput("{Del " vLen "}")
	else if InStr(vPosInfo, "E") ;at end of selection
		SendInput("{Del}{Backspace " (vLen-1) "}")

	;avoiding Noop:
	if (vLen >= 1)
	{
		if InStr(vPosInfo, "S") ;at start of selection
			SendInput("{Del " vLen "}")
		else if InStr(vPosInfo, "E") ;at end of selection
			SendInput("{Del}{Backspace " (vLen-1) "}")
	}

;in functions, bailing out early is common
;using Noop in if/else ladders is consistent with this

;often, bailing out early, is a better strategy than deeper and deeper nesting

;==============================

;at some point you may want to add an additional layer of complexity
;so it would have been better if you'd already kept any existing complexity to a minimum

;==============================
```
Sometimes we are translating from other languages, any noops must be maintained in some form, or else, the code must be rearranged.

Note: a 'noop' control flow statement, couldn't be used in a ternary statement.