### PR TITLE
v2: Added StartingPos parameter to StrReplace.

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -317,7 +317,7 @@ FuncEntry g_BIF[] =
 	BIFn(StrLower, 1, 2, BIF_StrCase),
 	BIF1(StrPtr, 1, 1),
 	BIFn(StrPut, 1, 4, BIF_StrGetPut),
-	BIF1(StrReplace, 2, 6, {5}),
+	BIF1(StrReplace, 2, 7, {5}),
 	BIF1(StrSplit, 1, 4),
 	BIFn(StrUpper, 1, 2, BIF_StrCase),
 	BIF1(SubStr, 2, 3),

--- a/source/util.h
+++ b/source/util.h
@@ -682,7 +682,7 @@ LPTSTR ltcschr(LPCTSTR haystack, TCHAR ch);
 LPTSTR lstrcasestr(LPCTSTR phaystack, LPCTSTR pneedle);
 LPTSTR tcscasestr (LPCTSTR phaystack, LPCTSTR pneedle);
 UINT StrReplace(LPTSTR aHaystack, LPTSTR aOld, LPTSTR aNew, StringCaseSenseType aStringCaseSense
-	, UINT aLimit = UINT_MAX, size_t aSizeLimit = -1, LPTSTR *aDest = NULL, size_t *aHaystackLength = NULL);
+	, UINT aLimit = UINT_MAX, size_t aSizeLimit = -1, LPTSTR *aDest = NULL, size_t *aHaystackLength = NULL, INT_PTR aStartingOffset = 0);
 size_t PredictReplacementSize(ptrdiff_t aLengthDelta, int aReplacementCount, int aLimit, size_t aHaystackLength
 	, size_t aCurrentLength, size_t aEndOffsetOfCurrMatch);
 LPTSTR TranslateLFtoCRLF(LPTSTR aString);


### PR DESCRIPTION
Added a `StartingPos` parameter to `StrReplace()`, similar to `SubStr()`.

`ReplacedStr := StrReplace(Haystack, Needle [, ReplaceText, CaseSense, OutputVarCount, Limit, StartingPos])`

Some test code:
```
;StrReplace (StartingPos) test code:

;ReplacedStr := StrReplace(Haystack, Needle, ReplaceText, CaseSense, OutputVarCount, Limit, StartingPos)

CaseSense := 1
Limit := -1
;Limit := 3

Haystack := "aaaaaaaaaa", Needle := "a", Start := -12
;Haystack := "xy_xy_xy_xy_xy_xy_xy_xy_xy_xy_", Needle := "xy_", Start := -33

StartPos := Start
End := -Start
Loop
{
	vOutput := StartPos "`r`n`r`n"
	if StartPos
	{
		vOutput .= StrReplace(Haystack, Needle, "b", CaseSense, &Count, Limit, StartPos) "`r`n" Count "`r`n`r`n"
		vOutput .= StrReplace(Haystack, Needle, "", CaseSense, &Count, Limit, StartPos) "`r`n" Count "`r`n`r`n"
		vOutput .= StrReplace(Haystack, Needle, "cc_", CaseSense, &Count, Limit, StartPos) "`r`n" Count
	}
	MsgBox(vOutput)

	if (StartPos = End)
		break
	StartPos++
}
```
At one point, in `util.cpp`, I was torn between various options: increasing code size but adding code outside 2 loops, adding one line of code inside 2 loops, etc. In this PR, I have opted for the simplest solution, but there may be a more optimal solution.

I do not wish for functions to have too many parameters, however, I do not feel that 7 parameters are too many for a function, and that this parameter is worthwhile. Although not ideal, in AHK v1, `InputBox` had 11 parameters, and I found that quite manageable. I also feel that the `StartingPos` parameter is useful, and consistent with other functions such as `SubStr`, `InStr`, `RegExMatch`, `RegExReplace`, and a possible `StrCount` function.

Although some of this functionality could be achieved by using `SubStr` and concatenation etc, there are certain distracting and code-convoluting low-level tasks that I'd rather be handled directly by the built-in functions.

Some uses:
- Use `RegExMatch` to identify any leading whitespace, and then after that position, replace any tabs with spaces, and apply `RTrim`.
- File paths: replace a string in a file's name, but not in its directory.
- Use `InStr` to find the position, then replace the nth occurrence of a string.
- Compared to `RegExReplace`, you do not have to escape any characters.
- For very large strings, this should reduce some of the copying and moving about of data that would otherwise be required.