### PR TITLE
v1: Added Between() and Clamp().

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8661,6 +8661,12 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 0;
 		max_params = 3;
 	}
+	else if (!_tcsicmp(func_name, _T("Between")) || !_tcsicmp(func_name, _T("Clamp")))
+	{
+		bif = BIF_BetweenClamp;
+		min_params = 3;
+		max_params = 3;
+	}
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3356,6 +3356,7 @@ BIF_DECL(BIF_Trim); // L31: Also handles LTrim and RTrim.
 
 BIF_DECL(BIF_Hotstring);
 BIF_DECL(BIF_InputHook);
+BIF_DECL(BIF_BetweenClamp);
 
 
 BIF_DECL(BIF_IsObject);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -18791,6 +18791,64 @@ BIF_DECL(BIF_Exception)
 
 
 
+BIF_DECL(BIF_BetweenClamp)
+{
+	ExprTokenType param;
+	TCHAR mode = ctoupper(aResultToken.marker[0]); // Get 1st char of function name.
+	bool has_floats = false;
+	aResultToken.symbol = SYM_STRING;
+	aResultToken.marker = _T("");
+	for (int i = 0; i < 3; ++i)
+	{
+		ParamIndexToNumber(i, param);
+		switch (param.symbol)
+		{
+			case SYM_INTEGER:
+				break;
+			case SYM_FLOAT:
+				has_floats = true;
+				break;
+			default:
+				_f_throw(i == 0 ? ERR_PARAM1_INVALID : i == 1 ? ERR_PARAM2_INVALID : ERR_PARAM3_INVALID);
+		}
+	}
+
+	if (has_floats)
+	{
+		double fNum = ParamIndexToDouble(0);
+		double fLow = ParamIndexToDouble(1);
+		double fHigh = ParamIndexToDouble(2);
+		if (fHigh < fLow)
+			_f_throw(_T("Invalid bounds."));
+		if (mode == 'B') // Between.
+		{
+			aResultToken.symbol = SYM_INTEGER;
+			aResultToken.value_int64 = (fLow <= fNum) && (fNum <= fHigh); // Integer.
+		}
+		else // Clamp.
+		{
+			aResultToken.symbol = SYM_FLOAT;
+			double fTemp = fNum < fHigh ? fNum : fHigh;
+			aResultToken.value_double = fLow > fTemp ? fLow : fTemp;
+		}
+	}
+	else
+	{
+		__int64 iNum = ParamIndexToInt64(0);
+		__int64 iLow = ParamIndexToInt64(1);
+		__int64 iHigh = ParamIndexToInt64(2);
+		if (iHigh < iLow)
+			_f_throw(_T("Invalid bounds."));
+		aResultToken.symbol = SYM_INTEGER;
+		if (mode == 'B') // Between.
+			aResultToken.value_int64 = (iLow <= iNum) && (iNum <= iHigh);
+		else // Clamp.
+			aResultToken.value_int64 = max(iLow, min(iNum, iHigh));
+	}
+}
+
+
+
 ////////////////////////////////////////////////////////
 // HELPER FUNCTIONS FOR TOKENS AND BUILT-IN FUNCTIONS //
 ////////////////////////////////////////////////////////


### PR DESCRIPTION
Replaces #214.

## Example code
```
MsgBox, % Clamp(-10, 0, 100) ;0
MsgBox, % Clamp(110, 0, 100) ;100
MsgBox, % Clamp(50, 0, 100) ;50

MsgBox, % Clamp(-10.0, 0, 100) ;0.0
MsgBox, % Clamp(110.0, 0, 100) ;100.0
MsgBox, % Clamp(50.0, 0, 100) ;50.0

MsgBox, % Between(-10, 0, 100) ;0
MsgBox, % Between(110, 0, 100) ;0
MsgBox, % Between(50, 0, 100) ;1

MsgBox, % Between(-10.0, 0, 100) ;0
MsgBox, % Between(110.0, 0, 100) ;0
MsgBox, % Between(50.0, 0, 100) ;1
```

## Clamp
`Value := Clamp(Number, LowerBound, UpperBound)`

Clamp is described here: #214.

Throws if any input value is non-numeric.
Throws if the bounds are in the wrong order. (Parameter `#2` must be less than or equal to Parameter `#3`.)

If any of the input values is a float, the return value will be a float, else, an integer.

## Between
`Bool := Between(Number, LowerBound, UpperBound)`

Checks whether a number is between two values (inclusive).

Throws if any input value is non-numeric.
Throws if the bounds are in the wrong order. (Parameter `#2` must be less than or equal to Parameter `#3`.)

Number:
The number to be checked.
LowerBound:
To be within the specified range, Number must be greater than or equal to this number.
UpperBound:
To be within the specified range, Number must be less than or equal to this number.
Return Value:
If Number is within the specified range (inclusive), true, else, false.
The return value will be always be an integer (1 or 0).

Unlike the AHK v1 pseudo-operator `between`, this function handles numeric input only.

For reference: [If Var between Low and High - Syntax & Usage | AutoHotkey](https://www.autohotkey.com/docs/commands/IfBetween.htm)

## Rationale for Between

`if Between(var, 1, 10)`
`if (var >= 1 && var <= 10)`
`if (1 <= var && var <= 10)`

I find `Between` more succinct/readable/maintainable than the alternatives, and:
- It requires zero mental energy when writing new code.
- You avoid stating the variable twice.
- Bugs due to using the wrong operator are avoided.
- Although `Between` can only handle 'or equal to', 99.9% of the time, I want integers in an inclusive range.

An example use is to validate that an index from `InputBox` is between 1 and `MyArray.Length()`.

Even if chained operators were introduced, which I'm not sure would be a good idea (I remain neutral), few languages have them, whereas a `Between` function could be more simply recreated in any language that lacked it.