### PR TITLE
v1: Added Object.Reverse() and Object.Swap(). And ObjReverse()/ObjSwap().

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8558,6 +8558,8 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		BIF_OBJ_CASE(NewEnum,		0, 0)
 		BIF_OBJ_CASE(Clone,			0, 0)
 		BIF_OBJ_CASE(BindMethod,	1, 10000) // obj, method [, param...]
+		BIF_OBJ_CASE(Reverse,		0, 0)
+		BIF_OBJ_CASE(Swap,			2, 2) // key1, key2
 #undef BIF_OBJ_CASE
 		else if (!_tcsicmp(suffix, _T("AddRef")) || !_tcsicmp(suffix, _T("Release")))
 			bif = BIF_ObjAddRefRelease;

--- a/source/script.h
+++ b/source/script.h
@@ -3388,6 +3388,8 @@ BIF_DECL(BIF_ObjMinIndex);
 BIF_DECL(BIF_ObjNewEnum);
 BIF_DECL(BIF_ObjHasKey);
 BIF_DECL(BIF_ObjClone);
+BIF_DECL(BIF_ObjReverse);
+BIF_DECL(BIF_ObjSwap);
 
 
 // Advanced file IO interfaces

--- a/source/script_object.h
+++ b/source/script_object.h
@@ -13,7 +13,7 @@ enum ObjectMethodID { // Partially ported from v2 BuiltInFunctionID.  Used for c
 	FID_ObjInsertAt, FID_ObjDelete, FID_ObjRemoveAt, FID_ObjPush, FID_ObjPop, FID_ObjLength
 	, FID_ObjHasKey, FID_ObjGetCapacity, FID_ObjSetCapacity, FID_ObjGetAddress, FID_ObjClone
 	, FID_ObjNewEnum, FID_ObjMaxIndex, FID_ObjMinIndex, FID_ObjRemove, FID_ObjInsert
-	, FID_ObjCount
+	, FID_ObjCount, FID_ObjReverse, FID_ObjSwap
 };
 
 
@@ -351,6 +351,8 @@ public:
 	ResultType _NewEnum(ExprTokenType &aResultToken, ExprTokenType *aParam[], int aParamCount);
 	ResultType _HasKey(ExprTokenType &aResultToken, ExprTokenType *aParam[], int aParamCount);
 	ResultType _Clone(ExprTokenType &aResultToken, ExprTokenType *aParam[], int aParamCount);
+	ResultType _Reverse(ExprTokenType &aResultToken, ExprTokenType *aParam[], int aParamCount);
+	ResultType _Swap(ExprTokenType &aResultToken, ExprTokenType *aParam[], int aParamCount);
 
 	static LPTSTR sMetaFuncName[];
 

--- a/source/script_object_bif.cpp
+++ b/source/script_object_bif.cpp
@@ -390,6 +390,8 @@ BIF_METHOD(MinIndex)
 BIF_METHOD(NewEnum)
 BIF_METHOD(HasKey)
 BIF_METHOD(Clone)
+BIF_METHOD(Reverse)
+BIF_METHOD(Swap)
 
 
 //


### PR DESCRIPTION
## Introduction

```
Obj.Reverse()
ObjReverse(Obj)

Obj.Swap(Key1, Key2)
ObjSwap(Obj, Key1, Key2)

```

Obj.Reverse():
- Reverse the 'array' keys, other keys are left untouched.
- Reverse keys 1 to `Obj.MaxIndex()`, if there are no gaps.
- In AHK v2, this would be available for the Array type only.

Obj.Swap():
- Swap any 2 keys.
- In AHK v2, this would be available for the Array and Map types.

## Implementation

- Errors. `Obj.Swap()` throws if a key is missing. `Obj.Reverse()` throws if there are gaps between keys 1 and `Obj.MaxIndex()`.
- Return value. The methods/functions return a blank string. Throwing indicates failure.
- Function versions of methods. I added these so that users don't have to expend any cognitive energy remembering which methods do/don't have equivalent functions, they can just assume that they do.
- The code can be altered as desired, e.g. error messages.