### PR TITLE
Fix FlatVector::Remove

### DIFF
--- a/source/script_object.h
+++ b/source/script_object.h
@@ -170,7 +170,7 @@ public:
 	{
 		auto v = Value();
 		ASSERT(i >= 0 && i + count <= data->length);
-		FreeRange(i, count);
+		FreeRange(i, i + count);
 		memmove(v + i, v + i + count, (data->length - i - count) * sizeof(T));
 		data->length -= count;
 	}


### PR DESCRIPTION
FreeRange is designed to remove a range from + to rather than a count of items. count = 1 makes only sense if i=0 since otherwise the for loop is never executed and Data not freed: for (; i < count; ++i)