### PR TITLE
v1: Backported Buffer() from alpha branch. Added RemoteBuffer().

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8674,6 +8674,18 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 0;
 		max_params = 3;
 	}
+	else if (!_tcsicmp(func_name, _T("Buffer")))
+	{
+		bif = BIF_Buffer;
+		min_params = 0;
+		max_params = 2;
+	}
+	else if (!_tcsicmp(func_name, _T("RemoteBuffer")))
+	{
+		bif = BIF_RemoteBuffer;
+		min_params = 2;
+		max_params = 6;
+	}
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3358,6 +3358,8 @@ BIF_DECL(BIF_Trim); // L31: Also handles LTrim and RTrim.
 
 BIF_DECL(BIF_Hotstring);
 BIF_DECL(BIF_InputHook);
+BIF_DECL(BIF_Buffer);
+BIF_DECL(BIF_RemoteBuffer);
 
 
 BIF_DECL(BIF_IsObject);

--- a/source/script_object.h
+++ b/source/script_object.h
@@ -445,3 +445,55 @@ public:
 	void DebugWriteProperty(IDebugProperties *, int aPage, int aPageSize, int aDepth);
 #endif
 };
+
+
+//
+// Buffer
+//
+class BufferObject : public ObjectBase
+{
+	void *mData;
+	size_t mSize;
+	BufferObject() : mData(nullptr), mSize(0) {}
+
+	~BufferObject() { free(mData); }
+
+public:
+	static BufferObject *Create(size_t aSize);
+
+	ResultType STDMETHODCALLTYPE Invoke(ExprTokenType &aResultToken, ExprTokenType &aThisToken, int aFlags, ExprTokenType *aParam[], int aParamCount);
+	IObject_Type_Impl("Buffer")
+};
+
+
+//
+// RemoteBuffer
+//
+class RemoteBufferObject : public ObjectBase
+{
+	LPVOID mPtr;
+	SIZE_T mSize;
+	HANDLE mhProc;
+	DWORD mPID;
+	bool mIsLocal;
+	DWORD mFreeType;
+
+	RemoteBufferObject() : mPtr(0), mSize(0), mhProc(0), mPID(0), mIsLocal(false), mFreeType(0) {}
+
+	~RemoteBufferObject()
+	{
+		if (mIsLocal)
+			free(mPtr);
+		else
+		{
+			VirtualFreeEx(mhProc, mPtr, 0, mFreeType);
+			CloseHandle(mhProc);
+		}
+	}
+
+public:
+	static RemoteBufferObject *Create(DWORD aPID, SIZE_T aSize, DWORD aAccessRights, DWORD aAllocType, DWORD aProtect, DWORD aFreeType);
+
+	ResultType STDMETHODCALLTYPE Invoke(ExprTokenType &aResultToken, ExprTokenType &aThisToken, int aFlags, ExprTokenType *aParam[], int aParamCount);
+	IObject_Type_Impl("RemoteBuffer")
+};


### PR DESCRIPTION
## Introduction

A backport attempt for `Buffer()`.

`RemoteBuffer()`, to read/write to external (and internal) processes.
If the script's PID is specified, the code is optimised to handle a local process by using a regular internal memory buffer.

Note: I replaced the original commit. The new commit has an improved `RemoteBufferObject::Invoke` method, i.e. the `Read`/`Write` methods now accept `LocalOffset` *and* `RemoteOffset` parameters, before they only accepted a `RemoteOffset` parameter.

## Documentation

