### PR TITLE
v1: Added StrJoin().

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8661,6 +8661,12 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 0;
 		max_params = 3;
 	}
+	else if (!_tcsicmp(func_name, _T("StrJoin")))
+	{
+		bif = BIF_StrJoin;
+		min_params = 1;
+		max_params = 10000; // An arbitrarily high limit that will never realistically be reached.
+	}
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3356,6 +3356,7 @@ BIF_DECL(BIF_Trim); // L31: Also handles LTrim and RTrim.
 
 BIF_DECL(BIF_Hotstring);
 BIF_DECL(BIF_InputHook);
+BIF_DECL(BIF_StrJoin);
 
 
 BIF_DECL(BIF_IsObject);


### PR DESCRIPTION
## Introduction

Replaces #191.
Simpler algorithm and fixed memory leak.
Fixed numeric values sometimes resolving to blank strings (there was a difference between variadic and non-variadic parameters).
The function now throws on an invalid pad array (1st param). E.g. if it contains non-string values.

## Implementation

I had to change the min param count from 2 to 1.
Without this, if you did something like:
```
var := StrJoin("", ["a", "b", "c"]*)
var := StrJoin("", []*)
```
The 2nd line would silently fail, and the value of `var` would not update.

## Test code

```
;==================================================

;test code: StrJoin (AHK v1)

;==================================================

oArray1 := StrSplit("abcdefghijklmnopqrstuvwxyz")
oArray2 := StrSplit("")
oArray3 := []
oArray4 := StrSplitLen("abcdefghijklmnopqrstuvwxyz", 5)
oArray5 := StrSplit("abcdefghijklmnopqrstuvwxy") ;25 items = 24 join strings (to test array with 3 (alternating) join strings)
oArray6 := ["abc", 123, "def", 456]

Loop 6
{
	oArray := oArray%A_Index%

	vText1 := StrJoin("_", oArray*)
	vText2 := JEE_StrJoin("_", oArray*)
	if (vText1 != vText2)
		MsgBox(JEE_StrJoin("", "mismatch: index ", A_Index, ", line ", A_LineNumber, "`r`n`r`n", vText1, "`r`n===`r`n" vText2))

	vText1 := StrJoin("", oArray*)
	vText2 := JEE_StrJoin("", oArray*)
	if (vText1 != vText2)
		MsgBox(JEE_StrJoin("", "mismatch: index ", A_Index, ", line ", A_LineNumber, "`r`n`r`n", vText1, "`r`n===`r`n" vText2))

	vText1 := StrJoin(["_", "__", "___"], oArray*)
	vText2 := JEE_StrJoin(["_", "__", "___"], oArray*)
	if (vText1 != vText2)
		MsgBox(JEE_StrJoin("", "mismatch: index ", A_Index, ", line ", A_LineNumber, "`r`n`r`n", vText1, "`r`n===`r`n" vText2))
}

MsgBox("done")
return

;==================================================

StrSplitLen(vText, vBlockLen:=1, vOpt:="")
{
	local
	if (vText = "")
		return [""] ;[FIXME] or throw?
	if (vBlockLen = 1)
		return StrSplit(vText)

	vCount := Ceil(StrLen(vText)/vBlockLen)
	oArray := []
	oArray.SetCapacity(vCount)

	vOffset := 1
	if InStr(vOpt, "R")
	{
		vOffset := Mod(StrLen(vText), vBlockLen)
		if vOffset
		{
			oArray.Push(SubStr(vText, 1, vOffset))
			vCount--
		}
		vOffset++
	}

	Loop % vCount
	{
		oArray.Push(SubStr(vText, vOffset, vBlockLen))
		vOffset += vBlockLen
	}
	return oArray
}

;==================================================

JEE_StrJoin(vSep, oArray*)
{
	local
	VarSetStrCapacity(vOutput, oArray.Length()*200)
	if IsObject(vSep) && (vSep.Length() = 1) ;convert 1-item array to string
		vSep := vSep.1
	if !IsObject(vSep)
	{
		Loop % oArray.Length()-1
			vOutput .= oArray[A_Index] vSep
		vOutput .= oArray[oArray.Length()]
	}
	else
	{
		oSep := vSep
		vLast := oSep.Length()
		vIndex := 0
		Loop % oArray.Length()-1
		{
			;vIndex := Mod(A_Index-1, vLast)+1
			vIndex := (vIndex = vLast) ? 1 : vIndex + 1
			vOutput .= oArray[A_Index] oSep[vIndex]
		}
		vOutput .= oArray[oArray.Length()]
	}
	return vOutput
}

;==================================================

VarSetStrCapacity(ByRef TargetVar, RequestedCapacity:="")
{
	static ChrSize, IsReady
	if !VarSetCapacity(IsReady)
	{
		ChrSize := A_IsUnicode ? 2 : 1
		IsReady := "1"
	}
	if (RequestedCapacity = "")
		return VarSetCapacity(TargetVar) // ChrSize
	else if (RequestedCapacity = -1)
		return VarSetCapacity(TargetVar, -1) // ChrSize
	return VarSetCapacity(TargetVar, RequestedCapacity*ChrSize) // ChrSize
}

;==================================================

MsgBox(vText)
{
	MsgBox, % vText
}

;==================================================
```