### PR TITLE
v2: Added ControlExist().

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -65,6 +65,7 @@ FuncEntry g_BIF[] =
 	BIFn(ControlChooseString, 2, 6, BIF_Control),
 	BIF1(ControlClick, 0, 8),
 	BIFn(ControlDeleteItem, 2, 6, BIF_Control),
+	BIFn(ControlExist, 1, 5, BIF_ControlGet),
 	BIFn(ControlFindItem, 2, 6, BIF_ControlGet),
 	BIF1(ControlFocus, 1, 5),
 	BIFn(ControlGetChecked, 1, 5, BIF_ControlGet),

--- a/source/script.h
+++ b/source/script.h
@@ -665,7 +665,7 @@ enum BuiltInFunctionID {
 	FID_ProcessExist = 0, FID_ProcessClose, FID_ProcessWait, FID_ProcessWaitClose, 
 	FID_MonitorGet = 0, FID_MonitorGetWorkArea, FID_MonitorGetCount, FID_MonitorGetPrimary, FID_MonitorGetName, 
 	FID_OnExit = 0, FID_OnClipboardChange, FID_OnError,
-	FID_ControlGetChecked = 0, FID_ControlGetEnabled, FID_ControlGetVisible, FID_ControlFindItem, FID_ControlGetIndex, FID_ControlGetChoice, FID_ControlGetItems, FID_ListViewGetContent, FID_EditGetLineCount, FID_EditGetCurrentLine, FID_EditGetCurrentCol, FID_EditGetLine, FID_EditGetSelectedText, FID_ControlGetStyle, FID_ControlGetExStyle, FID_ControlGetHwnd,
+	FID_ControlGetChecked = 0, FID_ControlGetEnabled, FID_ControlGetVisible, FID_ControlFindItem, FID_ControlGetIndex, FID_ControlGetChoice, FID_ControlGetItems, FID_ListViewGetContent, FID_EditGetLineCount, FID_EditGetCurrentLine, FID_EditGetCurrentCol, FID_EditGetLine, FID_EditGetSelectedText, FID_ControlGetStyle, FID_ControlGetExStyle, FID_ControlGetHwnd, FID_ControlExist,
 	FID_ControlSetChecked = 0, FID_ControlSetEnabled, FID_ControlShow, FID_ControlHide, FID_ControlSetStyle, FID_ControlSetExStyle, FID_ControlShowDropDown, FID_ControlHideDropDown, FID_ControlAddItem, FID_ControlDeleteItem, FID_ControlChooseIndex, FID_ControlChooseString, FID_EditPaste,
 	FID_ControlSend = SCM_NOT_RAW, FID_ControlSendText = SCM_RAW_TEXT,
 	FID_DriveEject = 0, FID_DriveLock, FID_DriveUnlock, FID_DriveSetLabel,

--- a/source/script_autoit.cpp
+++ b/source/script_autoit.cpp
@@ -650,6 +650,13 @@ BIF_DECL(BIF_ControlGet)
 	// aControl might not be a ClassNN, so don't rely on it for class checks.
 	//LPTSTR aControl = ParamIndexToString(0, control_buf);
 
+	if (control_cmd == FID_ControlExist)
+	{
+		HWND target_window, control_window;
+		DetermineTargetControl(control_window, target_window, aResultToken, aParam, aParamCount, 0, false);
+		_f_return((size_t)control_window);
+	}
+
 	DETERMINE_TARGET_CONTROL(0);
 
 	DWORD_PTR dwResult, index, length, item_length, u, item_count;


### PR DESCRIPTION
## Description
```
Hwnd := ControlExist(Control [, WinTitle, WinText, ExcludeTitle, ExcludeText])
```
Similar to `ControlGetHwnd`, except it does not throw, it instead returns 0 if no matching control is found.

The `ControlExist`/`ControlGetHwnd` pairing would be similar to the `WinExist`/`WinGetID` pairing.

The function is useful for succinctly checking whether a control exists, and retrieving its window handle. It avoids needing the try/catch code that `ControlGetHwnd` would need.

## Test code

```
;test ControlExist:

q::
{
	hCtl := ControlGetHwnd("Edit1", "A")
	MsgBox(hCtl)
}

w::
{
	hCtl := ControlExist("Edit1", "A")
	MsgBox(hCtl)
}

e::
{
	hCtl := ControlGetHwnd("Edit2", "A") ;throws on Notepad main window
	MsgBox(hCtl)
}

r::
{
	hCtl := ControlExist("Edit2", "A") ;returns 0 on Notepad main window
	MsgBox(hCtl)
}
```