### PR TITLE
v1: Backported A_InitialWorkingDir from alpha branch.

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -104,6 +104,7 @@ VarEntry g_BIV_A[] =
 	A_(IconNumber),
 	A_(IconTip),
 	A_x(Index, BIV_LoopIndex),
+	A_(InitialWorkingDir),
 	A_x(IPAddress1, BIV_IPAddress),
 	A_x(IPAddress2, BIV_IPAddress),
 	A_x(IPAddress3, BIV_IPAddress),

--- a/source/script.h
+++ b/source/script.h
@@ -3220,6 +3220,7 @@ BIV_DECL_R (BIV_Is64bitOS);
 BIV_DECL_R (BIV_Language);
 BIV_DECL_R (BIV_UserName_ComputerName);
 BIV_DECL_R (BIV_WorkingDir);
+BIV_DECL_R (BIV_InitialWorkingDir);
 BIV_DECL_R (BIV_WinDir);
 BIV_DECL_R (BIV_Temp);
 BIV_DECL_R (BIV_ComSpec);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -11677,6 +11677,13 @@ VarSizeType BIV_WorkingDir(LPTSTR aBuf, LPTSTR aVarName)
 		// Above avoids subtracting 1 to be conservative and to reduce code size (due to the need to otherwise check for zero and avoid subtracting 1 in that case).
 }
 
+VarSizeType BIV_InitialWorkingDir(LPTSTR aBuf, LPTSTR aVarName)
+{
+	if (aBuf)
+		_tcscpy(aBuf, g_WorkingDirOrig);
+	return (VarSizeType)_tcslen(g_WorkingDirOrig);
+}
+
 VarSizeType BIV_WinDir(LPTSTR aBuf, LPTSTR aVarName)
 {
 	TCHAR buf[MAX_PATH]; // MSDN (2018): The uSize parameter "should be set to MAX_PATH."


### PR DESCRIPTION
## Introduction

A backport attempt for `A_InitialWorkingDir`.

Original commit: https://github.com/Lexikos/AutoHotkey_L/commit/31577e61.

## Test code

```
;test code: A_InitialWorkingDir (AHK v1)

MsgBox, % A_InitialWorkingDir "`r`n`r`n" A_WorkingDir

SetWorkingDir, % A_Desktop

MsgBox, % A_InitialWorkingDir "`r`n`r`n" A_WorkingDir
```