### PR TITLE
v1: Added Clamp().

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8661,6 +8661,12 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 0;
 		max_params = 3;
 	}
+	else if (!_tcsicmp(func_name, _T("Clamp")))
+	{
+		bif = BIF_Clamp;
+		min_params = 3;
+		max_params = 3;
+	}
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3356,6 +3356,7 @@ BIF_DECL(BIF_Trim); // L31: Also handles LTrim and RTrim.
 
 BIF_DECL(BIF_Hotstring);
 BIF_DECL(BIF_InputHook);
+BIF_DECL(BIF_Clamp);
 
 
 BIF_DECL(BIF_IsObject);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -18791,6 +18791,49 @@ BIF_DECL(BIF_Exception)
 
 
 
+BIF_DECL(BIF_Clamp)
+{
+	ExprTokenType param;
+	bool has_floats = false;
+	for (int i = 0; i < 3; ++i)
+	{
+		ParamIndexToNumber(i, param);
+		switch (param.symbol)
+		{
+			case SYM_INTEGER:
+				break;
+			case SYM_FLOAT:
+				has_floats = true;
+				break;
+			default:
+				aResultToken.symbol = SYM_STRING;
+				aResultToken.marker = _T("");
+				_f_throw(i == 0 ? ERR_PARAM1_INVALID : i == 1 ? ERR_PARAM2_INVALID : ERR_PARAM3_INVALID);
+				return;
+		}
+	}
+
+	if (has_floats)
+	{
+		double fNum = ParamIndexToDouble(0);
+		double fLow = ParamIndexToDouble(1);
+		double fHigh = ParamIndexToDouble(2);
+		aResultToken.symbol = SYM_FLOAT;
+		double fTemp = fNum < fHigh ? fNum : fHigh;
+		aResultToken.value_double = fLow > fTemp ? fLow : fTemp;
+	}
+	else
+	{
+		__int64 iNum = ParamIndexToInt64(0);
+		__int64 iLow = ParamIndexToInt64(1);
+		__int64 iHigh = ParamIndexToInt64(2);
+		aResultToken.symbol = SYM_INTEGER;
+		aResultToken.value_int64 = max(iLow, min(iNum, iHigh));
+	}
+}
+
+
+
 ////////////////////////////////////////////////////////
 // HELPER FUNCTIONS FOR TOKENS AND BUILT-IN FUNCTIONS //
 ////////////////////////////////////////////////////////


### PR DESCRIPTION
`Value := Clamp(Number, Low, High)`
Returns Number if it is between Low and High, else Low if Number is less than Low, else High if Number is greater than High.
If any of the parameters is a Float, the function returns a Float, else the function returns an Integer.

An example use is getting the system volume, increasing/decreasing it by a set amount, and then setting the system volume.

Examples:
```
MsgBox, % Clamp(-10, 0, 100) ;0
MsgBox, % Clamp(110, 0, 100) ;100
MsgBox, % Clamp(50, 0, 100) ;50
```

Some benefits:
- Can replace 4-liners with 1-liners e.g.:
```
if (num < low)
	num := low
if (num > high)
	num := high

num := Clamp(num, low, high)
```
- Clear code: it makes the intention of the code clearer, and it makes relevant code shorter.
- If altering the code, you don't have the alter num 4 times, and low and high twice.
- Newbies sometimes mess things like this up, including using Max or Min in an incorrect way. This is more intuitive. I.e. as simple as this code is, you in effect have to create an algorithm and work out what existing functionality will achieve it, leading to unpredictable results. Some users think of Max/Min, not </>, but get them the wrong way round.
- Some users try to be too clever with a one-liner, and get it wrong, or get it right, but the code is cryptic, e.g. `vNum := Max(vLow, Min(vNum, vHigh))` is correct.
- Avoid bugs. Surprisingly often, low-level but simple code leads to bugs, when a slightly higher-level more intuitive approach would have avoided them, and aided debugging.