### PR TITLE
Changing VK_ESCAPE to reset hotstring detection

### DIFF
--- a/source/hook.cpp
+++ b/source/hook.cpp
@@ -2536,6 +2536,9 @@ bool CollectInput(KBDLLHOOKSTRUCT &aEvent, const vk_type aVK, const sc_type aSC,
 	{
 		switch (aVK)
 		{
+		case VK_ESCAPE:		// Reset hotstring detection if user presses esc, 
+							// as this commonly indicates a wish to "abort" rather than producing a character.
+			char_count = 0; // To avoid storing VK_ESCAPE in g_HSBuf below.
 		case VK_LEFT:
 		case VK_RIGHT:
 		case VK_DOWN:


### PR DESCRIPTION
New, `esc` causes the hotstring recognition process to reset.

Before, pressing `esc` while collecting input for hotstrings, `chr(27)` was stored in the hotstring buffer.

Reason, `esc` is more commonly used to _abort_ rather than producing _text_.

_edit_, fixed comment, to avoid alerting the word repetition police