### PR TITLE
v1: Backported Buffer support from alpha branch for NumXXX/StrXXX/File.RawXXX/A_Clipboard.

### DIFF
--- a/source/var.cpp
+++ b/source/var.cpp
@@ -743,6 +743,16 @@ ResultType Var::AssignSkipAddRef(IObject *aValueToAssign)
 
 	if (var.mType != VAR_NORMAL)
 	{
+		if (var.mType == VAR_CLIPBOARD)
+			if (MetaObject::Object *obj = dynamic_cast<MetaObject::Object *>(aValueToAssign))
+			{
+				ExprTokenType t1;
+				ExprTokenType t2;
+				if ((obj->GetItem(t1, _T("Ptr")))
+				&& (obj->GetItem(t2, _T("Size"))))
+					SetClipboardAll((CHAR *)TokenToInt64(t1), (size_t)TokenToInt64(t2));
+				return OK;
+			}
 		aValueToAssign->Release();
 		return g_script.ScriptError(ERR_INVALID_VALUE, _T("An object."));
 	}


### PR DESCRIPTION
## Introduction
This PR adds `Buffer` support to: `NumPut`, `NumGet`, `StrPut`, `StrGet`, `File.RawRead`, `File.RawWrite`, `Clipboard`/`A_Clipboard`.
But not `DllCall`.
The functions can handle Buffer-like objects.
And the `Clipboard` variable can receive a Buffer-like object, as produced by a `ClipboardAll` function backport (AHK code).

PR #235 introduces `A_Clipboard` to AHK v1.

## Rationale
The benefits are for people writing code in AHK v1, using a `Buffer` object backport (AHK code), to increase their readiness for moving to AHK v2.
And for people regularly working in both versions.

## For reference
The `StrPut`/`StrGet` fixes were a little complex, slight errors are possible, in which case, apologies.

Of all the code I have viewed, I think AHK v1 `StrPut`/`StrGet` could benefit from slight comment additions/clarifications.

In AHK code, I have backports for `ClipboardAll`/`FileAppend`/`FileRead` that handle `Buffer` objects. And a `Buffer` class backport.

## Test code
```
;==================================================

;test Buffer - Clipboard (assign object)

;manually: copy image data in MS Paint
vClipSaved := ClipboardAll

Clipboard := "abc"
MsgBox, % Clipboard

;buffer direct:
vSize := VarSetCapacity(vClipSaved)
Clipboard := {Ptr:&vClipSaved, Size:vSize}
;manually: paste image data in MS Paint
MsgBox ;while the MsgBox is showing, a chance to paste image data

Clipboard := "def"
MsgBox, % Clipboard

;buffer variable:
vSize := VarSetCapacity(vClipSaved)
oBuf := {Ptr:&vClipSaved, Size:vSize}
Clipboard := oBuf
;manually: paste image data in MS Paint
return

;==================================================

;test Buffer - File.RawRead and File.RawWrite
;note: creates a text file in the script folder

vPath := A_ScriptDir "\test buf+ - File object.txt"
if !FileExist(vPath)
	FileAppend, % "abcdefghijklmnopqrstuvwxyz", % "*" vPath, CP0

VarSetCapacity(vDataOut, 4)
StrPut("wxyz", &vDataOut, 4, "CP0")
oBufOut := {Ptr:&vDataOut, Size:4}

VarSetCapacity(vData, 4)
oBuf := {Ptr:&vData, Size:4}
oFile := FileOpen(vPath, "rw")
oFile.RawRead(oBuf, 4)
MsgBox, % StrGet(oBuf, 4, "CP0") ;abcd

MsgBox, % StrGet(oBufOut, 4, "CP0") ;wxyz

oFile.Pos := 0
oFile.RawWrite(oBufOut, 4)
oFile.Pos := 0
oFile.RawRead(oBuf, 4)
MsgBox, % StrGet(oBuf, 4, "CP0") ;wxyz

StrPut("abcd", oBufOut, 4, "CP0")
oFile.Pos := 0
oFile.RawWrite(oBufOut, 4)
oFile.Pos := 0
oFile.RawRead({Ptr:&vDataOut, Size:4}, 4)
MsgBox, % StrGet({Ptr:&vDataOut, Size:4}, 4, "CP0") ;abcd
oFile.Close()

;==================================================

;test Buffer - NumPut and NumGet

VarSetCapacity(vData, 4)

;buffer direct:
NumPut(111, {Ptr:&vData, Size:4}, 0, "UInt")
MsgBox, % NumGet({Ptr:&vData, Size:4}, 0, "UInt") ;111

;buffer variable:
oBuf := {Ptr:&vData, Size:4}
NumPut(222, oBuf, 0, "UInt")
MsgBox, % NumGet(oBuf, 0, "UInt") ;222

;string variable:
NumPut(333, vData, 0, "UInt")
MsgBox, % NumGet(vData, 0, "UInt") ;333

;string address (&):
NumPut(444, &vData, 0, "UInt")
MsgBox, % NumGet(&vData, 0, "UInt") ;444

;string address (+0):
pData := &vData
NumPut(555, pData+0, 0, "UInt")
MsgBox, % NumGet(pData+0, 0, "UInt") ;555

;buffer variable (size too small) (should fail, returning a blank):
oBuf := {Ptr:&vData, Size:2}
NumPut(666, oBuf, 0, "UInt")
MsgBox, % NumGet(oBuf, 0, "UInt") ;(blank)

;adress 0 (+0) (should fail, returning a blank):
pData := &vData
NumPut(777, 0+0, 0, "UInt")
MsgBox, % NumGet(0+0, 0, "UInt") ;(blank)

MsgBox, % NumGet(pData+0, 0, "UInt") ;555 (should show the last successful write value)
return

;==================================================

;test Buffer - StrPut and StrGet

VarSetCapacity(vData, 4)

;buffer direct:
StrPut("aaa", {Ptr:&vData, Size:4}, "CP0")
MsgBox, % StrGet({Ptr:&vData, Size:4}, "CP0") ;aaa

;buffer variable:
oBuf := {Ptr:&vData, Size:4}
StrPut("bbb", oBuf, "CP0")
MsgBox, % StrGet(oBuf, "CP0") ;bbb

;buffer direct:
StrPut("ccc", {Ptr:&vData, Size:4}, "UTF-16")
MsgBox, % StrGet({Ptr:&vData, Size:4}, "UTF-16") ;(blank)

;buffer variable:
oBuf := {Ptr:&vData, Size:4}
StrPut("ddd", oBuf, "UTF-16")
MsgBox, % StrGet(oBuf, "UTF-16") ;(blank)

;buffer variable:
oBuf := {Ptr:&vData, Size:4}
StrPut("e", oBuf, "UTF-16")
MsgBox, % StrGet(oBuf, "UTF-16") ;e

StrPut("f", {Ptr:&vData, Size:4}, "UTF-16")
MsgBox, % StrGet({Ptr:&vData, Size:4}, "UTF-16") ;f

MsgBox, % StrGet(oBuf, "CP0") ;f

MsgBox, % "done"
return

;==================================================
```