### PR TITLE
v1: Added 'push' and 'print' operators. Added Print().

### DIFF
--- a/source/defines.h
+++ b/source/defines.h
@@ -206,6 +206,8 @@ enum SymbolType // For use with ExpandExpression() and IsPureNumeric().
 	, SYM_FUNC     // A call to a function.
 	, SYM_NEW      // new Class()
 	, SYM_REGEXMATCH // L31: Experimental ~= RegExMatch operator, equivalent to a RegExMatch call in two-parameter mode.
+	, SYM_PUSH
+	, SYM_PRINT
 	, SYM_COUNT    // Must be last because it's the total symbol count for everything above.
 	, SYM_INVALID = SYM_COUNT // Some callers may rely on YIELDS_AN_OPERAND(SYM_INVALID)==false.
 };

--- a/source/script.h
+++ b/source/script.h
@@ -3404,6 +3404,7 @@ BIF_DECL(BIF_ComObjQuery);
 
 
 BIF_DECL(BIF_Exception);
+BIF_DECL(BIF_Print);
 
 
 BOOL LegacyResultToBOOL(LPTSTR aResult);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -18790,6 +18790,16 @@ BIF_DECL(BIF_Exception)
 
 
 
+BIF_DECL(BIF_Print)
+{
+	LPTSTR aText = ParamIndexToString(0, aResultToken.buf);
+	MsgBox(aText, NULL, NULL, NULL, NULL);
+	aResultToken.symbol = SYM_STRING;
+	aResultToken.marker = _T("");
+}
+
+
+
 ////////////////////////////////////////////////////////
 // HELPER FUNCTIONS FOR TOKENS AND BUILT-IN FUNCTIONS //
 ////////////////////////////////////////////////////////


### PR DESCRIPTION
## Code details:
- The `push` operator invokes `ObjPush()`.
- The `print` operator invokes `Print()`.
- I created a simple placeholder function, `Print()`. It displays the text in a MsgBox. It currently returns a blank string.
- `Print()` could be made identical to using `MsgBox()` with 1 parameter in AHK v2, or possibly somewhat different to that.
- The `print` operator could be uncoupled from `Print()` and instead be redefined by using an `OnPrint()` function.
- The operator precedence levels can be changed if desired.
- `print` could be restricted to: the start of a sub-expression, and to just after an open parenthesis, to protect the user from incorrect usage.

## Syntax:
```
;push a value to an array, equivalent to Obj.Push(Value):
Obj push Value
Index := Obj push Value

;invoke the built-in or a custom Print() function:
print Value

;invoke the Print() function:
;the built-in function works very similarly to MsgBox(Value):
Print(Value)
```

