### PR TITLE
v1: Backported A_Clipboard from alpha branch.

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -64,6 +64,7 @@ VarEntry g_BIV_A[] =
 	A_x(BatchLines, BIV_BatchLines),
 	A_x(CaretX, BIV_Caret),
 	A_x(CaretY, BIV_Caret),
+	A_x(Clipboard, (BuiltInVarType)VAR_CLIPBOARD),
 	A_x(ComputerName, BIV_UserName_ComputerName),
 	A_(ComSpec),
 	A_x(ControlDelay, BIV_xDelay),


### PR DESCRIPTION
A built-in variable, `A_Clipboard`, equivalent to the existing built-in variable, `Clipboard`.
This makes AHK v1 consistent with AHK v2, so that both versions have `A_Clipboard`.

Test code:
```
;==================================================

;test A_Clipboard:

;manually: copy image data in MS Paint
vClipSaved := ClipboardAll

A_Clipboard := "abc"
MsgBox, % A_Clipboard "`r`n" Clipboard ;abc
A_Clipboard .= "def"
MsgBox, % A_Clipboard "`r`n" Clipboard ;abcdef

Clipboard := "ghi"
MsgBox, % A_Clipboard "`r`n" Clipboard ;ghi
Clipboard .= "jkl"
MsgBox, % A_Clipboard "`r`n" Clipboard ;ghijkl

A_Clipboard := vClipSaved
;manually: paste image data in MS Paint

;==================================================
```