### PR TITLE
v1: Added Buffer support to RegExMatch/RegExReplace.

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -15140,8 +15140,35 @@ BIF_DECL(BIF_RegEx)
 
 	// Since compiling succeeded, get info about other parameters.
 	TCHAR haystack_buf[MAX_NUMBER_SIZE];
-	LPTSTR haystack = ParamIndexToString(0, haystack_buf); // Load-time validation has already ensured that at least two actual parameters are present.
-	int haystack_length = (int)ParamIndexLength(0, haystack);
+	LPTSTR haystack;
+	int haystack_length;
+	if (Object *obj = dynamic_cast<Object *>(TokenToObject(*aParam[0])))
+	{
+		ExprTokenType t1;
+		ExprTokenType t2;
+		DWORD capacity;
+		if ((obj->GetItem(t1, _T("Ptr")))
+		&& (obj->GetItem(t2, _T("Size"))))
+		{
+			haystack = (LPTSTR)TokenToInt64(t1);
+#ifdef UNICODE
+			haystack_length = (int)TokenToInt64(t2) / 2;
+#else
+			haystack_length = (int)TokenToInt64(t2);
+#endif
+		}
+		else
+		{
+			aResultToken.symbol = SYM_STRING;
+			aResultToken.marker = _T("");
+			return;
+		}
+	}
+	else
+	{
+		haystack = ParamIndexToString(0, haystack_buf); // Load-time validation has already ensured that at least two actual parameters are present.
+		haystack_length = (int)ParamIndexLength(0, haystack);
+	}
 
 	int param_index = mode_is_replace ? 5 : 3;
 	int starting_offset;


### PR DESCRIPTION
## Introduction
This PR adds `Buffer` support to `RegExMatch` and `RegExReplace`.
The functions would be able to handle Buffer-like objects.

PR #237 backported Buffer support to various functions.
This function introduces a novel feature.

The error handling could be changed.

## Rationale

In AHK v1, it was common to create a large string, and write binary data to that string, and pass it to `RegExMatch` or `RegExReplace`.
In AHK v2, binary data is generally stored in `Buffer` objects, however, the `RegExXXX` functions don't currently support `Buffer` objects. Thus you'd have to create a large string, and copy the binary data to it.
It would be useful to do a binary search (`RegExMatch`) or binary count (`RegExReplace`) on a `Buffer` object.

For people who had previously used the `RegExXXX` functions on binary data stored in a string, ideally some alternative would be available.

Other uses include: performing binary searches at an odd address, and, searching a string but redefining what is considered the start/end of that string.

## Return value

At present, `RegExReplace` would return a string, even though the input value was a buffer. This could be changed. The AHK v1 documentation could state that the return value is undefined, when the input value is a `Buffer`, and in future, the return value could be a `Buffer` object.

And perhaps a similar change could be made regarding `RegExMatch` and `RegExMatchInfo` objects.

## Test code

```
;test RegExMatch/RegExReplace Buffer support:

vSize := 200
VarSetCapacity(vData, vSize, 0)
NumPut(Ord("a"), &vData, 60, "Short") ;1-based: char 31
NumPut(Ord("a"), &vData, 80, "Short") ;1-based: char 41
NumPut(Ord("a"), &vData, 100, "Short") ;1-based: char 51
oBuf := {Ptr:&vData, Size:vSize}

MsgBox, % RegExMatch(oBuf, "a") ;31
MsgBox, % RegExMatch(oBuf, "a",, 40) ;41
MsgBox, % RegExMatch(oBuf, "a",, 50) ;51

RegExReplace(oBuf, "a", "", vCount)
MsgBox, % vCount ;3

;==============================

;test invalid Buffer objects:

MsgBox, % RegExMatch({}, "a") ;(blank)
MsgBox, % RegExMatch({Ptr:&vData}, "a") ;(blank)
MsgBox, % RegExMatch({Size:vSize}, "a") ;(blank)

;==============================

;test that RegExMatch/RegExReplace still work with strings:

vText := "___a_a_a"

MsgBox, % RegExMatch(vText, "a") ;4

RegExReplace(vText, "a", "", vCount)
MsgBox, % vCount ;3

;==============================

;test RegExMatch/RegExReplace re. redefining the start/end of a string:

vText := "abcd_abcd_abcd_abcd_"

MsgBox, % RegExMatch(vText, "^a") ;1
MsgBox, % RegExMatch(vText, "^a",, 6) ;0
MsgBox, % RegExMatch({Ptr:&vText, Size:10*2}, "^a") ;1
MsgBox, % RegExMatch({Ptr:&vText+5*2, Size:10*2}, "^a") ;1

RegExReplace({Ptr:&vText+5*2, Size:10*2}, "a", "", vCount)
MsgBox, % vCount ;2
```