### PR TITLE
v1: Added Object.Length and Object.Count.

### DIFF
--- a/source/script_object.cpp
+++ b/source/script_object.cpp
@@ -590,6 +590,21 @@ ResultType STDMETHODCALLTYPE Object::Invoke(
 					return OK;
 				}
 			}
+			//
+			// BUILT-IN "LENGTH" AND "COUNT" PROPERTIES
+			//
+			else if (param_count_excluding_rvalue == 1 && IS_INVOKE_GET && !_tcsicmp(key.s, _T("length")))
+			{
+				IntKeyType max_index = mKeyOffsetObject ? mFields[mKeyOffsetObject - 1].key.i : 0;
+				aResultToken.symbol = SYM_INTEGER;
+				aResultToken.value_int64 = (__int64)(max_index > 0 ? max_index : 0);
+				return OK;
+			}
+			else if (param_count_excluding_rvalue == 1 && IS_INVOKE_GET && !_tcsicmp(key.s, _T("count")))
+			{
+				aResultToken.SetValue((__int64)mFieldCount);
+				return OK;
+			}
 		} // if (!IS_INVOKE_META && key_type == SYM_STRING)
 	} // if (!field)
 


### PR DESCRIPTION
## Introduction

A backport attempt for `Object.Length` and `Object.Count`.
The behaviour intends to match `Object.Base`: if a `Length` or `Count` key is created, then that value is returned, not the Length/Count.

If these count as breaking compatibility, then these would be great candidates for a `#Compat` or `#Unlock` (or another name) directive, to unlock them. I would use them all the time!

## Test code

```
test code: Object.Length and Object.Count (AHK v1)

oArray := [1, 2, 3]
MsgBox, % oArray.Length() ;3
MsgBox, % oArray.Length ;3
MsgBox, % oArray.Count() ;3
MsgBox, % oArray.Count ;3

oMap := Object("a",1, "b",2, "c",3)
MsgBox, % oMap.Length() ;0
MsgBox, % oMap.Length ;0
MsgBox, % oMap.Count() ;3
MsgBox, % oMap.Count ;3

MsgBox

oMap.Length := "abc"
oMap.Count := "def"

MsgBox, % oMap.Length() ;(blank)
MsgBox, % ObjLength(oMap) ;0
MsgBox, % oMap.Length ;abc

MsgBox, % oMap.Count() ;(blank)
MsgBox, % ObjCount(oMap) ;5
MsgBox, % oMap.Count ;def
```