Buffer:
```
BufferObj := Buffer([ByteCount, FillByte])
```
RemoteBuffer:
```
RemoteBufferObj := RemoteBuffer(PID, Size [, AccessRights, AllocType, Protect, FreeType])

Default values:
AccessRights: PROCESS_QUERY_INFORMATION|PROCESS_VM_WRITE|PROCESS_VM_READ|PROCESS_VM_OPERATION (0x438)
AllocType: MEM_RESERVE|MEM_COMMIT (0x3000)
Protect: PAGE_READWRITE (0x4)
FreeType: MEM_RELEASE (0x8000)

(See MSDN pages for more details: OpenProcess, VirtualAllocEx, WriteProcessMemory, ReadProcessMemory, VirtualFreeEx, CloseHandle.)

Methods:
Note: Dest/Source can be a Buffer object, or a standard object (with Ptr/Size keys/properties), or an address integer.
BytesRead := Read(Dest [, Size, LocalOffset:=0, RemoteOffset:=0])
BytesWritten := Write(Source [, Size, LocalOffset:=0, RemoteOffset:=0])

Properties (all read-only):
Ptr: Address of the remote buffer.
Size: Size of the remote buffer.
HProc: Handle to the remote process.
PID: PID of the remote process.
IsLocal: True/False depending on whether the remote buffer is in an external process, or in the internal process.
```

## Implementation

I am very flexible re. any changes to the internal code and outward functionality.
E.g. changing (internal/external) function parameter names, (internal/external) property names, error message strings.

*Possibly* it's worth considering whether `Read`/`Write` could be replaced with names that are less ambiguous. I.e. it can be confusing sometimes which is which. However, they do match `ReadProcessMemory`/`WriteProcessMemory`.

As with all functions I submit for AHK v1, I'd prefer if they throw, rather than silently fail.
E.g. Read/Write could throw on failure, and return the bytes read/written on success.

## Implementation: buffer objects across functions.

The `RemoteBufferObject::Invoke` code can handle built-in `Buffer` object properties and custom `Buffer` object keys/properties. This could be turned into a function and used by any BIFs that accept `Buffer` objects.

## Implementation: optional parameters

There are quite a few optional parameters for `RemoteBuffer`, but I found the number to be acceptable.

An alternative, which could for greater customisability:
Space-separated strings, which could be used for often-used and rarely-used parameters.
E.g.:
```
RemoteBufferObj := RemoteBuffer(PID, Size [, Options])
oRemoteBuf := RemoteBuffer(PID, Size, "AR0x438 AT0x3000 P0x4 FT0x8000")
```

Here are all(/most of) the functions/parameters for consideration:

```
List of 6 Winapi functions and their parameters:
OpenProcess(dwDesiredAccess, bInheritHandle, dwProcessId)
VirtualAllocEx(hProcess, lpAddress, dwSize, flAllocationType, flProtect)
WriteProcessMemory(hProcess, lpBaseAddress, lpBuffer, nSize, lpNumberOfBytesWritten)
ReadProcessMemory(hProcess, lpBaseAddress, lpBuffer, nSize, lpNumberOfBytesRead)
VirtualFreeEx(hProcess, lpAddress, dwSize, dwFreeType)
CloseHandle(hObject)

Key:
FUNC: specified when calling the function
MTD: specified when calling a method
RET: returned by a method or property
-------: CURRENTLY NOT SPECIFIABLE / ACCESSIBLE

FUNC	dwDesiredAccess [AccessRights]
-------	bInheritHandle [CURRENTLY NOT SPECIFIABLE / ACCESSIBLE]
FUNC	dwProcessId [PID]
RET		hProcess / hObject
-------	lpAddress [CURRENTLY NOT SPECIFIABLE / ACCESSIBLE] [desired address in external process]
FUNC	dwSize [Size]
FUNC	flAllocationType [AllocType]
FUNC	flProtect [Protect]
RET/MTD	lpBaseAddress [address in external process, or an offset of it]
MTD	lpBuffer [address in local process, or an offset of it]
MTD	nSize
RET		lpNumberOfBytesWritten
RET		lpNumberOfBytesRead
FUNC	dwFreeType [FreeType]
```
E.g. for `bInheritHandle`, perhaps 'IH0'/'IH1' could be added as one of the space-separated strings. It's not something I've personally used.

## Comments

RemoteBuffer:
- Facilitates the use of memory in external processes, e.g. for external GUI interaction (e.g. Scintilla controls), and for sharing data between scripts.
- Eases the backporting of future AHK v2 external GUI interaction functions (as custom AHK v1 functions).
- Avoids the use of 6 functions via `DllCall`. (`OpenProcess, VirtualAllocEx, WriteProcessMemory, ReadProcessMemory, VirtualFreeEx, CloseHandle`.)
- Simplifies code by handling any optimisations for you, when the PID is local (when it matches `GetCurrentProcessId`).
- The RemoteBuffer object, and LocalOffset/RemoteOffset parameters make it really smooth to work with remote buffers.

