### PR TITLE
v2: Changed IsTime to ensure digit count is even and 14 maximum.

### DIFF
--- a/source/util.cpp
+++ b/source/util.cpp
@@ -211,7 +211,8 @@ ResultType YYYYMMDDToSystemTime(LPTSTR aYYYYMMDD, SYSTEMTIME &aSystemTime, bool 
 		// explicit zero for the day of the month.  It also reports failure if st.wYear is
 		// less than 1601, which for simplicity is enforced globally throughout the program
 		// since none of the Windows API calls seem to support earlier years.
-		return SystemTimeToFileTime(&aSystemTime, &ft) ? OK : FAIL;
+		// Length checks, and 1601 being the minimum year value, ensure a digit count of 4/6/8/10/12/14.
+		return (SystemTimeToFileTime(&aSystemTime, &ft) && !(length % 2) && (length <= 14)) ? OK : FAIL;
 		// Above: The st.wDayOfWeek member is ignored by the above (but might be used by our caller), but
 		// that's okay because it shouldn't need validation.
 	}


### PR DESCRIPTION
This would change IsTime to only report true for dates of length: 4/6/8/10/12/14.

At present, IsTime allows dates of an odd length, and that are longer than 14 digits.
Also, the underlying algorithm treats '2006x' as '20060x', '200605x' as '2006050x', ..., '200605040302x' as '2006050403020x'.
E.g. '20002' is considered valid, even though it's ambiguous as either the 2nd or '20th' month of the year.

I had thought that the proposed behaviour was already the default, when I started using AutoHotkey, until I systematically tested 'var is date'/IsTime.

So, on balance, I would support this PR or one like it, although I don't feel particularly strongly.

A test script:
```
;test IsTime:
vDate := ""
vOutput := ""
Loop 20
{
	if (A_Index = 1)
		vDate .= "2"
	else
		vDate .= "1"
	vOutput .= IsTime(vDate) "`t" vDate "`r`n"
}
A_Clipboard := vOutput
MsgBox(vOutput)
```
