### PR TITLE
v1: Added OnHotkey().

### DIFF
--- a/source/application.cpp
+++ b/source/application.cpp
@@ -836,7 +836,14 @@ bool MsgSleep(int aSleepDuration, MessageMode aMode)
 				// even if it can't launch due to MaxThreads, MaxThreadsPerHotkey, or some other reason:
 				hs->DoReplace(msg.lParam);  // Does only the backspacing if it's not an auto-replace hotstring.
 				if (hs->mReplacement) // Fully handled by the above; i.e. it's an auto-replace hotstring.
+				{
+					if (g_script.mOnHotkey.Count())
+					{
+						ExprTokenType param[] = { hs->mName, (__int64)fore_window, (__int64)criterion_found_hwnd, (__int64)2 };
+						g_script.mOnHotkey.Call(param, 4, 1);
+					}
 					continue;
+				}
 				// Otherwise, continue on and let a new thread be created to handle this hotstring.
 				// Since this isn't an auto-replace hotstring, set this value to support
 				// the built-in variable A_EndChar:
@@ -1068,6 +1075,11 @@ bool MsgSleep(int aSleepDuration, MessageMode aMode)
 				// the options that distinguish between (for example) :c:ahk:: and ::ahk::
 				g_script.mThisHotkeyName = (msg.message == AHK_HOTSTRING) ? hs->mName : hk->mName;
 				g_script.mThisHotkeyStartTime = GetTickCount(); // Fixed for v1.0.35.10 to not happen for GUI threads.
