### PR TITLE
v1: Fixed 'var is digit/xdigit' misidentifying digits/hex digits.

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -13093,7 +13093,7 @@ ResultType Line::EvaluateCondition() // __forceinline on this reduces benchmarks
 		case VAR_TYPE_DIGIT:
 			if_condition = true;
 			for (cp = ARG1; *cp; ++cp)
-				if (!_istdigit((UCHAR)*cp))
+				if (!_istdigit((USHORT)*cp))
 				{
 					if_condition = false;
 					break;
@@ -13105,7 +13105,7 @@ ResultType Line::EvaluateCondition() // __forceinline on this reduces benchmarks
 				cp += 2;
 			if_condition = true;
 			for (; *cp; ++cp)
-				if (!_istxdigit((UCHAR)*cp))
+				if (!_istxdigit((USHORT)*cp))
 				{
 					if_condition = false;
 					break;


### PR DESCRIPTION
A cast to UCHAR causes 'var is digit/xdigit' to misidentify digits/hex digits.
This same problem also exists in AHK v2, and is fixed (and further explained) by #218.