### PR TITLE
remove inclusion of unused header

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -15,7 +15,6 @@ GNU General Public License for more details.
 */
 
 #include "stdafx.h" // pre-compiled headers
-#include <olectl.h> // for OleLoadPicture()
 #include <winioctl.h> // For PREVENT_MEDIA_REMOVAL and CD lock/unlock.
 #include "qmath.h" // Used by Transform() [math.h incurs 2k larger code size just for ceil() & floor()]
 #include "mt19937ar-cok.h" // for sorting in random order


### PR DESCRIPTION
script2.cpp doesn't need olectl.h