### PR TITLE
v2: Changed OnMessage callback function parameter order.

### DIFF
--- a/source/application.cpp
+++ b/source/application.cpp
@@ -1759,10 +1759,10 @@ bool MsgMonitor(MsgMonitorInstance &aInstance, HWND aWnd, UINT aMsg, WPARAM awPa
 	// Set up the array of parameters for func->Invoke().
 	ExprTokenType param[] =
 	{
-		(__int64)awParam,
-		(__int64)(DWORD_PTR)alParam, // Additional type-cast prevents sign-extension on 32-bit, since LPARAM is signed.
+		(__int64)(size_t)aWnd,
 		(__int64)aMsg,
-		(__int64)(size_t)aWnd
+		(__int64)awParam,
+		(__int64)(DWORD_PTR)alParam // Additional type-cast prevents sign-extension on 32-bit, since LPARAM is signed.
 	};
 
 	ResultType result;


### PR DESCRIPTION
## Rationale

```
;OnMessage callback function (old order):
MyWndProc(wParam, lParam, uMsg, hWnd)
{
}

;OnMessage callback function (new order):
;the new order is consistent with a WndProc specified by SetWindowLong and GWL_WNDPROC:
MyWndProc(hWnd, uMsg, wParam, lParam)
{
}
```
Someone (not me) suggested that the OnMessage callback function parameter order be changed to be more standard, consistent with window procedures.

I found while working on some GUI-based code that this would be beneficial, e.g. to allow the same callback function to work with both AutoHotkey's OnMessage and the Winapi's SetWindowLong.

The AHK v1 parameter order is unusual, I didn't find the arguments made for it particularly convincing, and as a newbie I didn't find specifying all 4 arguments to be any great disadvantage, whereas if you want a callback function to work with both OnMessage and SetWindowLong, or if you're translating existing code from other languages, the more standard order would be better.

For reference:
[WindowProc callback function (Windows) | Microsoft Docs](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms633573(v=vs.85))

## Note

AFAICS you only need to change 4 lines of code. Apologies if I have overlooked anything.

## Test code

```
;==================================================

;test OnMessage (AHK v2.0-a133)

;==================================================

;OnMessage parameter order receive.ahk
Persistent()
OnMessage(111, MyMessageMonitor)
MyMessageMonitor(hWnd, uMsg, wParam, lParam)
{
	MsgBox(A_ScriptHwnd "`r`n`r`n" hWnd "`r`n" uMsg "`r`n" wParam "`r`n" lParam)
}

;==================================================

;OnMessage parameter order send.ahk
DetectHiddenWindows(1)
hWnd := WinGetID("OnMessage parameter order receive.ahk")
PostMessage(111, 222, 333,, "ahk_id " hWnd)

;==================================================
```