### PR TITLE
v1: Backported File.Handle from alpha branch.

### DIFF
--- a/source/TextIO.cpp
+++ b/source/TextIO.cpp
@@ -766,6 +766,7 @@ class FileObject : public ObjectBase // fincs: No longer allowing the script to 
 		if_member("Length", Length)
 		if_member("AtEOF", AtEOF)
 		if_member("__Handle", Handle) // Prefix with underscores because it is designed for advanced users.
+		if_member("Handle", Handle)
 		if_member("Encoding", Encoding)
 		if_member("Close", Close)
 		// Supported for enhanced clarity:


### PR DESCRIPTION
Adds `File.Handle` to AHK v1.
AHK v1 and v2 would both have `File.Handle`.
AHK v1 would continue to have `File.__Handle`.

Test code:
```
;test File.Handle:

if (oFile := FileOpen(A_ScriptFullPath, "r"))
{
	MsgBox, % oFile.Handle "`r`n" oFile.__Handle
	oFile.Close()
}
MsgBox, % "done"
```