### PR TITLE
v1: Added FloorMod().

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8464,7 +8464,7 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 	}
 	else if (!_tcsicmp(func_name, _T("Floor")) || !_tcsicmp(func_name, _T("Ceil")))
 		bif = BIF_FloorCeil;
-	else if (!_tcsicmp(func_name, _T("Mod")))
+	else if (!_tcsicmp(func_name, _T("Mod")) || !_tcsicmp(func_name, _T("FloorMod")))
 	{
 		bif = BIF_Mod;
 		min_params = 2;


### PR DESCRIPTION
## Description
Floor modulo. Returns the remainder of the specified dividend divided by the specified divisor.

```
Value := FloorMod(Dividend, Divisor)
```
The sign of the result is always the same as the sign of the second parameter.
(This is unlike `Mod` where: the sign of the result is always the same as the sign of the first parameter.)

If either input is a floating point number, the function throws.
(This is unlike `Mod` where: the result is also a floating point number.)

If the second parameter is zero, the function throws.
(This is unlike `Mod` where: the function yields a blank result (empty string).)
(This is consistent with `Mod` in AHK v2.)

## Background Information: Comparing Mod and FloorMod

Mod is related to division, if you do 16 / 10, the remainder is 6. Mod gives you the remainder.
The question is how to handle special cases where one or more of the numbers is negative.

Some examples:

```
Mod(16, 10) ;6
Mod(-16, 10) ;-6
Mod(16, -10) ;6
Mod(-16, -10) ;-6

FloorMod(16, 10) ;6
FloorMod(-16, 10) ;4 ;differs from Mod
FloorMod(16, -10) ;-4 ;differs from Mod
FloorMod(-16, -10) ;-6
```
- FloorMod is similar to Mod, but generally more useful and convenient.
- When doing modulo arithmetic, you almost always have a positive divisor, and you almost always want a result that is positive or 0.
- Unfortunately, when using Mod, if the first parameter is negative, you get a negative (or 0) result.
- Fortunately, when using FloorMod, if the second parameter (divisor) is positive, you get a positive (or 0) result.
- This fact about FloorMod can greatly simplify code.
- Personally, for writing new code, if a language could only have Mod or FloorMod, I would pick FloorMod. That said, because so much existing code already uses Mod, I would want to have both.

## Background Information: An Example
For example, if we're handling letters, and we use a divisor of 26:
FloorMod gives you a number in the range 0 to 25.
Mod gives you a number in the range -25 to 25.
```
MsgBox, % Mod(-3, 26) ;-3
MsgBox, % FloorMod(-3, 26) ;23
```

If we consider a script that cycles through array items:

```
;==============================

;cycle backwards by 3 in a 1-based list (using Mod):

oArray := StrSplit("abcdefghijklmnopqrstuvwxyz")
vOutput := ""
vNum := 26
vShift := -3
Loop, 26
{
	vOutput .= oArray[vNum]
	;note: -1 converts 1-based to 0-based, apply shift, apply mod, +1 to get 1-based again
	vNum := Mod(vNum-1+vShift, 26) + 1
	if (vNum < 1) ;this line is unnecessary if using FloorMod
		vNum += 26 ;this line is unnecessary if using FloorMod
}
MsgBox, % vOutput ;zwtqnkhebyvspmjgdaxurolifc ;each letter appears once

;==============================

;cycle backwards by 3 in a 1-based list (using FloorMod):

oArray := StrSplit("abcdefghijklmnopqrstuvwxyz")
vOutput := ""
vNum := 26
vShift := -3
Loop, 26
{
	vOutput .= oArray[vNum]
	;note: -1 converts 1-based to 0-based, apply shift, apply mod, +1 to get 1-based again
	vNum := FloorMod(vNum-1+vShift, 26) + 1
}
MsgBox, % vOutput ;zwtqnkhebyvspmjgdaxurolifc ;each letter appears once

;==============================
```
You will notice 2 lines that can be omitted if we use FloorMod. This is a small advantage here, but across multiple scripts and complicated code, and writing a quick script, these advantages add up.

If altering the code, you save 2 lines, but you also save 4 items. Those 4 items can be quite complicated to deal with, and may be variables rather than hardcoded, and so a bug can easily be introduced if modifying them.

As mentioned regarding Clamp(). #214.
Surprisingly often, low-level but simple code leads to bugs, when a slightly higher-level more intuitive approach would have avoided them, and aided debugging.

## Other Programming Languages

- Taking C++, Java and Python as examples:
- In C++ and Java, the `%` operator is equivalent to Mod.
- In Python, the `%` operator is equivalent to FloorMod.
- Java has Math.floorMod.

## Mod and Integer Divide, FloorMod and Floor Divide

- Mod and integer divide, FloorMod and floor divide, have special mathematical relationships.
- If AutoHotkey had all 4 built-in, this would be a great achievement. These elements of functionality often cause incompatibility problems and sometimes disputes.
- Some further information:
[[rust-dev] Division and modulo for signed numbers](https://mail.mozilla.org/pipermail/rust-dev/2013-April/003680.html)
#225

## Mod Operators

- I have not proposed any mod operators at this time, because they typically contain `%`, which has a special meaning in AutoHotkey, so might be complicated to implement.
- If mod operators were added, I would choose: `%` or `mod` for `Mod()`, and perhaps `%%` for `FloorMod()`. `%%` is floor mod in the R programming language, and would fit nicely with Python's `//`, floor divide.