## An aside

- I will be submitting the final PRs that I promised, in the next 7 days or so:
- DTPGetDate/DTPSetDate. Get/set external SysDateTimePick32 control dates.
- A few other tidbits.
- Then finally:
BinCompare/BinCopy.
InBuf. Find nth/nth-to-last occurrence.
BinDiff/StrDiff. 2 buffers/strings. Find nth/nth-to-last difference (byte/char).

## Test code

```
;==================================================

;test code: Buffer() and RemoteBuffer() (AHK v1)

;note:
;^q:: to test RemoteBuffer on the active window
;^w:: to display a GUI
;^e:: to display a GUI (in a new process)
;^r:: test Buffer object

;==================================================

^r:: ;test Buffer object:
;note: as in AHK v2, setting the Size property changes the pointer address, even when decreasing the size

vInfo := ""

oBuf := Buffer(16, 1) ;0x0101010101010101 (72340172838076673)
vInfo .= oBuf.Size " " oBuf.Ptr " " NumGet(oBuf.Ptr, 0, "UInt64") "`r`n"

NumPut(123456789123456789, oBuf.Ptr, 0, "Int64")
vInfo .= oBuf.Size " " oBuf.Ptr " " NumGet(oBuf.Ptr, 0, "Int64") "`r`n"

oBuf.Size := 8
vInfo .= oBuf.Size " " oBuf.Ptr " " NumGet(oBuf.Ptr, 0, "Int64") "`r`n"

oBuf.Size := 24
vInfo .= oBuf.Size " " oBuf.Ptr " " NumGet(oBuf.Ptr, 0, "Int64") "`r`n"

Clipboard := vInfo
MsgBox("Buffer object test info on clipboard")
return

;==================================================

^q:: ;test RemoteBuffer on the active window
try hCtl := ControlGetHwnd("SysDateTimePick321", "A")
catch
{
	MsgBox("error: no DTP control found")
	return
}

;get DTP date:
SoundBeep
MsgBox(MyDTPGetTime("SysDateTimePick321", "A"))

;set DTP date:
SoundBeep
MyDTPSetTime("20010101010101", "SysDateTimePick321", "A")
return

;==================================================

^w:: ;display a local GUI
DetectHiddenWindows, On
WinGet, vPID, PID, ahk_id %A_ScriptHwnd%
Gui, New, +HwndhGui, %vPID% (Internal)
Gui, Add, DateTime, Choose20060504030201, HH:mm:ss dd/MM/yyyy
Gui, Show
return

;==================================================

^e:: ;display an external GUI
vScript := " ;continuation section
(%
DetectHiddenWindows, On
WinGet, vPID, PID, ahk_id %A_ScriptHwnd%
Gui, New, +HwndhGui, %vPID% (External)
Gui, Add, DateTime, Choose20060504030201, HH:mm:ss dd/MM/yyyy
Gui, Show
return
)"
ExecScript(vScript, False)
return

;==================================================

;Run / RunWait - Syntax & Usage | AutoHotkey
;https://www.autohotkey.com/docs/commands/Run.htm#ExecScript

ExecScript(Script, Wait:=true)
{
    shell := ComObjCreate("WScript.Shell")
    exec := shell.Exec("AutoHotkey.exe /ErrorStdOut *")
    exec.StdIn.Write(script)
    exec.StdIn.Close()
    if Wait
        return exec.StdOut.ReadAll()
}

;==================================================

MyDTPGetTime(vCtlClassNN, vWinTitle)
{
	local
	hCtl := ControlGetHwnd(vCtlClassNN, vWinTitle)

	oSYSTEMTIME := Buffer(16, 0)

	vPID := WinGetPID("ahk_id " hCtl)
	oRemoteBuf := RemoteBuffer(vPID, 16)
	;GDT_VALID := 0
	SendMessage(0x1001, 0, oRemoteBuf.Ptr,, "ahk_id " hCtl) ;DTM_GETSYSTEMTIME := 0x1001
	oRemoteBuf.Read(oSYSTEMTIME)
	;oRemoteBuf.Read(oSYSTEMTIME.Ptr, 16) ;also works
	oRemoteBuf := ""

	;not possible:
	;oDate := NumGet(oSYSTEMTIME.Ptr, 0, {Type:"UShort", Quant:7})
	;oDate := NumGet(oSYSTEMTIME.Ptr, 0, ArrayRept("UShort", 7))
	;vDate := Format("{:04}{:02}{4:02}{:02}{:02}{:02}", oDate*)

	vDate := ""
	Loop 7
	{
		if !(A_Index = 3)
			vDate .= Format("{:02}", NumGet(oSYSTEMTIME.Ptr, A_Index*2-2, "UShort"))
	}
	return vDate
}

;==================================================

MyDTPSetTime(vDate, vCtlClassNN, vWinTitle)
{
	local
	hCtl := ControlGetHwnd(vCtlClassNN, vWinTitle)

	if !IsTime(vDate)
		throw Error("invalid date", -1)
	if (StrLen(vDate) < 14)
		vDate .= SubStr("19990101000000", vLen+1)
	vDate := RegExReplace(vDate, "(....)(..)(..)(..)(..)(..)", "$1-$2-0-$3-$4-$5-$6-0")
	oSYSTEMTIME := Buffer(16, 0)

	;not possible:
	;oDate := StrSplit(vDate, "-")
	;NumPut(oDate, oSYSTEMTIME.Ptr, 0, "UShort")
	;NumPut(oDate, oSYSTEMTIME.Ptr, 0, {Type:"UShort", Quant:8})
	;NumPut(oDate, oSYSTEMTIME.Ptr, 0, ArrayRept("UShort", 8))

	Loop Parse, vDate, % "-"
		NumPut(A_LoopField, oSYSTEMTIME.Ptr, (A_Index*2)-2, "UShort")

	vPID := WinGetPID("ahk_id " hCtl)
	oRemoteBuf := RemoteBuffer(vPID, 16)
	oRemoteBuf.Write(oSYSTEMTIME)
	;oRemoteBuf.Write(oSYSTEMTIME.Ptr, 16) ;also works
	;GDT_VALID := 0
	SendMessage(0x1002, 0, oRemoteBuf.Ptr,, "ahk_id " hCtl) ;DTM_SETSYSTEMTIME := 0x1002
	oRemoteBuf := ""
}

;==================================================

;note: these functions sometimes differ from the 'AHK v2 functions for AHK v1' library (reduced functionality):

MsgBox(Text)
{
	MsgBox, % Text
}

SendMessage(Msg, wParam:="", lParam:="", Control:="", WinTitle:="", WinText:="", ExcludeTitle:="", ExcludeText:="", Timeout:="")
{
	local hCtl
	if IsObject(wParam)
	{
		if wParam.HasKey("Ptr")
			wParam := wParam.Ptr
		else
			throw Exception("This value of type " Chr(34) "Object" Chr(34) " has no property named " Chr(34) "Ptr" Chr(34) ".", -1)
	}
	if IsObject(lParam)
	{
		if lParam.HasKey("Ptr")
			lParam := lParam.Ptr
		else
			throw Exception("This value of type " Chr(34) "Object" Chr(34) " has no property named " Chr(34) "Ptr" Chr(34) ".", -1) ;note: unlike AHK v2, we always state 'Object'
	}
	hCtl := AHKFC_ControlGetHwndAux(Control, WinTitle, WinText, ExcludeTitle, ExcludeText)
	if !hCtl
		throw Exception("Target control not found.", -1)
	SendMessage, % Msg, % wParam, % lParam,, % "ahk_id " hCtl,,,, % Timeout
	if (ErrorLevel = "FAIL")
		throw Exception("", -1)
	return 0 + ErrorLevel
}

ControlGetHwnd(Control:="", WinTitle:="", WinText:="", ExcludeTitle:="", ExcludeText:="")
{
	local hCtl
	if Control is % "integer"
	{
		if (Type(Control) = "Integer")
			return 0 + WinExist("ahk_id " Control)
	}
	if IsObject(Control) && Control.HasKey("Hwnd")
		return 0 + WinExist("ahk_id " Control.Hwnd)
	if (Control = "")
		return 0 + WinExist(WinTitle, WinText, ExcludeTitle, ExcludeText)
	ControlGet, hCtl, % "Hwnd",, % Control, % "ahk_id " WinExist(WinTitle, WinText, ExcludeTitle, ExcludeText)
	if ErrorLevel
		throw Exception("", -1)
	return 0 + hCtl
}

WinGetPID(WinTitle:="", WinText:="", ExcludeTitle:="", ExcludeText:="")
{
	local OutputVar
	if !WinExist(WinTitle, WinText, ExcludeTitle, ExcludeText)
		throw Exception("Target window not found.", -1)
	WinGet, OutputVar, % "PID"
	if (OutputVar = "")
		return ""
	return 0 + OutputVar
}

IsTime(Value)
{
	if (StrLen(Value) & 1) || (StrLen(Value) > 14) ;note: 'is' already fails for < 4 chars (a year below 1601 fails), valid lengths: 4/6/8/10/12/14
		return 0 + False
	if Value is % "time"
		return 0 + True
	return 0 + False
}

Error(Message, Params*) ;Message, What, Extra
{
	local What
	if (Params.Length() > 2)
		throw Exception("Too many parameters passed to function.", -1)
	if !Params.HasKey(1)
		Params[1] := 0
	What := Params[1]
	if What is integer
		Params[1]--
	return Exception(Message, Params*)
}

;note: should be essentially the same as ControlGetHwnd, but should not throw
AHKFC_ControlGetHwndAux(Control:="", WinTitle:="", WinText:="", ExcludeTitle:="", ExcludeText:="")
{
	local hCtl
	if Control is % "integer"
	{
		if (Type(Control) = "Integer")
			return 0 + WinExist("ahk_id " Control)
	}
	if IsObject(Control) && Control.HasKey("Hwnd")
		return 0 + WinExist("ahk_id " Control.Hwnd)
	if (Control = "")
		return 0 + WinExist(WinTitle, WinText, ExcludeTitle, ExcludeText)
	ControlGet, hCtl, % "Hwnd",, % Control, % "ahk_id " WinExist(WinTitle, WinText, ExcludeTitle, ExcludeText)
	return 0 + hCtl
}

Type(Value)
{
	local e, f, m
	static IsReady, nBoundFunc, nEnumObj, nFileObj, nMatchObj
	;note: doesn't fully match the AHK v2 function (sometimes misidentifies a Float as a String, a possible solution: float += 0)
	if !VarSetCapacity(IsReady)
	{
		nMatchObj := NumGet(&(m, RegExMatch("", "O)", m)), "Ptr")
		nBoundFunc := NumGet(&(f := Func("Func").Bind()), "Ptr")
		nFileObj := NumGet(&(f := FileOpen("*", "w")), "Ptr")
		nEnumObj := NumGet(&(e := ObjNewEnum({})), "Ptr")
		IsReady := "1"
	}
	if IsObject(Value)
	{
		return ObjGetCapacity(Value) != "" ? (Value.HasKey("__Class") ? "Class" : "Object")
		: IsFunc(Value) ? "Func"
		: ComObjType(Value) != "" ? "ComObject"
		: NumGet(&Value, "Ptr") == nBoundFunc ? "BoundFunc"
		: NumGet(&Value, "Ptr") == nMatchObj ? "RegExMatchInfo"
		: NumGet(&Value, "Ptr") == nFileObj ? "FileObject"
		: NumGet(&Value, "Ptr") == nEnumObj ? "Object::Enumerator"
		: "Property"
	}
	else if (ObjGetCapacity([Value], 1) != "")
		return "String"
	else
		return InStr(Value, ".") ? "Float" : "Integer"
}

;==================================================

```