+				if (g_script.mOnHotkey.Count())
+				{
+					ExprTokenType param[] = { g_script.mThisHotkeyName, (__int64)fore_window, (__int64)criterion_found_hwnd, (__int64)(msg.message == AHK_HOTSTRING ? 1 : 0) };
+					g_script.mOnHotkey.Call(param, 4, 1);
+				}
 			}
 
 			// Also save the ErrorLevel of the subroutine that's about to be suspended.

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8504,7 +8504,8 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 	}
 	else if (!_tcsicmp(func_name, _T("OnExit"))
 		|| !_tcsicmp(func_name, _T("OnClipboardChange"))
-		|| !_tcsicmp(func_name, _T("OnError")))
+		|| !_tcsicmp(func_name, _T("OnError"))
+		|| !_tcsicmp(func_name, _T("OnHotkey")))
 	{
 		bif = BIF_On;
 		max_params = 2;

--- a/source/script.h
+++ b/source/script.h
@@ -2439,7 +2439,7 @@ public:
 	MsgMonitorStruct *Find(UINT aMsg, IObject *aCallback, bool aIsLegacyMode);
 	MsgMonitorStruct *Add(UINT aMsg, IObject *aCallback, bool aIsLegacyMode, bool aAppend = TRUE);
 	void Remove(MsgMonitorStruct *aMonitor);
-	ResultType Call(ExprTokenType *aParamValue, int aParamCount, int aInitNewThreadIndex); // Used for OnExit and OnClipboardChange, but not OnMessage.
+	ResultType Call(ExprTokenType *aParamValue, int aParamCount, int aInitNewThreadIndex); // Used for OnExit, OnClipboardChange, OnError and OnHotkey, but not OnMessage.
 
 	MsgMonitorStruct& operator[] (const int aIndex) { return mMonitor[aIndex]; }
 	int Count() { return mCount; }
@@ -2985,7 +2985,7 @@ public:
 	TCHAR mThisMenuItemName[MAX_MENU_NAME_LENGTH + 1];
 	TCHAR mThisMenuName[MAX_MENU_NAME_LENGTH + 1];
 	LPTSTR mThisHotkeyName, mPriorHotkeyName;
-	MsgMonitorList mOnExit, mOnClipboardChange, mOnError; // Event handlers for OnExit(), OnClipboardChange() and OnError().
+	MsgMonitorList mOnExit, mOnClipboardChange, mOnError, mOnHotkey; // Event handlers for OnExit(), OnClipboardChange(), OnError() and OnHotkey().
 	Label *mOnClipboardChangeLabel; // Separate from mOnClipboardChange for backward-compatibility reasons.
 	Label *mOnExitLabel;  // The label to run when the script terminates (NULL if none).
 	HWND mNextClipboardViewer;

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -16750,7 +16750,8 @@ BIF_DECL(BIF_On)
 	enum OnEventType {
 		OnExit,
 		OnError,
-		OnClipboardChange
+		OnClipboardChange,
+		OnHotkey
 	} event_type;
 	MsgMonitorList *phandlers;
 	switch (tolower(aResultToken.marker[3]))
@@ -16762,6 +16763,10 @@ BIF_DECL(BIF_On)
 	case 'l':
 		event_type = OnClipboardChange;
 		phandlers = &g_script.mOnClipboardChange;
+		break;
+	case 'o':
+		event_type = OnHotkey;
+		phandlers = &g_script.mOnHotkey;
 		break;
 	default:
 		event_type = OnExit;


### PR DESCRIPTION
## Introduction

This function would allow you to execute a callback function, each time a hotkey or hotstring was triggered.
It handles hotkeys, non-auto-replace hotstrings and auto-replace hotstrings.

The callback function receives 4 values:
1. Label. The hotkey/hotstring label.
2. HwndActive. The HWND of the active window when the hotkey was triggered.
3. HwndMatch. The HWND of the window that matched the `#IfWin` criteria, if any. (Note: this may sometimes give useful though unintuitive results, e.g. it returns 0 for a global hotkey/hotstring and it returns 0 for `IfWinNot` criteria.)
4. Type. The hotkey type: 0 if a hotkey, 1 if a non-auto-replace hotstring, 2 if an auto-replace hotstring.

This function or similar would meet the demand for logging hotkey usage data or taking other actions, each time a hotkey/hotstring is triggered.

## Rationale

This functionality is something I'd thought about almost immediately, when I first started using AutoHotkey, around 10 years ago. To log usage data. E.g. first time, last time, count.

Possible workarounds:
- Replace all instances of `return` with a function that logs hotkey usage data and then calls `Exit`. E.g. I use `RetX()` in key scripts.
- Replace all hotkey subroutines with functions, and use the `Hotkey` command/function to launch a go-between function, that logs usage data, before launching the functions.
- (These both have the drawback of not working with auto-replace hotstrings.)

A separate `OnHotstring` function would be fine. Either way, the `Type` parameter allows users to filter by type.

I ordered the type values so that `Type` was effectively a bool, 'IsHotstring': 0 for hotkey, 1 or 2 for hotstring. Hotkeys and non-auto-replace hotstrings are quite similar, so I gave them closer numbers: 0 and 1, leaving auto-replace hotstrings as 2.

I'm not in any great hurry to have this function or similar approved, but I present it here now, if it's of interest.

## Refactoring and 'A_ThisHotkeyHwnd'

tl;dr: IIRC the source code retrieves the active window twice, it could be simpler and more useful/intuitive.

Something I thought of since writing the function: the source code may need some minor refactoring to guarantee 'the active window when the hotkey was triggered'. E.g. the active window HWND could **always** be retrieved, whenever a hotkey/hotstring is triggered, and that HWND would be passed **into**, not out of, any HotCriterionAllowsFiring/CriterionAllowsFiring checks. The 'match' HWND would be unchanged.

I had thought that an `A_ThisHotkeyHwnd` variable might be useful, equivalent to `HwndActive` above.
I would use it in virtually every hotkey subroutine I have. It would be more secure than using `WinExist` to retrieve the HWND retrospectively, which is what I'm doing now.

The point about HotCriterionAllowsFiring and CriterionAllowsFiring would also apply.

An `A_ThisHotkeyHwndMatch` variable might be useful for hotkeys with `#IfWinExist`, however, I don't recall ever needing that, and it could also be achieved by using `#If WinExist(...)` and retrieving the Last Found Window. So I'm not recommending that.

## Test code

```
;==================================================

;test OnHotkey:

OnHotkey("MyOnHotkeyCallbackFunc")
OnHotkey("MyOnHotkeyCallbackFunc2")
return

#IfWinActive ahk_class Notepad
:*b0:myhg2-::my hotstring

#IfWinActive ahk_class Notepad
q::
:*b0:myhg-::
return

#IfWinNotActive ahk_class Notepad
+q::
return

#IfWinExist ahk_class WordPadClass
w::
return

#IfWinNotExist ahk_class WordPadClass
+w::
return

#If WinExist("ahk_class WordPadClass")
r::
return

#If !WinExist("ahk_class WordPadClass")
+r::
return

MyOnHotkeyCallbackFunc(oParams*)
{
	WinGetTitle, vWinTitle1, % "ahk_id " oParams[2]
	WinGetTitle, vWinTitle2, % "ahk_id " oParams[3]
	ToolTip, % oParams[1] "`r`n" vWinTitle1 "`r`n" vWinTitle2 "`r`n" oParams[4]
}

MyOnHotkeyCallbackFunc2(oParams*)
{
	SoundBeep
}

;==================================================
```