### PR TITLE
v2: Added VerCompare().

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -332,6 +332,7 @@ FuncEntry g_BIF[] =
 	BIFn(Trim, 1, 2, BIF_Trim),
 	BIF1(Type, 1, 1),
 	BIF1(VarSetStrCapacity, 1, 2, {1}),
+	BIF1(VerCompare, 2, 2),
 	BIFn(WinActivate, 0, 4, BIF_WinActivate),
 	BIFn(WinActivateBottom, 0, 4, BIF_WinActivate),
 	BIFn(WinActive, 0, 4, BIF_WinExistActive),

--- a/source/script.h
+++ b/source/script.h
@@ -3431,6 +3431,7 @@ BIF_DECL(BIF_Process);
 BIF_DECL(BIF_ProcessSetPriority);
 BIF_DECL(BIF_MonitorGet);
 BIF_DECL(BIF_Wait);
+BIF_DECL(BIF_VerCompare);
 
 BIF_DECL(BIF_PerformAction);
 BIF_DECL(BIF_SetBIV);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -16704,6 +16704,38 @@ ResultType Object::Error__New(ResultToken &aResultToken, int aID, int aFlags, Ex
 
 
 
+BIF_DECL(BIF_VerCompare)
+{
+	size_t len1;
+	size_t len2;
+	_f_param_string(ver1, 0, &len1);
+	_f_param_string(ver2, 1, &len2);
+	int num1;
+	int num2;
+	if ((_tcsspn(ver1, _T("0123456789.")) != len1) || _tcsstr(ver1, _T(".."))
+		|| *ver1 == '\0' || *ver1 == '.' || *(ver1+len1-1) == '.')
+			_f_throw_param(0);
+	if ((_tcsspn(ver2, _T("0123456789.")) != len2) || _tcsstr(ver2, _T(".."))
+		|| *ver2 == '\0' || *ver2 == '.' || *(ver2+len2-1) == '.')
+			_f_throw_param(1);
+	--ver1;
+	--ver2;
+	while (ver1 || ver2)
+	{
+		num1 = ver1 ? _ttoi(ver1+1) : 0;
+		num2 = ver2 ? _ttoi(ver2+1) : 0;
+		if (num1 > num2)
+			_f_return_i(1);
+		else if (num1 < num2)
+			_f_return_i(-1);
+		ver1 = ver1 ? _tcsstr(ver1+1, _T(".")) : 0;
+		ver2 = ver2 ? _tcsstr(ver2+1, _T(".")) : 0;
+	}
+	_f_return_i(0);
+}
+
+
+
 ////////////////////////////////////////////////////////
 // HELPER FUNCTIONS FOR TOKENS AND BUILT-IN FUNCTIONS //
 ////////////////////////////////////////////////////////


### PR DESCRIPTION
Compares two strings as version numbers.
```
Result := VerCompare(Version1, Version2)
```

Version numbers must not contain any characters other than digits and dots.
Version numbers must start and end with a digit.
Version numbers must not contain any consecutive dots.

Some examples:
```
MsgBox(VerCompare("1.2.3", "1.2.4")) ;-1
MsgBox(VerCompare("1.2", "1.2")) ;0
MsgBox(VerCompare("1.2", "1.2.0")) ;0
MsgBox(VerCompare("1.2", "1.2.0.0.0.0.0.0.1")) ;-1
MsgBox(VerCompare("1.2", "1.2.0.0.0.0.0.0.0")) ;0
```

Two uses are to compare version numbers and to compare IP addresses.

This function or similar, could be added as a stand-alone function, or by some other means such as a 'V' comparison mode in StrCompare or a 'NumCompare' function.
The function name can be changed if desired.
The code can be radically altered if desired.
I don't feel too strongly regarding this function's inclusion.