## Rationale for 'print':
- It is useful to separate `MsgBox` for user input/notification, and `Print` for debugging. It makes the intention clear when reviewing old code. It also makes it easier to find lines relating to debugging.
- The operators facilitate writing quick code. Parentheses and dots (and capitalising, and holding shift) are avoided, making typing more fluid. And the `push` operator plays better with <kbd>Ctrl+Right</kbd> and <kbd>Shift+End</kbd> than with the method. You can add and remove one word, `print`, versus adding and removing `MyPrint(` and navigating to add/remove `)`.
- You can redefine the `Print` function to make the `print` operator perform special or additional tasks.
- Even if something can be done with hotstrings/hotkeys, sometimes it's simpler to manually type or edit something.
- In AHK v1, `MsgBox, %` avoids parentheses, but doesn't make the debugging intention clear, and can't be used in a sub-expression, whereas `MyPrint()` has the disadvantage of requiring parentheses.
- In AHK v2, you can do a `Print` one-liner, using a custom function e.g. `MyPrint` and command-style notation, but you can't use this in sub-expressions. E.g.:
```
;AHK v2 function style:
MyPrint("a") ;valid
MyPrint("a"), MyPrint("b") ;valid

;AHK v2 command style:
MyPrint "a" ;valid
MyPrint "a", MyPrint "b" ;invalid

;operator:
print "a", print "b" ;valid (NEW)
```
- E.g. I often add a temporary `print`, as a sub-expression, to monitor/debug code:
```
Loop Parse, text, % "`n", % "`r"
{
	if (cond)
		var := MyFunc(A_LoopField), print var
}
```
## For reference re. 'print':
- The `print` statement was popular in Python 2, and there is demand for it to be returned in Python 3.
- I think the problem with it in Python 2, was that they made various unique bits of syntax for it, whereas I'm proposing a standard unary operator cf.:
```
always unary: new ! not ~ ++ --
sometimes unary: + - * &
```
- Another problem with it in Python 2 was that you couldn't redefine its behaviour. This in part led to the unique bits of syntax. I've proposed that you *can* redefine `print`.
- I.e. the idea was good, but Python implemented it badly. A lot of people now are asking to at least be able to do `print var`.
[printing - Python 3 print without parenthesis - Stack Overflow](https://stackoverflow.com/questions/32122868/python-3-print-without-parenthesis/32124420)
- C++'s `cout` does not use parentheses. Also, PHP's `echo`, and Ruby's `puts`. Some other examples I came across: Elixir: `io.puts`, Fortran: `print`, F#: `printfn`, Perl: `print` and `say`.

## Rationale for 'push':
```
;simpler:
;and you don't have to worry about maintaining parentheses while editing:
;and no surrounding parentheses to obscure any complicated expressions:
oArray := []
oArray push LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG
oArray push LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG
oArray push LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG
oArray push LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG
oArray push LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG

;current:
oArray := []
oArray.Push(LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG)
oArray.Push(LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG)
oArray.Push(LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG)
oArray.Push(LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG)
oArray.Push(LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG)

;workaround:
oArray := []
;oArray.Length := 10000 ;arbitrary value ;AHK v2 needs this
i := 1
;i := oArray.Length() + 1 ;if the array already has members, use this instead
oArray[i++] := LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG
oArray[i++] := LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG
oArray[i++] := LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG
oArray[i++] := LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG
oArray[i++] := LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG

;also:
;but this makes it harder to shuffle items:
;and you have to look after the final square bracket:
;and it's less aesthetically pleasing:
oArray := [LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG
, LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG
, LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG
, LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG
, LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG]

;==================================================

;replacing '.=' with push and StrJoin, improves readability and maintainability:
;note: if the expressions differ in length, counting the "`r`n" instances is less easy:
;note: if the 'LONG...' part is enclosed in parentheses, these can be removed:

;before:
vText := ""
vText .= LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG "`r`n"
vText .= LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG "`r`n"
vText .= LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG "`r`n"
vText .= LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG "`r`n"
vText .= LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG "`r`n"

;after:
oArray := []
oArray push LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG
oArray push LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG
oArray push LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG
oArray push LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG
oArray push LONGLONGLONGLONGLONGLONGLONGLONGLONGLONG
vText := StrJoin("`r`n", oArray*) "`r`n"

;==================================================
```
- To add an item to a string, I can just use `.=`, but every time I want to add an item to an array, I have to remember that it requires an object method, and write it out longhand. If there were an operator equivalent to `.=`, to add an item to an array, it would be even more convenient than `.=` because you wouldn't even need to add a string separator such as ``"`r`n"``.
- I find that you can write and debug code very quickly in AutoHotkey, with `push` and `print` being the only 2 bottlenecks that hotstrings are not sufficient to solve.
- You can have situations where there are multiple long strings that you want to put into an array, or multiple complicated formulas, or some code for a quick test.  Simply prepending each line with `MyArray push` would be faster and more readable than setting up a continuation section, or one of the alternatives (e.g. hotkeys/hotstrings). Plus you can easily comment out items.
- Sometimes I want to modify quick code that does multiple string appends, to multiple array pushes, or the reverse, and a `push` operator would facilitate this. `.=` to `push` and replace the trailing separator string with nothing.
```
vOutput .= vText "`r`n"
oOutput push vText
```
- `push` is similar to, and fits in with, the (other) assignment operators such as `+=` and `.=`.
- In AHK v1 and v2, I sometimes use the workaround `oArray[i++] := vValue`. Although in AHK v2, this has the disadvantage of requiring setting the `Length` property in advance.
- AHK v2 has a sort of shorthand for push, but it's not perfect aesthetically: `oArray.Push vValue`, and is nonstandard/unusual cf. other programming languages. Also, you can't use it in a sub-expression, unlike `push`, e.g.:
`var := MyFunc(A_LoopField), oDebug push var`.
- So, `push` can be used to quickly add to an array for debugging purposes, for later inspection, a 'delayed print'.
- I considered that `.=` could be used to push values, but decided against it, it would complicate matters, and it seems better as a string operator only. E.g. when inspecting code, that would make `.=` ambiguous, you couldn't tell if it was appending or pushing. Cf. Python's use of `*` to repeat a string, which is interesting, but overall I'm against it. 

## A metric for measuring typing inconvenience:

I compared `push` v. `.Push()`:
- pain factor points: 1 for a normal character [push .]
- pain factor points: 2 for a character that needs shift [P()]
- bonus pain points: 1 [. far more inconvenient than space, not as easy to reach]
- bonus pain points: 2 [parentheses: remembering to add the trailing parenthesis, not confusing Push's parentheses with the argument's]
- bonus pain points: 2 [doesn't play nicely with ctrl+(shift)+left/ctrl+(shift)+right, e.g. it stops before the opening parenthesis, not before the argument, an issue when navigating and doing quick copying-and-pasting]

[space + p+u+s+h + space]
a push b [pain factor: 1+4+1 = 6]

[dot + shift+p+u+s+h + shift+9 + shift+0]
a.Push(b) [pain factor 1+2+3+2+2+(1)+(2)+(2) = 15]

I like the speed of:
`myarray SPACE push SPACE CTRL+V ENTER`
versus:
`myarray DOT CAPITAL-P ush DOT OPEN-BRACKETS CTRL+V CLOSE+BRACKETS ENTER`

Also, I often press space accidentally, and then have to backspace it before I begin. Because usually with assignment, I type the variable name and press space:
`myarray SPACE BACKSPACE DOT CAPITAL-P ush OPEN-BRACKETS CTRL+V CLOSE+BRACKETS ENTER`


## Breaking changes?
- Clearly new commands/functions/methods are allowed in AHK v1, but I'm not sure about operators.
- If the features are liked, but in some way constitute a breaking change, a directive, could unlock certain features.
- E.g., at some point, it could give `**` the correct associativity (right-associative), as in AHK v2, and make if-statements always use expression syntax. Or instead warn you if a line is ambiguous, so you can add parentheses to make it forwards compatible.
- The directive could work in a similar way to `#Warn`, with granularity.

## Test code:
```
;==================================================

;demonstrate 'push' (and 'print'):

oArray := ["a", "b", "c"]
oArray push "d"
oArray push "e"
print oArray.Length() ;5
print Format("{}{}{}{}{}", oArray*) ;abcde

;==============================

;these look similar, but the latter is easier to manipulate and think about,
;in initial development:

oArray.Push(c1 ? v1 : (c2 ? v2 : (c3 ? v3 : v4)))
oArray.Push(c1 ? v1 : (c2 ? (c3 ? v2 : v3) : v4))
oArray.Push(c1 ? (c2 ? v1 : v2) : (c3 ? v3 : v4))
oArray.Push(c1 ? (c2 ? v1 : (c3 ? v2 : v3)) : v4)
oArray.Push(c1 ? (c2 ? (c3 ? v1 : v2) : v3) : v4)

oArray push c1 ? v1 : (c2 ? v2 : (c3 ? v3 : v4))
oArray push c1 ? v1 : (c2 ? (c3 ? v2 : v3) : v4)
oArray push c1 ? (c2 ? v1 : v2) : (c3 ? v3 : v4)
oArray push c1 ? (c2 ? v1 : (c3 ? v2 : v3)) : v4
oArray push c1 ? (c2 ? (c3 ? v1 : v2) : v3) : v4

;==============================

;the latter is more readable and easier to manipulate,
;the latter plays better with Ctrl+Right and Shift+End,
;a string continuation section could be used, but requires Loop Parse,
;these 'push' lines can be easily commented out:

oArray := []
oArray.Push("C:\WINDOWS\system32\user32.dll")
oArray.Push("C:\WINDOWS\system32\kernel32.dll")
oArray.Push("C:\WINDOWS\system32\msvcrt.dll")
oArray.Push("C:\WINDOWS\system32\shell32.dll")
oArray.Push("C:\WINDOWS\system32\gdi32.dll")
oArray.Push("C:\WINDOWS\system32\advapi32.dll")
oArray.Push("C:\WINDOWS\system32\wininet.dll")
oArray.Push("C:\WINDOWS\system32\shlwapi.dll")
oArray.Push("C:\WINDOWS\system32\comdlg32.dll")

oArray := []
oArray push "C:\WINDOWS\system32\user32.dll"
oArray push "C:\WINDOWS\system32\kernel32.dll"
oArray push "C:\WINDOWS\system32\msvcrt.dll"
oArray push "C:\WINDOWS\system32\shell32.dll"
oArray push "C:\WINDOWS\system32\gdi32.dll"
oArray push "C:\WINDOWS\system32\advapi32.dll"
oArray push "C:\WINDOWS\system32\wininet.dll"
oArray push "C:\WINDOWS\system32\shlwapi.dll"
oArray push "C:\WINDOWS\system32\comdlg32.dll"

;==================================================

;demonstrate 'print' (and 'push'):

print "hello world"

var := 1
oDebug1 := []
oDebug2 := []
Loop 2
{
	if (A_Index = 1)
		var++, print var ;2
	else
		var--
		, print var ;1

	if (A_Index = 1)
		var++, oDebug1 push var
	else
		var--
		, oDebug2 push var
}

;testing operator precedence levels: push v. the ternary operator:
;the 'loadtime error' example is the only potentially unintuitive example I've come across,
;in general, 'print should be on the left of the sub-expression, else in parentheses',
;there are pros and cons to different operator precedence levels:
Loop 2
{
	;(A_Index = 1) ? print "y" : print "n" ;note: this line causes a loadtime error
	(A_Index = 1) ? (print "y") : (print "n")
	print (A_Index = 1) ? "y" : "n"
}

print a := b := c := 3, print a+1, print b+2, print c+3 ;output: 3 4 5 6

var := 0
print var += 5 ;output: 5

MsgBox, % "done"

;==================================================

;custom redefinition of Print function:
Print(ByRef vText:="") ;ByRef for performance
{
	static vScriptNameNoExt := RegExReplace(A_ScriptName, "\.[^.]*$")
	vLineNum := Exception("", -1).Line

	;choose one of these lines (either MsgBox prompt or console):
	MsgBox,, % vScriptNameNoExt, % vText
	;PrintAlt(vLineNum ": " vText)
}

;==================================================

;based on:
;printf() - AutoHotkey Community
;https://autohotkey.com/boards/viewtopic.php?f=5&t=59630&p=251599#p251599

;custom redefinition of Print function:
PrintAlt(ByRef vText:="")  ;ByRef for performance
{
	static vIsReady := 0, oStdOut
	if !vIsReady
	{
		DllCall("kernel32\AllocConsole")
		oStdOut := FileOpen("*", "w `n")
		vIsReady := 1
	}
	oStdOut.Write(vText)
	if !(vText ~= "`n$")
		oStdOut.Write("`n")
	oStdOut.Read(0) ;flush the write buffer
}

;==================================================
```

This marks the completion of my Saint George's Day and subsequent updates. I may add one or two things, but these now cover virtually everything on my wish list.