### PR TITLE
v2: Added ProcessGetName/ProcessGetPath.

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -257,6 +257,8 @@ FuncEntry g_BIF[] =
 	BIFn(PostMessage, 1, 8, BIF_PostSendMessage),
 	BIFn(ProcessClose, 1, 1, BIF_Process),
 	BIFn(ProcessExist, 0, 1, BIF_Process),
+	BIFn(ProcessGetName, 0, 1, BIF_Process),
+	BIFn(ProcessGetPath, 0, 1, BIF_Process),
 	BIF1(ProcessSetPriority, 1, 2),
 	BIFn(ProcessWait, 1, 2, BIF_Process),
 	BIFn(ProcessWaitClose, 1, 2, BIF_Process),

--- a/source/script.h
+++ b/source/script.h
@@ -662,7 +662,7 @@ enum BuiltInFunctionID {
 	FID_WinMoveBottom = 0, FID_WinMoveTop,
 	FID_WinShow = 0, FID_WinHide, FID_WinMinimize, FID_WinMaximize, FID_WinRestore, FID_WinClose, FID_WinKill,
 	FID_WinActivate = 0, FID_WinActivateBottom,
-	FID_ProcessExist = 0, FID_ProcessClose, FID_ProcessWait, FID_ProcessWaitClose, 
+	FID_ProcessExist = 0, FID_ProcessClose, FID_ProcessWait, FID_ProcessWaitClose, FID_ProcessGetName, FID_ProcessGetPath,
 	FID_MonitorGet = 0, FID_MonitorGetWorkArea, FID_MonitorGetCount, FID_MonitorGetPrimary, FID_MonitorGetName, 
 	FID_OnExit = 0, FID_OnClipboardChange, FID_OnError,
 	FID_ControlGetChecked = 0, FID_ControlGetEnabled, FID_ControlGetVisible, FID_ControlFindItem, FID_ControlGetIndex, FID_ControlGetChoice, FID_ControlGetItems, FID_ListViewGetContent, FID_EditGetLineCount, FID_EditGetCurrentLine, FID_EditGetCurrentCol, FID_EditGetLine, FID_EditGetSelectedText, FID_ControlGetStyle, FID_ControlGetExStyle, FID_ControlGetHwnd,

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -2337,6 +2337,13 @@ BIF_DECL(BIF_Process)
 				_f_return_i(pid);
 			}
 		} // for()
+
+	case FID_ProcessGetName:
+	case FID_ProcessGetPath:
+		pid = *aProcess ? ProcessExist(aProcess) : GetCurrentProcessId();
+		TCHAR process_name[MAX_PATH];
+		GetProcessName(pid, process_name, _countof(process_name), process_cmd == FID_ProcessGetName);
+		_f_return(process_name);
 	} // case
 	} // switch()
 }


### PR DESCRIPTION
```
ProcessName := ProcessGetName([PIDOrName])
ProcessPath := ProcessGetPath([PIDOrName])
```

If `PIDOrName` is omitted, the functions return the name/path of the AutoHotkey exe.

As mentioned in #222: it can be somewhat/a little distracting when certain functions lack an inverse.
While you can get a process name/path from a window, via WinGetProcessName/WinGetProcessPath, currently, you can't get a process name/path from a PID (or process name).