### PR TITLE
v1: Added VarGetName().

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8674,6 +8674,8 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 0;
 		max_params = 3;
 	}
+	else if (!_tcsicmp(func_name, _T("VarGetName")))
+		bif = BIF_VarGetName;
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3358,6 +3358,7 @@ BIF_DECL(BIF_Trim); // L31: Also handles LTrim and RTrim.
 
 BIF_DECL(BIF_Hotstring);
 BIF_DECL(BIF_InputHook);
+BIF_DECL(BIF_VarGetName);
 
 
 BIF_DECL(BIF_IsObject);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -18790,6 +18790,28 @@ BIF_DECL(BIF_Exception)
 
 
 
+BIF_DECL(BIF_VarGetName)
+{
+	if (aParam[0]->symbol != SYM_VAR)
+	{
+		// Incorrect usage: return empty string to indicate the error.
+		aResultToken.symbol = SYM_STRING;
+		aResultToken.marker = _T("");
+	}
+	else
+	{
+		int len = _tcslen(aParam[0]->var->ResolveAlias()->mName);
+		TCHAR *output = new TCHAR[len+1];
+		tmemcpy(output, aParam[0]->var->ResolveAlias()->mName, len+1);
+		aResultToken.symbol = SYM_STRING;
+		aResultToken.marker = output;
+		aResultToken.mem_to_free = output;
+		aResultToken.marker_length = len;
+	}
+}
+
+
+
 ////////////////////////////////////////////////////////
 // HELPER FUNCTIONS FOR TOKENS AND BUILT-IN FUNCTIONS //
 ////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

`VarName := VarGetName(Var)`

Retrieve the original variable name for a variable.
E.g. the original variable name may differ from the local variable name for a function.

## Implementation

A 2nd parameter, `Depth` could be added, to only go up n levels, rather than to the very top.
Perhaps -1 could indicate maximum depth, and be the default.
That said, I haven't wanted that functionality for myself.

## Rationale

This can be used in debugging e.g.:
```
myvar := 123
PrintVar(myvar)

PrintVar(ByRef param)
{
	MsgBox, % VarGetName(param) ": " param ;myvar: 123
}
```

Something I wanted when I first started using AutoHotkey around 10 years ago, although you get used to things not being available, and somehow get by without them.

Anyhow, I feel that this function or similar, is worth considering.

## Test code

```
;test VarGetName:

myvar := 123

MsgBox, % VarGetName(myvar) ;myvar
MyFunc(myvar)
MyFunc2(myvar)
PrintVar(myvar)

MyFunc(param)
{
	MsgBox, % VarGetName(param) ;param
}

MyFunc2(ByRef param)
{
	MsgBox, % VarGetName(param) ;myvar
}

PrintVar(ByRef param)
{
	MsgBox, % VarGetName(param) ": " param ;myvar: 123
}
```