### PR TITLE
v1: Backported VerCompare() from alpha branch.

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8674,6 +8674,12 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 0;
 		max_params = 3;
 	}
+	else if (!_tcsicmp(func_name, _T("VerCompare")))
+	{
+		bif = BIF_VerCompare;
+		min_params = 2;
+		max_params = 2;
+	}
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3358,6 +3358,7 @@ BIF_DECL(BIF_Trim); // L31: Also handles LTrim and RTrim.
 
 BIF_DECL(BIF_Hotstring);
 BIF_DECL(BIF_InputHook);
+BIF_DECL(BIF_VerCompare);
 
 
 BIF_DECL(BIF_IsObject);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -18790,6 +18790,16 @@ BIF_DECL(BIF_Exception)
 
 
 
+BIF_DECL(BIF_VerCompare)
+{
+	TCHAR buf[MAX_NUMBER_SIZE];
+	LPTSTR a = ParamIndexToString(0, aResultToken.buf);
+	LPTSTR b = ParamIndexToString(1, buf);
+	aResultToken.value_int64 = CompareVersion(a, b);
+}
+
+
+
 ////////////////////////////////////////////////////////
 // HELPER FUNCTIONS FOR TOKENS AND BUILT-IN FUNCTIONS //
 ////////////////////////////////////////////////////////


### PR DESCRIPTION
## Introduction

A backport attempt for `VerCompare`.

Original commit: https://github.com/Lexikos/AutoHotkey_L/commit/8a015f75017e1fad58575b959a7aa6cc49c58f3c.

## Test code

```
;==================================================

;test code: VerCompare (AHK v1)

if (VerCompare(A_AhkVersion, "2.0") < 0)
    MsgBox("This version < 2.0; possibly a pre-release version.")
else
    MsgBox("This version is 2.0 or later.")

MsgBox(VerCompare("1.20.0", "1.3"))  ; Returns 1
MsgBox(StrCompare("1.20.0", "1.3"))  ; Returns -1

MsgBox(VerCompare("2.0-a137", "2.0-a136"))  ; Returns 1
MsgBox(VerCompare("2.0-a137", "2.0"))  ; Returns -1
MsgBox(VerCompare("10.2-beta.3", "10.2.0"))  ; Returns -1

;==================================================

MsgBox(Text)
{
	MsgBox, % Text
}

StrCompare(ByRef String1, ByRef String2, CaseSensitive:=0) ;ByRef for performance
{
	local Output, SCS
	SCS := A_StringCaseSense
	if (CaseSensitive = 1)
		StringCaseSense, % "On"
	else if (SCS = "On")
		StringCaseSense, % "Locale"
	Output := ("" String1 > "" String2) ? 1 : ("" String1 < "" String2) ? -1 : 0
	StringCaseSense, % SCS
	return Output
}

;==================================================
```

## Btw

Btw.
Congrats on AHK v2.0-beta.1. Excellent Stuff.
Sometimes in everyday life, when something good happens, I say Fantastikos.