### PR TITLE
v1: Added HexGet/HexPut/Base64Get/Base64Put functions.

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8661,6 +8661,18 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 0;
 		max_params = 3;
 	}
+	else if (!_tcsicmp(func_name, _T("Base64Get")) || !_tcsicmp(func_name, _T("HexGet")))
+	{
+		bif = BIF_HexBase64Get;
+		min_params = 1;
+		max_params = 2;
+	}
+	else if (!_tcsicmp(func_name, _T("Base64Put")) || !_tcsicmp(func_name, _T("HexPut")))
+	{
+		bif = BIF_HexBase64Put;
+		min_params = 1;
+		max_params = 3;
+	}
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3356,6 +3356,8 @@ BIF_DECL(BIF_Trim); // L31: Also handles LTrim and RTrim.
 
 BIF_DECL(BIF_Hotstring);
 BIF_DECL(BIF_InputHook);
+BIF_DECL(BIF_HexBase64Get);
+BIF_DECL(BIF_HexBase64Put);
 
 
 BIF_DECL(BIF_IsObject);


### PR DESCRIPTION
PR #212 uses Winapi functions, and uses an `#include`. It may give a smaller exe.
PR #281 uses faster in-house algorithms, and has test code examples.

## Documentation

```
String := HexGet(Source, Size)
String := Base64Get(Source, Size)

ByteCount := HexPut(String)
ByteCount := HexPut(String, Target [, Length])
ByteCount := Base64Put(String)
ByteCount := Base64Put(String, Target [, Length])
```

`Base64Get`/`HexGet`:
Reads binary data from a memory address, as a base64 string.
Reads binary data from a memory address, as a hex string.

`Base64Put`/`HexPut`:
Writes binary data to a memory address, based on a base64 string.
Writes binary data to a memory address, based on a hex string.
If no Target was given, it returns the required buffer size in bytes.
`HexPut` throws if an odd number of hex characters is specified.

## Rationale

Some uses:
- Storing image/icon or wave/MIDI resources.
- Storing machine code functions. Or code from dll files.
- Displaying/inspecting binary data.
- Performing operations on binary data.
- Handling big endian data/integers.
- Handling hex strings used with `RegRead`/`RegWrite`.

Avoids:
- Workarounds such as using hex, or arrays stuffed with integers, with `NumPut` and `Loop`, when `Base64Put` would be shorter.
- Multiple incompatible custom functions.
- `XXXGet` functions that are relatively short but don't support Windows XP or earlier.

## Implementation

- The function uses `#include "wincrypt.h"`, if desired, in-house algorithms could be used instead. E.g. #281.
- `HexGet` returns upper case. I find this more readable/elegant, but this could be changed if desired.