### PR TITLE
v1: Backported Object.Has() from alpha branch. Added ObjHas().

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8551,7 +8551,6 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		BIF_OBJ_CASE(Length, 		0, 0)
 		BIF_OBJ_CASE(MinIndex, 		0, 0)
 		BIF_OBJ_CASE(MaxIndex, 		0, 0)
-		BIF_OBJ_CASE(HasKey,		1, 1) // key
 		BIF_OBJ_CASE(GetCapacity,	0, 1) // [key]
 		BIF_OBJ_CASE(SetCapacity,	1, 2) // [key,] new_capacity
 		BIF_OBJ_CASE(GetAddress,	1, 1) // key
@@ -8559,6 +8558,12 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		BIF_OBJ_CASE(Clone,			0, 0)
 		BIF_OBJ_CASE(BindMethod,	1, 10000) // obj, method [, param...]
 #undef BIF_OBJ_CASE
+		else if (!_tcsicmp(suffix, _T("HasKey")) || !_tcsicmp(suffix, _T("Has")))
+		{
+			bif = BIF_ObjHasKey;
+			min_params = 2;
+			max_params = 2;
+		}
 		else if (!_tcsicmp(suffix, _T("AddRef")) || !_tcsicmp(suffix, _T("Release")))
 			bif = BIF_ObjAddRefRelease;
 		else if (!_tcsicmp(suffix, _T("RawSet")))

--- a/source/script_object.cpp
+++ b/source/script_object.cpp
@@ -765,7 +765,7 @@ int Object::GetBuiltinID(LPCTSTR aName)
 	switch (toupper(*aName))
 	{
 	case 'H':
-		if (!_tcsicmp(aName, _T("HasKey")))
+		if (!_tcsicmp(aName, _T("HasKey")) || !_tcsicmp(aName, _T("Has")))
 			return FID_ObjHasKey;
 		break;
 	case 'N':


### PR DESCRIPTION
## Introduction

A backport attempt for `Object.Has()`.

## Test code

```
;test code: Object.Has() and ObjHas() (AHK v1)

oArray := [1, 2, 3]
MsgBox, % oArray.Has(2) ;1
MsgBox, % oArray.Has(4) ;0
MsgBox, % ObjHas(oArray, 2) ;1
MsgBox, % ObjHas(oArray, 4) ;0

oMap := Object("a",1, "b",2, "c",3)
MsgBox, % oMap.Has("b") ;1
MsgBox, % oMap.Has("d") ;0
MsgBox, % ObjHas(oMap, "b") ;1
MsgBox, % ObjHas(oMap, "d") ;0

```