### PR TITLE
v2: Restored A_ScriptName as read-only. Added A_ScriptTitle.

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -494,7 +494,8 @@ VarEntry g_BIV_A[] =
 	A_(ScriptDir),
 	A_(ScriptFullPath),
 	A_(ScriptHwnd),
-	A_w(ScriptName),
+	A_(ScriptName),
+	A_w(ScriptTitle),
 	A_x(Sec, BIV_DateTime),
 	A_w(SendLevel),
 	A_w(SendMode),
@@ -557,7 +558,7 @@ Script::Script()
 	, mClassObjectCount(0), mUnresolvedClasses(NULL), mClassProperty(NULL), mClassPropertyDef(NULL)
 	, mCurrFileIndex(0), mCombinedLineNumber(0)
 	, mFileSpec(_T("")), mFileDir(_T("")), mFileName(_T("")), mOurEXE(_T("")), mOurEXEDir(_T("")), mMainWindowTitle(_T(""))
-	, mScriptName(NULL)
+	, mScriptTitle(NULL)
 	, mIsReadyToExecute(false), mAutoExecSectionIsRunning(false)
 	, mIsRestart(false), mErrorStdOut(false), mErrorStdOutCP(-1)
 #ifndef AUTOHOTKEYSC

--- a/source/script.h
+++ b/source/script.h
@@ -2954,7 +2954,7 @@ public:
 	LPTSTR mFileSpec; // Will hold the full filespec, for convenience.
 	LPTSTR mFileDir;  // Will hold the directory containing the script file.
 	LPTSTR mFileName; // Will hold the script's naked file name.
-	LPTSTR mScriptName; // Value of A_ScriptName; defaults to mFileName if NULL. See also DefaultDialogTitle().
+	LPTSTR mScriptTitle; // Value of A_ScriptTitle; defaults to mFileName if NULL. See also DefaultDialogTitle().
 	LPTSTR mOurEXE; // Will hold this app's module name (e.g. C:\Program Files\AutoHotkey\AutoHotkey.exe).
 	LPTSTR mOurEXEDir;  // Same as above but just the containing directory (for convenience).
 	LPTSTR mMainWindowTitle; // Will hold our main window's title, for consistency & convenience.
@@ -3215,7 +3215,8 @@ BIV_DECL_R (BIV_MyDocuments);
 BIV_DECL_R (BIV_Caret);
 BIV_DECL_R (BIV_Cursor);
 BIV_DECL_R (BIV_ScreenWidth_Height);
