### PR TITLE
Changing the way CheckScriptTimers() resloves next_timer

### DIFF
--- a/source/script.h
+++ b/source/script.h
@@ -2943,7 +2943,8 @@ public:
 	bool mOnClipboardChangeIsRunning;
 	ExitReasons mExitReason;
 
-	ScriptTimer *mFirstTimer, *mLastTimer;  // The first and last script timers in the linked list.
+	ScriptTimer *mFirstTimer, *mLastTimer;  // The first and last script timers in the linked list. 
+											// At least DeleteTimer relies on timers never being inserted anywhere else than after the last timer in the linked list.
 	UINT mTimerCount, mTimerEnabledCount;
 
 	UserMenu *mFirstMenu, *mLastMenu;
@@ -3027,7 +3028,7 @@ public:
 	};
 	ResultType UpdateOrCreateTimer(IObject *aCallback
 		, bool aUpdatePeriod, __int64 aPeriod, bool aUpdatePriority, int aPriority);
-	void DeleteTimer(IObject *aCallback);
+	void DeleteTimer(IObject *aCallback, ScriptTimer **aNextTimer = nullptr);
 	LPTSTR DefaultDialogTitle();
 	UserFunc* CreateHotFunc();
 	ResultType DefineFunc(LPTSTR aBuf, bool aStatic = false, bool aIsInExpression = false);


### PR DESCRIPTION
**Reason**, `next_timer` might be deleted via `timer.mCallback`'s `__delete` routine.
**About**, `DeleteTimer` outputs `next_timer` on request if it is still present in the linked list after `delete timer` is done. 

**Examples**, explicitly deleted via `SetTimer`
```autohotkey
class x {
	__delete()=>settimer(y, 0)
	call()=>0
}
f() => ''
y := f.bind()
settimer x(), -1
settimer y, -50
``` 
And indirectly via interruption,
```autohotkey
class x {	
	__delete()=>sleep(100)
	call()=>0
}
settimer x(), -1
settimer x(), -50
```
