### PR TITLE
Add virtual keys for Japanese keyboards

### DIFF
--- a/source/globaldata.cpp
+++ b/source/globaldata.cpp
@@ -730,6 +730,27 @@ modifier is specified along with it:
 , {_T("Launch_App1"), VK_LAUNCH_APP1}
 , {_T("Launch_App2"), VK_LAUNCH_APP2}
 
+// Japanese Virtual Key Support
+, { _T("Kana"), VK_KANA}
+, { _T("Ime_On"), VK_IME_ON}
+, { _T("Kanji"), VK_KANJI}
+, { _T("Henkan"), VK_CONVERT}
+, { _T("Ime_Off"), VK_IME_OFF}
+, { _T("Muhenkan"), VK_NONCONVERT}
+
+// These keys behave like 3-state radio keys.
+, { _T("Eisu"), VK_OEM_ATTN} // VK_DBE_ALPHANUMERIC
+, { _T("Katakana"), VK_OEM_FINISH} // VK_DBE_KATAKANA
+, { _T("Hiragana"), VK_OEM_COPY} // VK_DBE_HIRAGANA
+
+// These keys behave like toggle radio keys.
+, { _T("Hankaku"), VK_OEM_AUTO} // VK_DBE_SBCSCHAR
+, { _T("Zenkaku"), VK_OEM_ENLW} // VK_DBE_DBCSCHAR
+
+// These keys behave like toggle radio keys.
+, { _T("Romaji"), VK_OEM_BACKTAB} // VK_DBE_ROMAN
+, { _T("NoRomaji"), VK_ATTN} // VK_DBE_NOROMAN
+
 // Probably safest to terminate it this way, with a flag value.  (plus this makes it a little easier
 // to code some loops, maybe).  Can also calculate how many elements are in the array using sizeof(array)
 // divided by sizeof(element).  UPDATE: Decided not to do this in case ever decide to sort this array; don't


### PR DESCRIPTION
Fixes #55

This fix includes key names for Japanese-specific keys, which simplifies AHK settings for Japanese keyboard users.
In my opinion, it is better to keep the key names consistent with the VK names, not the names based on actual behaviors.   


Due to historical reasons, there are some unique keys and VKs for Japanese inputting systems, and users are dependent on these keys. Some of the keys behave like two or three state radio keys; keydown for enabling the function of a pressed key, and keyup for disabling that of a key previously pressed. This behavior might imitate physical switches for backward compatibility. 


Typical Japanese IMEs correspond to keydown events and ignore keyups of IME keys. In the default setting of the Microsoft IME, pressing Ime_off/on, Hiragana and Katakana keys guarantee to change an input mode to the designated one. The other keys toggle the input mode in various ways, sometimes ignoring the (virtual) key names.


When the hardware keyboard is set to "Japanese keyboard (106/109 key)," some of the key events are suppressed by OS and the behaviors became so complicated that the current AHK cannot handle them. However, when the keyboard setting is changed to "English keyboard (101/102 key)," the behaviors became much simpler and AHK can handle them.


I found the more detailed explanation in the following URL:
https://metacpan.org/pod/UI::KeyboardLayout#Far-Eastern-keyboards-on-Windows 

We can see how a Japanese keyboard works in the following code:
https://github.com/microsoft/Windows-driver-samples/blob/master/input/layout/fe_kbds/jpn/106/kbd106.c
https://github.com/microsoft/Windows-driver-samples/blob/master/input/layout/fe_kbds/jpn/101/kbd101.c