-BIV_DECL_RW(BIV_ScriptName);
+BIV_DECL_R (BIV_ScriptName);
+BIV_DECL_RW(BIV_ScriptTitle);
 BIV_DECL_R (BIV_ScriptDir);
 BIV_DECL_R (BIV_ScriptFullPath);
 BIV_DECL_R (BIV_ScriptHwnd);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -4769,9 +4769,9 @@ DWORD GetAHKInstallDir(LPTSTR aBuf)
 
 LPTSTR Script::DefaultDialogTitle()
 {
-	// If the script has set A_ScriptName, use that:
-	if (mScriptName)
-		return mScriptName;
+	// If the script has set A_ScriptTitle, use that:
+	if (mScriptTitle)
+		return mScriptTitle;
 	// If available, the script's filename seems a much better title than the program name
 	// in case the user has more than one script running:
 	return (mFileName && *mFileName) ? mFileName : T_AHK_NAME_VERSION;
@@ -10039,17 +10039,22 @@ BIV_DECL_R(BIV_ScreenWidth_Height)
 
 BIV_DECL_R(BIV_ScriptName)
 {
-	_f_return_p(g_script.mScriptName ? g_script.mScriptName : g_script.mFileName);
+	_f_return_p(g_script.mFileName);
 }
 
-BIV_DECL_W(BIV_ScriptName_Set)
+BIV_DECL_R(BIV_ScriptTitle)
+{
+	_f_return_p(g_script.mScriptTitle ? g_script.mScriptTitle : g_script.mFileName);
+}
+
+BIV_DECL_W(BIV_ScriptTitle_Set)
 {
 	// For simplicity, a new buffer is allocated each time.  It is not expected to be set frequently.
-	LPTSTR script_name = _tcsdup(BivRValueToString());
-	if (!script_name)
+	LPTSTR script_title = _tcsdup(BivRValueToString());
+	if (!script_title)
 		_f_throw_oom;
-	free(g_script.mScriptName);
-	g_script.mScriptName = script_name;
+	free(g_script.mScriptTitle);
+	g_script.mScriptTitle = script_title;
 }
 
 BIV_DECL_R(BIV_ScriptDir)


### PR DESCRIPTION
This PR separates `A_ScriptName` into 2 variables:
- `A_ScriptName` is made read-only again, as it was in AHK v1.
- `A_ScriptTitle` is introduced, a writable variable, that acts as the default dialog title.

Notes:
- The name, `A_ScriptTitle`, could be replaced with `A_DialogTitle`, `A_DlgTitle`, or something else, if desired. I would be happy with any of the 3 names.

## Documentation

A_ScriptTitle:
Can be used to get or set the default title for MsgBox, InputBox, FileSelect, DirSelect and Gui. If not set by the script, it defaults to the file name of the current script, without its directory, e.g. MyScript.ahk.

A_ScriptName:
The file name of the current script, without its directory, e.g. MyScript.ahk.

## A_ScriptName and other variables for #Include

It may be beneficial to introduce a variable, `A_ScriptNameNoExt`, and make `A_ScriptTitle` default to that.
This would make the default dialog title consistent for compiled and uncompiled scripts.
And `A_ScriptNameNoExt` would be useful for `#Include`.

To complete the set of `A_` variables:
```
A_VP1/A_VP2/A_VP3/A_VP4 [NEW] [these or similar, i.e. 'p' for part]
[1 variable for each part of the version number]
[I considered A_V1/A_V2/A_V3/A_V4, but felt they would cause confusion]
[e.g. #Include %A_ScriptDir%\%A_ScriptNameNoExt%-Lib-AHKv%A_VP1%.ahk]
[e.g. #Include %A_ScriptDir%\%A_ScriptNameNoExt%-Settings.ini]

A_AhkVersion [e.g. '1.1.33.00']
A_AhkVersionFull [NEW] [or A_AhkVersionFriendly/similar]
[e.g. perhaps '1.1.33.00 U32'] [AHK v2 would still state 'U']
[versus: v := A_AhkVersion " " (A_IsUnicode ? "U" : "A") (A_PtrSize=8 ? 64 : 32)]

A_ScriptTitle [NEW]

A_AhkPath
A_AhkDir [NEW] [like AutoHotkey_H] [useful for #Include]
A_AhkName [NEW] [e.g. useful if testing a script on multiple AHK exes]
A_AhkNameNoExt [NEW] [useful for #Include]
A_ScriptDir
A_ScriptFullPath
A_ScriptName
A_ScriptNameNoExt [NEW] [very useful for #Include and for A_ScriptTitle]

A_LoopFileNameNoExt [NEW] [useful, and for completion/simplicity]
```

Where, for compiled scripts, `A_AhkXXX` and `A_ScriptXXX` could both point to the compiled exe path.
The simplest, easiest to remember, behaviour. And logical, a compiled exe plays both roles.

Also useful would be an `/inc` command-line switch. To prepend/append scripts.
And/or something like `/join` (or another name). To launch multiple scripts as one.

Some syntax possibilities:
```
using * to mean this script:
/incbef script1.ahk script2.ahk
/incaft script4.ahk script5.ahk
/inc script1.ahk script2.ahk * script4.ahk script5.ahk

/join script1.ahk script2.ahk * script4.ahk script5.ahk
/join script1.ahk script2.ahk thisscript.ahk script4.ahk script5.ahk
```

## Rationale

- I would prefer `A_ScriptName` to be dependable, always referring to the script's path minus the dir.
- But I would still like to be able to modify the the default dialog title, so that it did not include the script's extension. It looks more elegant that way, and it seems odd to include the extension.
- If `A_ScriptName` was writable, any code using it to identify scripts could break, especially if the default dialog title departed significantly from the path minus dir.
- If `A_ScriptName` was being used to create files based on the script's filename, special characters in the new default dialog title could cause that to fail. Ordinarily, `A_ScriptName` would not contain invalid filename characters, because it is derived from a filename.
- Here are some code lines from my scripts, suggesting the utility of keeping `A_ScriptName` as read-only:
```
IniRead, vShowIcon, % vPath, % "List", % A_ScriptName
SplitPath, A_ScriptName,,,, vScriptNameNoExt
vScriptNameNoExt := SplitPath(A_ScriptName).NameNoExt
if (A_ScriptName = "AutoHotkey.ahk")
if !(A_ScriptName = "AutoHotkey.ahk")
ToolTip, % A_ScriptName ;diagnostic
Menu, Tray, Tip, % RegExReplace(A_ScriptName, "\.[^.]*$")
MsgBox("responsive:`r`n" A_ScriptName)
vPath := A_Desktop "\is responsive\z " A_ScriptName ".txt"
MsgBox(A_ThisFunc ":`r`n" A_ScriptName ":`r`n" "retrying append to text file",, "T5")
```

## Test code

```
;test A_ScriptName (restored as read-only) and A_ScriptTitle:

;A_ScriptName := "abc" ;error
MsgBox(A_ScriptName) ;MyScript.ahk

MsgBox(A_ScriptTitle) ;MyScript.ahk
SplitPath(A_ScriptName,,,, &vNameNoExt)
A_ScriptTitle := vNameNoExt
MsgBox(A_ScriptTitle) ;MyScript

MsgBox(A_ScriptName) ;MyScript.ahk
```