### PR TITLE
v2: Fixed IsDigit/IsXDigit misidentifying digits/hex digits.

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -13720,7 +13720,7 @@ BIF_DECL(BIF_IsTypeish)
 	case VAR_TYPE_DIGIT:
 		if_condition = true;
 		for (cp = aValueStr; *cp; ++cp)
-			if (!_istdigit((UCHAR)*cp))
+			if (!_istdigit((USHORT)*cp))
 			{
 				if_condition = false;
 				break;
@@ -13732,7 +13732,7 @@ BIF_DECL(BIF_IsTypeish)
 			cp += 2;
 		if_condition = true;
 		for (; *cp; ++cp)
-			if (!_istxdigit((UCHAR)*cp))
+			if (!_istxdigit((USHORT)*cp))
 			{
 				if_condition = false;
 				break;


### PR DESCRIPTION
A cast to UCHAR causes IsDigit/IsXDigit to misidentify digits/hex digits.
This same problem also exists in AHK v1, and is fixed by #219.

Some code demonstrating the problem:
```
;test IsDigit and IsXDigit:

;test IsDigit:
vOutput := ""
vCount1 := vCount2 := vCount3 := 0
Loop 65535
{
	vChar := Chr(A_Index)
	vCount1 += IsDigit(vChar)
	vCount2 += Test_IsDigit(vChar)
	vCount3 += Test_IsDigit(vChar, 1)
	if Test_IsDigit(vChar)
		vOutput .= vChar
}
A_Clipboard .= "`r`n" vOutput
MsgBox(vCount1 "`r`n" vCount2 "`r`n" vCount3) ;3328 313 3328 [313 is correct]

;test IsXDigit:
vOutput := ""
vCount1 := vCount2 := vCount3 := 0
Loop 65535
{
	vChar := Chr(A_Index)
	vCount1 += IsXDigit(vChar)
	vCount2 += Test_IsXDigit(vChar)
	vCount3 += Test_IsXDigit(vChar, 1)
	if Test_IsXDigit(vChar)
		vOutput .= vChar
}
A_Clipboard .= "`r`n" vOutput
MsgBox(vCount1 "`r`n" vCount2 "`r`n" vCount3) ;5632 44 5632 [44 is correct]
return

Test_IsDigit(vText, vDoBug:=0)
{
	static A_IsUnicode := 1
	static vFunc := A_IsUnicode ? "msvcrt\iswdigit" : "msvcrt\isdigit"
	static vType := A_IsUnicode ? "UShort" : "Int"
	Loop Parse, vText
	{
		vChar := A_LoopField
		vOrd := Ord(vChar)
		if vDoBug
			vOrd := vOrd & 0xFF ;this recreates the UCHAR cast bug: if (!_istdigit((UCHAR)*cp))

		if !DllCall(vFunc, vType,vOrd, "Cdecl")
			return 0
	}
	return 1
}

Test_IsXDigit(vText, vDoBug:=0)
{
	static A_IsUnicode := 1
	static vFunc := A_IsUnicode ? "msvcrt\iswxdigit" : "msvcrt\isxdigit"
	static vType := A_IsUnicode ? "UShort" : "Int"
	if (SubStr(vText, 1, 2) = "0x")
		vText := SubStr(vText, 3)
	Loop Parse, vText
	{
		vChar := A_LoopField
		vOrd := Ord(vChar)
		if vDoBug
			vOrd := vOrd & 0xFF ;this recreates the UCHAR cast bug: if (!_istxdigit((UCHAR)*cp))

		if !DllCall(vFunc, vType,vOrd, "Cdecl")
			return 0
	}
	return 1
}
```

Some code for listing Unicode characters:
```
;list Unicode characters:
vOutput := ""
VarSetStrCapacity(&vOutput, 2000000)
hModule := DllCall("kernel32\LoadLibrary", "Str","getuname.dll", "Ptr")
Loop 65536
{
	vOrd := A_Index - 1

	;if !IsDigit(Chr(vOrd))
	;	continue
	;if !IsXDigit(Chr(vOrd))
	;	continue
	;if !DllCall("msvcrt\iswdigit", "UShort",vOrd, "Cdecl")
	;	continue
	;if !DllCall("msvcrt\iswxdigit", "UShort",vOrd, "Cdecl")
	;	continue

	VarSetStrCapacity(&vName, 1024) ;arbitrary value (for the first 65536 Unicode chars, the longest name I saw was for char 64505, length 83, length 84 if include null)
	DllCall("getuname\GetUName", "UShort",vOrd, "Str",vName)
	vOutput .= vOrd "`t" vName "`r`n"
}
DllCall("kernel32\FreeLibrary", "Ptr",hModule)
A_Clipboard := vOutput
MsgBox("done")
return
```

For reference:
[NamesList.txt](http://www.unicode.org/Public/UNIDATA/NamesList.txt)