### PR TITLE
v1: Added StrEquals/StrContains/StrStarts/StrEnds functions.

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8661,6 +8661,15 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 0;
 		max_params = 3;
 	}
+	else if (!_tcsicmp(func_name, _T("StrEquals"))
+		|| !_tcsicmp(func_name, _T("StrContains"))
+		|| !_tcsicmp(func_name, _T("StrStarts"))
+		|| !_tcsicmp(func_name, _T("StrEnds")))
+	{
+		bif = BIF_StrMatch;
+		min_params = 2;
+		max_params = 3;
+	}
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3356,6 +3356,7 @@ BIF_DECL(BIF_Trim); // L31: Also handles LTrim and RTrim.
 
 BIF_DECL(BIF_Hotstring);
 BIF_DECL(BIF_InputHook);
+BIF_DECL(BIF_StrMatch);
 
 
 BIF_DECL(BIF_IsObject);

--- a/source/util.h
+++ b/source/util.h
@@ -621,6 +621,8 @@ inline LPTSTR HwndToString(HWND aHwnd, LPTSTR aBuf)
 // returns 0 on failure, but failure occurs only when parameter/flag is invalid, which should never happen in
 // this case.
 #define lstrcmpni(str1, len1, str2, len2) (CompareString(LOCALE_USER_DEFAULT, NORM_IGNORECASE, str1, (int)(len1), str2, (int)(len2)) - 2) // -2 for maintainability
+#define tcscmpn2(str1, str2, string_case_sense, len) ((string_case_sense) == SCS_INSENSITIVE ? _tcsnicmp(str1, str2, len) \
+	: ((string_case_sense) == SCS_INSENSITIVE_LOCALE ? lstrcmpni(str1, len, str2, len) : _tcsncmp(str1, str2, len)))
 
 
 // The following macros simplify and make consistent the calls to MultiByteToWideChar().


### PR DESCRIPTION
## Introduction

```
ItemNum := StrEquals(Haystack, NeedleStringOrArray [, CaseSense := false])
ItemNum := StrContains(Haystack, NeedleStringOrArray [, CaseSense := false])
ItemNum := StrStarts(Haystack, NeedleStringOrArray [, CaseSense := false])
ItemNum := StrEnds(Haystack, NeedleStringOrArray [, CaseSense := false])
```
If a needle array is passed, the function returns the 1-based index of the first needle that matches the haystack, else 0.
If a needle string is passed, the function returns 1 if the needle matches the haystack, else 0.

## Some benefits

