### PR TITLE
v2: Added RegCreateKey().

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -260,6 +260,7 @@ FuncEntry g_BIF[] =
 	BIFn(ProcessWait, 1, 2, BIF_Process),
 	BIFn(ProcessWaitClose, 1, 2, BIF_Process),
 	BIF1(Random, 0, 2),
+	BIFn(RegCreateKey, 1, 1, BIF_Reg),
 	BIFn(RegDelete, 0, 2, BIF_Reg),
 	BIFn(RegDeleteKey, 0, 1, BIF_Reg),
 	BIFn(RegExMatch, 2, 4, BIF_RegEx, {3}),

--- a/source/script.h
+++ b/source/script.h
@@ -666,7 +666,7 @@ enum BuiltInFunctionID {
 	FID_DriveGetList = 0, FID_DriveGetFilesystem, FID_DriveGetLabel, FID_DriveGetSerial, FID_DriveGetType, FID_DriveGetStatus, FID_DriveGetStatusCD, FID_DriveGetCapacity, FID_DriveGetSpaceFree,
 	FID_EnvGet = 0, FID_EnvSet,
 	FID_PostMessage = 0, FID_SendMessage,
-	FID_RegRead = 0, FID_RegWrite, FID_RegDelete, FID_RegDeleteKey,
+	FID_RegRead = 0, FID_RegWrite, FID_RegDelete, FID_RegDeleteKey, FID_RegCreateKey,
 	FID_SoundGetVolume = 0, FID_SoundGetMute, FID_SoundGetName, FID_SoundGetInterface, FID_SoundSetVolume, FID_SoundSetMute,
 	FID_RunWait = 0, FID_ClipWait, FID_KeyWait, FID_WinWait, FID_WinWaitClose, FID_WinWaitActive, FID_WinWaitNotActive,
 	// For BIF_SetBIV (functions corresponding to built-in vars): keep the order of these in sync with the array in BIF_SetBIV.

--- a/source/script_registry.cpp
+++ b/source/script_registry.cpp
@@ -673,6 +673,16 @@ BIF_DECL(BIF_Reg)
 	{
 	case FID_RegRead:  RegRead(aResultToken, root_key, sub_key, value_name, ParamIndexIsOmitted(2) ? nullptr : aParam[2]); break;
 	case FID_RegWrite: RegWrite(aResultToken, *value, value_type, root_key, sub_key, value_name); break;
+	case FID_RegCreateKey:
+	{
+		HKEY hRegKey;
+		DWORD dwRes;
+		LONG result = RegCreateKeyEx(root_key, sub_key, 0, _T(""), REG_OPTION_NON_VOLATILE, KEY_WRITE | g->RegView, NULL, &hRegKey, &dwRes);
+		g->LastError = result;
+		if (result != ERROR_SUCCESS)
+			_f_throw_win32(result);
+		break;
+	}
 	default:           RegDelete(aResultToken, root_key, sub_key, value_name); break;
 	}
 


### PR DESCRIPTION
## Description

`RegCreateKey(KeyName)`

Creates a registry key.

## Rationale

Currently, `RegWrite` is available, but this creates a key *and* a value.
This would only create a key.

Modelled on `RegDeleteKey` and `DirCreate`.

## Implementation

All regarding the `case FID_RegCreateKey` code block:

Implementation possibilities for `RegCreateKeyEx` (perhaps ignore):
`samDesired`: 3 possibilities: `KEY_WRITE` or `KEY_CREATE_SUB_KEY | STANDARD_RIGHTS_WRITE` or `KEY_CREATE_SUB_KEY`
`lpClass`: `_T("")` or `NULL` [elsewhere the source code uses `_T("")`]

Implementation possibilities for `RegCreateKeyEx` (probably implement):
`dwRes`: `&dwRes` or `NULL` [i.e. change to `NULL`, and omit definition line: `DWORD dwRes`]

Implementation correction:
This should be added under `RegCreateKeyEx`, just before `break`:
`RegCloseKey(hRegKey)`

Note:
`g->RegView` returns `KEY_WOW64_32KEY` or `KEY_WOW64_64KEY` (not 32 or 64).

## Test code

```
;test code: RegCreateKey (AHK v2)

RegCreateKey("HKEY_CURRENT_USER\Software\Microsoft\Notepad\MyKey0")

Loop 4
	RegCreateKey("HKEY_CURRENT_USER\Software\Microsoft\Notepad\MyKey" A_Index)

MsgBox("done")
```

## The Final PR

Most likely, this is the final PR, re. my view of a 'complete AutoHotkey'.
But I will at least explore these (names can be changed):

RemoteBuffer class. [Similar to this](https://autohotkey.com/board/topic/11173-module-remotebuffer-20/page-2#entry501339).

DTPGetDate/DTPSetDate. Get/set external `SysDateTimePick32` control dates.

BinCompare/BinCopy.
InBuf. Find nth/nth-to-last occurrence.
BinDiff/StrDiff. 2 buffers/strings. Find nth/nth-to-last difference (byte/char).

Struct class. (AHK code prototype, not C++.)