### PR TITLE
mark some static arrays as const so they are not reinitialized

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -3548,7 +3548,7 @@ inline ResultType Script::IsDirective(LPTSTR aBuf)
 
 		int i;
 
-		static LPTSTR sWarnTypes[] = { WARN_TYPE_STRINGS };
+		static const LPCTSTR sWarnTypes[] = { WARN_TYPE_STRINGS };
 		WarnType warnType = WARN_ALL; // Set default.
 		if (*parameter)
 		{
@@ -3562,7 +3562,7 @@ inline ResultType Script::IsDirective(LPTSTR aBuf)
 			warnType = (WarnType)i;
 		}
 
-		static LPTSTR sWarnModes[] = { WARN_MODE_STRINGS };
+		static const LPCTSTR sWarnModes[] = { WARN_MODE_STRINGS };
 		WarnMode warnMode = WARNMODE_MSGBOX; // Set default.
 		if (*param2)
 		{

--- a/source/script_com.cpp
+++ b/source/script_com.cpp
@@ -860,7 +860,7 @@ HRESULT TokenToVarType(ExprTokenType &aToken, VARTYPE aVarType, void *apValue)
 	// the following would be to switch(aVarType) and copy using the appropriate pointer
 	// type, but disassembly shows that approach produces larger code and internally uses
 	// an array of sizes like this anyway:
-	static char vt_size[] = {U,U,2,4,4,8,8,8,P,P,4,2,0,P,0,U,1,1,2,4,8,8,4,4,U,U,U,U,U,U,U,U,U,U,U,U,U,P,P};
+	static const char vt_size[] = {U,U,2,4,4,8,8,8,P,P,4,2,0,P,0,U,1,1,2,4,8,8,4,4,U,U,U,U,U,U,U,U,U,U,U,U,U,P,P};
 	size_t vsize = (aVarType < _countof(vt_size)) ? vt_size[aVarType] : 0;
 	if (!vsize)
 		return DISP_E_BADVARTYPE;

--- a/source/script_registry.cpp
+++ b/source/script_registry.cpp
@@ -325,7 +325,7 @@ ResultType Line::RegRead(HKEY aRootKey, LPTSTR aRegSubkey, LPTSTR aValueName)
 
 			int j = 0;
 			DWORD i, n; // i and n must be unsigned to work
-			TCHAR szHexData[] = _T("0123456789ABCDEF");  // Access to local vars might be faster than static ones.
+			static const TCHAR szHexData[] = _T("0123456789ABCDEF");
 			for (i = 0; i < dwRes; ++i)
 			{
 				n = pRegBuffer[i];				// Get the value and convert to 2 digit hex

--- a/source/util.cpp
+++ b/source/util.cpp
@@ -198,7 +198,7 @@ ResultType YYYYMMDDToSystemTime(LPTSTR aYYYYMMDD, SYSTEMTIME &aSystemTime, bool 
 	else // Month is in-range, which is necessary for the method below to work safely.
 	{
 		// Day-of-week code by Tomohiko Sakamoto:
-		static int t[] = {0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4};
+		static const int t[] = {0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4};
 		int y = aSystemTime.wYear;
 		y -= aSystemTime.wMonth < 3;
 		aSystemTime.wDayOfWeek = (y + y/4 - y/100 + y/400 + t[aSystemTime.wMonth-1] + aSystemTime.wDay) % 7;


### PR DESCRIPTION
This saves code size and time, particularly in frequently called
functions and loops