Some benefits versus existing functionality:
- `StrEquals` is more intuitive than `StrCompare`, and can handle multiple needles.
- `StrContains` can handle multiple needles, unlike `InStr`.
- `StrContains` can accept a blank needle, unlike `InStr` (in AHK v2).
- A minor point. When checking if one string contains another, `StrContains` returns 1 or 0, whereas `InStr` would need `!!` to achieve the same effect.
- `StrStarts`/`StrEnds` are more expressive and readable, and less bug-prone, than `SubStr` comparisons.
-  `StrStarts`/`StrEnds` are more reusable than `SubStr` comparisons: simpler to write and copy-and-paste, as string length values aren't needed.
- Versus `RegExMatch`, no character escaping is necessary.
- The `in`/`contains` AHK v1 pseudo-operators use special handling for commas, which is unusual, breaking the principle of least astonishment, and could cause bugs.
- The `in`/`contains` AHK v1 pseudo-operators don't let you specify case sensitivity.
- (It's easy to recreate functions in other programming languages, not so much with operators.)

## Numeric comparison

Potentially, in future, `CaseSense` parameters could accept 'N' to enable a numeric comparison for `StrEquals`/`StrCompare`.

## Comma-separated lists

I also use 4 additional functions, with a 'CSL' suffix, that treat `NeedleString` as a comma-separated list. The 'CSL' and non-'CSL' functions both handle `NeedleArray` identically.

The 4 'CSL' functions use the following logic:
```
StrContainsCSL(ByRef vText, ByRef oNeedles, vCaseSen:=0)
{
	if IsObject(oNeedles)
		return StrContains(vText, oNeedles, vCaseSen)
	return StrContains(vText, StrSplit(oNeedles, ","), vCaseSen)
}
```

They are not implemented in this PR, but are sufficiently useful that they may be worth considering as built-in functions, possibly with a different suffix than 'CSL'.

(The top 11 functions that I use, are in order: `'RetX', SubStr, InStr, 'StrEqualsCSL', DllCall, StrReplace, StrLen, SendInput, Chr, MsgBox, 'GetSelectedText'`. I use `RetX` instead of `return` to record hotkey usage data, then exit the thread. My `OnHotkey` proposal would allow me to use `return` again.)

If desired, special handling for double commas could be used as with the `in`/`contains` pseudo-operators in AHK v1, or some other handling. I am neutral re. special handling.

## tcscmpn2 macro

This PR contains a `tcscmpn2` macro, to compare n characters of a string, for use with `StrStarts`.
It complements the `tcsstr2` and `tcscmp2` macros.

The order of the macro parameters can be changed if desired.

## What about 'if array in/contains string'?

My current view is to be against this.

Logically, the 7 key scenarios are:
```
'equals':
if str1 equals str2

'contains':
if str_long contains/starts/ends str_short
e.g. does 'abc' contain 'a'/'b'/'c'
e.g. does 'abc' start with 'a'/'b'/'c'

'within':
if str_short within/at-the-start-of/at-the-end-of str_long
e.g. is 'a' within 'abc'/'def'/'ghi'
e.g. is 'a' at the start of 'abc'/'def'/'ghi'
```

The 4 functions handle this:
`if haystack contains/starts/contains needle_list`
I suppose:
`if haystack_list contains/starts/contains needle`
Would be equivalent to this (the 'within' functionality mentioned above):
`if needle within/at-the-start-of/at-the-end-of haystack_list`

Personally, I have only wanted 'if array contains/starts/contains string' functionality about 3 times, using a loop with 'if string operator string' was fine.
Also, I would like to be able to easily find such instances in code, retrospectively, hence I would want separate function names. I implemented a custom function `StrWithin`, but only used it once.

## What about 'if array in/contains array'?

Again, my current view is to be against this.

Re. 'if arrayA contains arrayB', I suppose this would tell you that at least one item in arrayB is a substring of at least one item in arrayA. This is somewhat odd. And what return value to use?

If people wanted something like 'if arrayA in arrayB', some kind of `Intersection`/`Union` functions/methods might be better.

## What about in/contains operators?

I believe that `StrEquals` and `StrContains` are sufficient, but would not oppose `in`/`contains` operators.

A complicating factor is: would `in`, when checking 2 values for equality, treat all values as strings, or take type into account.
Perhaps `contains` would compare everything as strings.
Re. type, I proposed that `CaseSense` parameters accept 'N', for numeric comparisons.

Also, would the operators be case sensitive? Yes, I suppose, as with `switch`.

## Implementation

I would hope that these functions or similar be added at some stage. And am happy for a debate to take place on the details.
After a decade of toing and froing, this is what I myself use.

The functions aim to handle the `CaseSense` parameter similarly to AHK v2.
Although it may be preferable to replace this handling with a backport of AHK v2's `ParamIndexToCaseSense` macro.
That macro would need some modifying to work in AHK v1.

## Test code

```
;test code: StrEquals/StrContains/StrStarts/StrEnds (AHK v1)

MsgBox, % StrEquals("abc", "abc") ;1
MsgBox, % StrContains("abc", "b") ;1
MsgBox, % StrStarts("abc", "a") ;1
MsgBox, % StrEnds("abc", "c") ;1

MsgBox, % StrEquals("abc", "xxx") ;0
MsgBox, % StrContains("abc", "x") ;0
MsgBox, % StrStarts("abc", "x") ;0
MsgBox, % StrEnds("abc", "x") ;0

MsgBox, % StrEquals("abc", ["xxx", "abc"]) ;2
MsgBox, % StrContains("abc", ["x", "b"]) ;2
MsgBox, % StrStarts("abc", ["x", "a"]) ;2
MsgBox, % StrEnds("abc", ["x", "c"]) ;2

MsgBox, % StrEquals("abc", ["xxx", "xxx"]) ;0
MsgBox, % StrContains("abc", ["x", "x"]) ;0
MsgBox, % StrStarts("abc", ["x", "x"]) ;0
MsgBox, % StrEnds("abc", ["x", "x"]) ;0

/*
;custom functionality not in PR:

MsgBox, % StrEqualsCSL("abc", "xxx,abc") ;2
MsgBox, % StrContainsCSL("abc", "x,b") ;2
MsgBox, % StrStartsCSL("abc", "x,a") ;2
MsgBox, % StrEndsCSL("abc", "x,c") ;2

MsgBox, % StrEqualsCSL("abc", "xxx,xxx") ;0
MsgBox, % StrContainsCSL("abc", "x,x") ;0
MsgBox, % StrStartsCSL("abc", "x,x") ;0
MsgBox, % StrEndsCSL("abc", "x,x") ;0
*/
```