### PR TITLE
Converting ACT_TOOLTIP to BIF_ToolTip

### DIFF
--- a/source/defines.h
+++ b/source/defines.h
@@ -615,7 +615,7 @@ enum enum_act {
 // All others are not included in g_act, and are only used with BIF_PerformAction:
 // ================================================================================
 , ACT_EXITAPP
-, ACT_TOOLTIP, ACT_TRAYTIP
+, ACT_TRAYTIP
 , ACT_RUNAS, ACT_DOWNLOAD
 , ACT_SEND, ACT_SENDTEXT, ACT_SENDINPUT, ACT_SENDPLAY, ACT_SENDEVENT
 , ACT_SENDMODE, ACT_SENDLEVEL, ACT_COORDMODE, ACT_SETDEFAULTMOUSESPEED

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -325,7 +325,7 @@ FuncEntry g_BIF[] =
 	BIF1(SysGetIPAddresses, 0, 0),
 	BIF1(Tan, 1, 1),
 	BIFA(Thread, 1, 3, ACT_THREAD),
-	BIFA(ToolTip, 0, 4, ACT_TOOLTIP),
+	BIF1(ToolTip, 0, 4),
 	BIF1(TraySetIcon, 0, 3),
 	BIFA(TrayTip, 0, 3, ACT_TRAYTIP),
 	BIFn(Trim, 1, 2, BIF_Trim),
@@ -11918,10 +11918,6 @@ ResultType Line::Perform()
 		return ShowMainWindow(MAIN_MODE_VARS, false); // Pass "unrestricted" when the command is explicitly used in the script.
 	case ACT_LISTHOTKEYS:
 		return ShowMainWindow(MAIN_MODE_HOTKEYS, false); // Pass "unrestricted" when the command is explicitly used in the script.
-
-	case ACT_TOOLTIP:
-		return ToolTip(FOUR_ARGS);
-
 	case ACT_TRAYTIP:
 		return TrayTip(THREE_ARGS);
 

--- a/source/script.h
+++ b/source/script.h
@@ -766,7 +766,6 @@ private:
 	ResultType IniWrite(LPTSTR aValue, LPTSTR aFilespec, LPTSTR aSection, LPTSTR aKey);
 	ResultType IniDelete(LPTSTR aFilespec, LPTSTR aSection, LPTSTR aKey);
 
-	ResultType ToolTip(LPTSTR aText, LPTSTR aX, LPTSTR aY, LPTSTR aID);
 	ResultType TrayTip(LPTSTR aText, LPTSTR aTitle, LPTSTR aOptions);
 
 	static ResultType SetToggleState(vk_type aVK, ToggleValueType &ForceLock, LPTSTR aToggleText);
@@ -3335,6 +3334,7 @@ BIF_DECL(BIF_TraySetIcon);
 
 BIF_DECL(BIF_MsgBox);
 BIF_DECL(BIF_InputBox);
+BIF_DECL(BIF_ToolTip);
 
 // Gui
 BIF_DECL(BIF_GuiFromHwnd);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -40,193 +40,6 @@ GNU General Public License for more details.
 // Window related //
 ////////////////////
 
-
-
-ResultType Line::ToolTip(LPTSTR aText, LPTSTR aX, LPTSTR aY, LPTSTR aID)
-{
-	int window_index = *aID ? ATOI(aID) - 1 : 0;
-	if (window_index < 0 || window_index >= MAX_TOOLTIPS)
-		return LineError(_T("Max window number is ") MAX_TOOLTIPS_STR _T("."), FAIL_OR_OK, aID);
-	HWND tip_hwnd = g_hWndToolTip[window_index];
-
-	// Destroy windows except the first (for performance) so that resources/mem are conserved.
-	// The first window will be hidden by the TTM_UPDATETIPTEXT message if aText is blank.
-	// UPDATE: For simplicity, destroy even the first in this way, because otherwise a script
-	// that turns off a non-existent first tooltip window then later turns it on will cause
-	// the window to appear in an incorrect position.  Example:
-	// ToolTip
-	// ToolTip, text, 388, 24
-	// Sleep, 1000
-	// ToolTip, text, 388, 24
-	if (!*aText)
-	{
-		if (tip_hwnd && IsWindow(tip_hwnd))
-			DestroyWindow(tip_hwnd);
-		g_hWndToolTip[window_index] = NULL;
-		return OK;
-	}
-
-	bool one_or_both_coords_unspecified = !*aX || !*aY;
-	POINT pt, pt_cursor;
-	if (one_or_both_coords_unspecified)
-	{
-		// Don't call GetCursorPos() unless absolutely needed because it seems to mess
-		// up double-click timing, at least on XP.  UPDATE: Is isn't GetCursorPos() that's
-		// interfering with double clicks, so it seems it must be the displaying of the ToolTip
-		// window itself.
-		GetCursorPos(&pt_cursor);
-		pt.x = pt_cursor.x + 16;  // Set default spot to be near the mouse cursor.
-		pt.y = pt_cursor.y + 16;  // Use 16 to prevent the tooltip from overlapping large cursors.
-		// Update: Below is no longer needed due to a better fix further down that handles multi-line tooltips.
-		// 20 seems to be about the right amount to prevent it from "warping" to the top of the screen,
-		// at least on XP:
-		//if (pt.y > dtw.bottom - 20)
-		//	pt.y = dtw.bottom - 20;
-	}
-
-	POINT origin = {0};
-	if (*aX || *aY) // Need the offsets.
-		CoordToScreen(origin, COORD_MODE_TOOLTIP);
-
-	// This will also convert from relative to screen coordinates if appropriate:
-	if (*aX)
-		pt.x = ATOI(aX) + origin.x;
-	if (*aY)
-		pt.y = ATOI(aY) + origin.y;
-
-	HMONITOR hmon = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
-	MONITORINFO mi;
-	mi.cbSize = sizeof(mi);
-	GetMonitorInfo(hmon, &mi);
-	// v1.1.34: Use work area to avoid trying to overlap the taskbar on newer OSes, which otherwise
-	// would cause the tooltip to appear at the top of the screen instead of the position we specify.
-	// This was observed on Windows 10 and 11, and confirmed to not apply to Windows 7 or XP.
-	RECT dtw = g_os.IsWin8orLater() ? mi.rcWork : mi.rcMonitor;
-
-	TOOLINFO ti = {0};
-	ti.cbSize = sizeof(ti);
-	ti.uFlags = TTF_TRACK;
-	ti.lpszText = aText;
-	// Note that the ToolTip won't work if ti.hwnd is assigned the HWND from GetDesktopWindow().
-	// All of ti's other members are left at NULL/0, including the following:
-	//ti.hinst = NULL;
-	//ti.uId = 0;
-	//ti.rect.left = ti.rect.top = ti.rect.right = ti.rect.bottom = 0;
-
-	// My: This does more harm that good (it causes the cursor to warp from the right side to the left
-	// if it gets to close to the right side), so for now, I did a different fix (above) instead:
-	//ti.rect.bottom = dtw.bottom;
-	//ti.rect.right = dtw.right;
-	//ti.rect.top = dtw.top;
-	//ti.rect.left = dtw.left;
-
-	// No need to use SendMessageTimeout() since the ToolTip() is owned by our own thread, which
-	// (since we're here) we know is not hung or heavily occupied.
-
-	// v1.0.40.12: Added the IsWindow() check below to recreate the tooltip in cases where it was destroyed
-	// by external means such as Alt-F4 or WinClose.
-	bool newly_created = !tip_hwnd || !IsWindow(tip_hwnd);
-	if (newly_created)
-	{
-		// This this window has no owner, it won't be automatically destroyed when its owner is.
-		// Thus, it will be explicitly by the program's exit function.
-		tip_hwnd = g_hWndToolTip[window_index] = CreateWindowEx(WS_EX_TOPMOST, TOOLTIPS_CLASS, NULL, TTS_NOPREFIX | TTS_ALWAYSTIP
-			, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, NULL, NULL, NULL, NULL);
-		SendMessage(tip_hwnd, TTM_ADDTOOL, 0, (LPARAM)(LPTOOLINFO)&ti);
-	}
-
-	// v1.1.34: Fixed to use the appropriate monitor, in case it's sized differently to the primary.
-	// Also fixed to account for incorrect DPI scaling done by the tooltip control; i.e. a value of
-	// n ends up allowing tooltips n*g_ScreenDPI/96 pixels wide.  TTM_SETMAXTIPWIDTH seems to want
-	// the max text width, not the max window width, so adjust for that.  Do this every time since
-	// the tooltip might be moving between screens of different sizes.
-	RECT text_rect = dtw;
-	SendMessage(tip_hwnd, TTM_ADJUSTRECT, FALSE, (LPARAM)&text_rect);
-	SendMessage(tip_hwnd, TTM_SETMAXTIPWIDTH, 0, (LPARAM)((text_rect.right - text_rect.left) * 96 / g_ScreenDPI));
-
-	if (newly_created)
-	{
-		// Must do these next two when the window is first created, otherwise GetWindowRect() below will retrieve
-		// a tooltip window size that is quite a bit taller than it winds up being:
-		SendMessage(tip_hwnd, TTM_TRACKPOSITION, 0, (LPARAM)MAKELONG(pt.x, pt.y));
-		SendMessage(tip_hwnd, TTM_TRACKACTIVATE, TRUE, (LPARAM)&ti);
-	}
-	// Bugfix for v1.0.21: The below is now called unconditionally, even if the above newly created the window.
-	// If this is not done, the tip window will fail to appear the first time it is invoked, at least when
-	// all of the following are true:
-	// 1) Windows XP;
-	// 2) Common controls v6 (via manifest);
-	// 3) "Control Panel >> Display >> Effects >> Use transition >> Fade effect" setting is in effect.
-	// v1.1.34: Avoid TTM_UPDATETIPTEXT if the text hasn't changed, to reduce flicker.  The behaviour described
-	// above could not be replicated, EVEN ON WINDOWS XP.  Whether it was ever observed on other OSes is unknown.
-	if (!newly_created && !ToolTipTextEquals(tip_hwnd, aText))
-		SendMessage(tip_hwnd, TTM_UPDATETIPTEXT, 0, (LPARAM)&ti);
-
-	RECT ttw = {0};
-	GetWindowRect(tip_hwnd, &ttw); // Must be called this late to ensure the tooltip has been created by above.
-	int tt_width = ttw.right - ttw.left;
-	int tt_height = ttw.bottom - ttw.top;
-
-	// v1.0.21: Revised for multi-monitor support.  I read somewhere that dtw.left can be negative (perhaps
-	// if the secondary monitor is to the left of the primary).  So it seems best to assume it is possible:
-	if (pt.x + tt_width >= dtw.right)
-		pt.x = dtw.right - tt_width - 1;
-	if (pt.y + tt_height >= dtw.bottom)
-		pt.y = dtw.bottom - tt_height - 1;
-	// It seems best not to have each of the below paired with the above.  This is because it allows
-	// the flexibility to explicitly move the tooltip above or to the left of the screen.  Such a feat
-	// should only be possible if done via explicitly passed-in negative coordinates for aX and/or aY.
-	// In other words, it should be impossible for a tooltip window to follow the mouse cursor somewhere
-	// off the virtual screen because:
-	// 1) The mouse cursor is normally trapped within the bounds of the virtual screen.
-	// 2) The tooltip window defaults to appearing South-East of the cursor.  It can only appear
-	//    in some other quadrant if jammed against the right or bottom edges of the screen, in which
-	//    case it can't be partially above or to the left of the virtual screen unless it's really
-	//    huge, which seems very unlikely given that it's limited to the maximum width of the
-	//    primary display as set by TTM_SETMAXTIPWIDTH above.
-	//else if (pt.x < dtw.left) // Should be impossible for this to happen due to mouse being off the screen.
-	//	pt.x = dtw.left;      // But could happen if user explicitly passed in a coord that was too negative.
-	//...
-	//else if (pt.y < dtw.top)
-	//	pt.y = dtw.top;
-
-	if (one_or_both_coords_unspecified)
-	{
-		// Since Tooltip is being shown at the cursor's coordinates, try to ensure that the above
-		// adjustment doesn't result in the cursor being inside the tooltip's window boundaries,
-		// since that tends to cause problems such as blocking the tray area (which can make a
-		// tooltip script impossible to terminate).  Normally, that can only happen in this case
-		// (one_or_both_coords_unspecified == true) when the cursor is near the bottom-right
-		// corner of the screen (unless the mouse is moving more quickly than the script's
-		// ToolTip update-frequency can cope with, but that seems inconsequential since it
-		// will adjust when the cursor slows down):
-		ttw.left = pt.x;
-		ttw.top = pt.y;
-		ttw.right = ttw.left + tt_width;
-		ttw.bottom = ttw.top + tt_height;
-		if (pt_cursor.x >= ttw.left && pt_cursor.x <= ttw.right && pt_cursor.y >= ttw.top && pt_cursor.y <= ttw.bottom)
-		{
-			// Push the tool tip to the upper-left side, since normally the only way the cursor can
-			// be inside its boundaries (when one_or_both_coords_unspecified == true) is when the
-			// cursor is near the bottom right corner of the screen.
-			pt.x = pt_cursor.x - tt_width - 3;    // Use a small offset since it can't overlap the cursor
-			pt.y = pt_cursor.y - tt_height - 3;   // when pushed to the the upper-left side of it.
-		}
-	}
-
-	// These messages seem to cause a complete update of the tooltip, which is slow and causes flickering.
-	// It is tempting to use SetWindowPos() instead to speed things up, but if TTM_TRACKPOSITION isn't
-	// sent each time, the next TTM_UPDATETIPTEXT message will move it back to whatever position was set
-	// with TTM_TRACKPOSITION last.
-	SendMessage(tip_hwnd, TTM_TRACKPOSITION, 0, (LPARAM)MAKELONG(pt.x, pt.y));
-	// And do a TTM_TRACKACTIVATE even if the tooltip window already existed upon entry to this function,
-	// so that in case it was hidden or dismissed while its HWND still exists, it will be shown again:
-	SendMessage(tip_hwnd, TTM_TRACKACTIVATE, TRUE, (LPARAM)&ti);
-	return OK;
-}
-
-
-
 ResultType TrayTipParseOptions(LPTSTR aOptions, NOTIFYICONDATA &nic)
 {
 	LPTSTR next_option, option_end;
@@ -5103,7 +4916,206 @@ BIF_DECL(BIF_InputBox)
 	_f_throw(ERR_INTERNAL_CALL);
 }
 
+BIF_DECL(BIF_ToolTip)
+{
+	int window_index = 0; // Default if param index 3 omitted
+	if (!ParamIndexIsOmitted(3))
+	{
+		Throw_if_Param_NaN(3);
+		window_index = ParamIndexToInt(3) - 1;
+		if (window_index < 0 || window_index >= MAX_TOOLTIPS)
+			_f_throw_value(_T("Max window number is ") MAX_TOOLTIPS_STR _T("."));
+	}
 
+	HWND tip_hwnd = g_hWndToolTip[window_index];
+
+	// Destroy windows except the first (for performance) so that resources/mem are conserved.
+	// The first window will be hidden by the TTM_UPDATETIPTEXT message if aText is blank.
+	// UPDATE: For simplicity, destroy even the first in this way, because otherwise a script
+	// that turns off a non-existent first tooltip window then later turns it on will cause
+	// the window to appear in an incorrect position.  Example:
+	// ToolTip
+	// ToolTip text, 388, 24
+	// Sleep 1000
+	// ToolTip text, 388, 24
+	TCHAR number_buf[MAX_NUMBER_SIZE];
+	auto tip_text = ParamIndexToOptionalString(0, number_buf);
+	if (!*tip_text)
+	{
+		if (tip_hwnd && IsWindow(tip_hwnd))
+			DestroyWindow(tip_hwnd);
+		g_hWndToolTip[window_index] = NULL;
+		_f_return_empty;
+	}
+	
+	bool param1_omitted = ParamIndexIsOmitted(1);
+	bool param2_omitted = ParamIndexIsOmitted(2);
+	bool one_or_both_coords_unspecified = param1_omitted || param2_omitted;
+		 
+	POINT pt, pt_cursor;
+	if (one_or_both_coords_unspecified)
+	{
+		// Don't call GetCursorPos() unless absolutely needed because it seems to mess
+		// up double-click timing, at least on XP.  UPDATE: Is isn't GetCursorPos() that's
+		// interfering with double clicks, so it seems it must be the displaying of the ToolTip
+		// window itself.
+		GetCursorPos(&pt_cursor);
+		pt.x = pt_cursor.x + 16;  // Set default spot to be near the mouse cursor.
+		pt.y = pt_cursor.y + 16;  // Use 16 to prevent the tooltip from overlapping large cursors.
+		// Update: Below is no longer needed due to a better fix further down that handles multi-line tooltips.
+		// 20 seems to be about the right amount to prevent it from "warping" to the top of the screen,
+		// at least on XP:
+		//if (pt.y > dtw.bottom - 20)
+		//	pt.y = dtw.bottom - 20;
+	}
+
+	POINT origin = { 0 };
+	if (!param1_omitted || !param2_omitted) // Need the offsets.
+		CoordToScreen(origin, COORD_MODE_TOOLTIP);
+
+	// This will also convert from relative to screen coordinates if appropriate:
+	if (!param1_omitted)
+	{
+		Throw_if_Param_NaN(1);
+		pt.x = ParamIndexToInt(1) + origin.x;
+	}
+	if (!param2_omitted)
+	{
+		Throw_if_Param_NaN(2);
+		pt.y = ParamIndexToInt(2) + origin.y;
+	}
+	HMONITOR hmon = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+	MONITORINFO mi;
+	mi.cbSize = sizeof(mi);
+	GetMonitorInfo(hmon, &mi);
+	// v1.1.34: Use work area to avoid trying to overlap the taskbar on newer OSes, which otherwise
+	// would cause the tooltip to appear at the top of the screen instead of the position we specify.
+	// This was observed on Windows 10 and 11, and confirmed to not apply to Windows 7 or XP.
+	RECT dtw = g_os.IsWin8orLater() ? mi.rcWork : mi.rcMonitor;
+
+	TOOLINFO ti = { 0 };
+	ti.cbSize = sizeof(ti);
+	ti.uFlags = TTF_TRACK;
+	ti.lpszText = tip_text;
+	// Note that the ToolTip won't work if ti.hwnd is assigned the HWND from GetDesktopWindow().
+	// All of ti's other members are left at NULL/0, including the following:
+	//ti.hinst = NULL;
+	//ti.uId = 0;
+	//ti.rect.left = ti.rect.top = ti.rect.right = ti.rect.bottom = 0;
+
+	// My: This does more harm that good (it causes the cursor to warp from the right side to the left
+	// if it gets to close to the right side), so for now, I did a different fix (above) instead:
+	//ti.rect.bottom = dtw.bottom;
+	//ti.rect.right = dtw.right;
+	//ti.rect.top = dtw.top;
+	//ti.rect.left = dtw.left;
+
+	// No need to use SendMessageTimeout() since the ToolTip() is owned by our own thread, which
+	// (since we're here) we know is not hung or heavily occupied.
+
+	// v1.0.40.12: Added the IsWindow() check below to recreate the tooltip in cases where it was destroyed
+	// by external means such as Alt-F4 or WinClose.
+	bool newly_created = !tip_hwnd || !IsWindow(tip_hwnd);
+	if (newly_created)
+	{
+		// This this window has no owner, it won't be automatically destroyed when its owner is.
+		// Thus, it will be explicitly by the program's exit function.
+		tip_hwnd = g_hWndToolTip[window_index] = CreateWindowEx(WS_EX_TOPMOST, TOOLTIPS_CLASS, NULL, TTS_NOPREFIX | TTS_ALWAYSTIP
+			, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, NULL, NULL, NULL, NULL);
+		if (!tip_hwnd)
+			_f_throw_win32();
+		SendMessage(tip_hwnd, TTM_ADDTOOL, 0, (LPARAM)(LPTOOLINFO)&ti);
+	}
+
+	// v1.1.34: Fixed to use the appropriate monitor, in case it's sized differently to the primary.
+	// Also fixed to account for incorrect DPI scaling done by the tooltip control; i.e. a value of
+	// n ends up allowing tooltips n*g_ScreenDPI/96 pixels wide.  TTM_SETMAXTIPWIDTH seems to want
+	// the max text width, not the max window width, so adjust for that.  Do this every time since
+	// the tooltip might be moving between screens of different sizes.
+	RECT text_rect = dtw;
+	SendMessage(tip_hwnd, TTM_ADJUSTRECT, FALSE, (LPARAM)&text_rect);
+	SendMessage(tip_hwnd, TTM_SETMAXTIPWIDTH, 0, (LPARAM)((text_rect.right - text_rect.left) * 96 / g_ScreenDPI));
+
+	if (newly_created)
+	{
+		// Must do these next two when the window is first created, otherwise GetWindowRect() below will retrieve
+		// a tooltip window size that is quite a bit taller than it winds up being:
+		SendMessage(tip_hwnd, TTM_TRACKPOSITION, 0, (LPARAM)MAKELONG(pt.x, pt.y));
+		SendMessage(tip_hwnd, TTM_TRACKACTIVATE, TRUE, (LPARAM)&ti);
+	}
+	// Bugfix for v1.0.21: The below is now called unconditionally, even if the above newly created the window.
+	// If this is not done, the tip window will fail to appear the first time it is invoked, at least when
+	// all of the following are true:
+	// 1) Windows XP;
+	// 2) Common controls v6 (via manifest);
+	// 3) "Control Panel >> Display >> Effects >> Use transition >> Fade effect" setting is in effect.
+	// v1.1.34: Avoid TTM_UPDATETIPTEXT if the text hasn't changed, to reduce flicker.  The behaviour described
+	// above could not be replicated, EVEN ON WINDOWS XP.  Whether it was ever observed on other OSes is unknown.
+	if (!newly_created && !ToolTipTextEquals(tip_hwnd, tip_text))
+		SendMessage(tip_hwnd, TTM_UPDATETIPTEXT, 0, (LPARAM)&ti);
+
+	RECT ttw = { 0 };
+	GetWindowRect(tip_hwnd, &ttw); // Must be called this late to ensure the tooltip has been created by above.
+	int tt_width = ttw.right - ttw.left;
+	int tt_height = ttw.bottom - ttw.top;
+
+	// v1.0.21: Revised for multi-monitor support.  I read somewhere that dtw.left can be negative (perhaps
+	// if the secondary monitor is to the left of the primary).  So it seems best to assume it is possible:
+	if (pt.x + tt_width >= dtw.right)
+		pt.x = dtw.right - tt_width - 1;
+	if (pt.y + tt_height >= dtw.bottom)
+		pt.y = dtw.bottom - tt_height - 1;
+	// It seems best not to have each of the below paired with the above.  This is because it allows
+	// the flexibility to explicitly move the tooltip above or to the left of the screen.  Such a feat
+	// should only be possible if done via explicitly passed-in negative coordinates for aX and/or aY.
+	// In other words, it should be impossible for a tooltip window to follow the mouse cursor somewhere
+	// off the virtual screen because:
+	// 1) The mouse cursor is normally trapped within the bounds of the virtual screen.
+	// 2) The tooltip window defaults to appearing South-East of the cursor.  It can only appear
+	//    in some other quadrant if jammed against the right or bottom edges of the screen, in which
+	//    case it can't be partially above or to the left of the virtual screen unless it's really
+	//    huge, which seems very unlikely given that it's limited to the maximum width of the
+	//    primary display as set by TTM_SETMAXTIPWIDTH above.
+	//else if (pt.x < dtw.left) // Should be impossible for this to happen due to mouse being off the screen.
+	//	pt.x = dtw.left;      // But could happen if user explicitly passed in a coord that was too negative.
+	//...
+	//else if (pt.y < dtw.top)
+	//	pt.y = dtw.top;
+
+	if (one_or_both_coords_unspecified)
+	{
+		// Since Tooltip is being shown at the cursor's coordinates, try to ensure that the above
+		// adjustment doesn't result in the cursor being inside the tooltip's window boundaries,
+		// since that tends to cause problems such as blocking the tray area (which can make a
+		// tooltip script impossible to terminate).  Normally, that can only happen in this case
+		// (one_or_both_coords_unspecified == true) when the cursor is near the bottom-right
+		// corner of the screen (unless the mouse is moving more quickly than the script's
+		// ToolTip update-frequency can cope with, but that seems inconsequential since it
+		// will adjust when the cursor slows down):
+		ttw.left = pt.x;
+		ttw.top = pt.y;
+		ttw.right = ttw.left + tt_width;
+		ttw.bottom = ttw.top + tt_height;
+		if (pt_cursor.x >= ttw.left && pt_cursor.x <= ttw.right && pt_cursor.y >= ttw.top && pt_cursor.y <= ttw.bottom)
+		{
+			// Push the tool tip to the upper-left side, since normally the only way the cursor can
+			// be inside its boundaries (when one_or_both_coords_unspecified == true) is when the
+			// cursor is near the bottom right corner of the screen.
+			pt.x = pt_cursor.x - tt_width - 3;    // Use a small offset since it can't overlap the cursor
+			pt.y = pt_cursor.y - tt_height - 3;   // when pushed to the the upper-left side of it.
+		}
+	}
+
+	// These messages seem to cause a complete update of the tooltip, which is slow and causes flickering.
+	// It is tempting to use SetWindowPos() instead to speed things up, but if TTM_TRACKPOSITION isn't
+	// sent each time, the next TTM_UPDATETIPTEXT message will move it back to whatever position was set
+	// with TTM_TRACKPOSITION last.
+	SendMessage(tip_hwnd, TTM_TRACKPOSITION, 0, (LPARAM)MAKELONG(pt.x, pt.y));
+	// And do a TTM_TRACKACTIVATE even if the tooltip window already existed upon entry to this function,
+	// so that in case it was hidden or dismissed while its HWND still exists, it will be shown again:
+	SendMessage(tip_hwnd, TTM_TRACKACTIVATE, TRUE, (LPARAM)&ti);
+	_f_return((size_t)tip_hwnd);
+}
 
 INT_PTR CALLBACK InputBoxProc(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 // MSDN:

--- a/source/util.cpp
+++ b/source/util.cpp
@@ -2026,6 +2026,8 @@ bool ToolTipTextEquals(HWND aToolTipHwnd, LPCTSTR aText)
 	ti.uId = 0;
 	size_t len = _tcslen(aText);
 	LPTSTR buf = ti.lpszText = (LPTSTR)_malloca((len + 2) * sizeof(TCHAR));
+	if (!buf)
+		return false;
 	SendMessage(aToolTipHwnd, TTM_GETTEXT, len + 2, (LPARAM)&ti);
 	bool is_equal = !_tcscmp(aText, buf);
 	_freea(buf);


### PR DESCRIPTION
**New**, `ToolTip` now returns `tip_hwnd` when showing a tooltip. Validates numeric parameters.

**Reason**, BIF implies slightly improved param verification/error type and returning `tip_hwnd` might be useful for some purposes.

**About**, throws win32 error if `CreateWindowEx` fails, this is probably very unlikely but guarantees that the return value is a valid hwnd. When destroying a tooltip, the function returns blank. Added `malloc` check in `ToolTipTextEquals`.