### PR TITLE
v2: Added ListViewHeaderGetContent().

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -208,6 +208,7 @@ FuncEntry g_BIF[] =
 	BIFA(ListLines, 0, 1, ACT_LISTLINES),
 	BIFA(ListVars, 0, 0, ACT_LISTVARS),
 	BIFn(ListViewGetContent, 0, 6, BIF_ControlGet),
+	BIFn(ListViewHeaderGetContent, 0, 6, BIF_ControlGet),
 	BIFn(Ln, 1, 1, BIF_SqrtLogLn),
 	BIF1(LoadPicture, 1, 3, {3}),
 	BIFn(Log, 1, 1, BIF_SqrtLogLn),

--- a/source/script.h
+++ b/source/script.h
@@ -659,7 +659,7 @@ enum BuiltInFunctionID {
 	FID_ProcessExist = 0, FID_ProcessClose, FID_ProcessWait, FID_ProcessWaitClose, 
 	FID_MonitorGet = 0, FID_MonitorGetWorkArea, FID_MonitorGetCount, FID_MonitorGetPrimary, FID_MonitorGetName, 
 	FID_OnExit = 0, FID_OnClipboardChange, FID_OnError,
-	FID_ControlGetChecked = 0, FID_ControlGetEnabled, FID_ControlGetVisible, FID_ControlFindItem, FID_ControlGetIndex, FID_ControlGetChoice, FID_ControlGetItems, FID_ListViewGetContent, FID_EditGetLineCount, FID_EditGetCurrentLine, FID_EditGetCurrentCol, FID_EditGetLine, FID_EditGetSelectedText, FID_ControlGetStyle, FID_ControlGetExStyle, FID_ControlGetHwnd,
+	FID_ControlGetChecked = 0, FID_ControlGetEnabled, FID_ControlGetVisible, FID_ControlFindItem, FID_ControlGetIndex, FID_ControlGetChoice, FID_ControlGetItems, FID_ListViewGetContent, FID_ListViewHeaderGetContent, FID_EditGetLineCount, FID_EditGetCurrentLine, FID_EditGetCurrentCol, FID_EditGetLine, FID_EditGetSelectedText, FID_ControlGetStyle, FID_ControlGetExStyle, FID_ControlGetHwnd,
 	FID_ControlSetChecked = 0, FID_ControlSetEnabled, FID_ControlShow, FID_ControlHide, FID_ControlSetStyle, FID_ControlSetExStyle, FID_ControlShowDropDown, FID_ControlHideDropDown, FID_ControlAddItem, FID_ControlDeleteItem, FID_ControlChooseIndex, FID_ControlChooseString, FID_EditPaste,
 	FID_ControlSend = SCM_NOT_RAW, FID_ControlSendText = SCM_RAW_TEXT,
 	FID_DriveEject = 0, FID_DriveLock, FID_DriveUnlock, FID_DriveSetLabel, FID_DriveRetract,
@@ -3487,6 +3487,7 @@ ResultType DetermineTargetControl(HWND &aControl, HWND &aWindow, ResultToken &aR
 LPTSTR GetExitReasonString(ExitReasons aExitReason);
 
 void ControlGetListView(ResultToken &aResultToken, HWND aHwnd, LPTSTR aOptions);
+void ControlGetListViewHeader(ResultToken &aResultToken, HWND aHwnd, LPTSTR aOptions);
 bool ControlSetTab(ResultToken &aResultToken, HWND aHwnd, DWORD aTabIndex);
 
 void PixelSearch(Var *aOutputVarX, Var *aOutputVarY

--- a/source/script_autoit.cpp
+++ b/source/script_autoit.cpp
@@ -629,6 +629,7 @@ BIF_DECL(BIF_ControlGet)
 	{
 	case FID_ControlFindItem: // String (required).
 	case FID_ListViewGetContent: // Options (optional).
+	case FID_ListViewHeaderGetContent: // Options (optional).
 		if (aParamCount)
 		{
 			aString = ParamIndexToString(0, _f_number_buf);
@@ -808,6 +809,9 @@ BIF_DECL(BIF_ControlGet)
 
 	case FID_ListViewGetContent:
 		return ControlGetListView(aResultToken, control_window, aString);
+
+	case FID_ListViewHeaderGetContent:
+		return ControlGetListViewHeader(aResultToken, control_window, aString);
 
 	case FID_EditGetLineCount:  // Must be an Edit
 		// MSDN: "If the control has no text, the return value is 1. The return value will never be less than 1."


### PR DESCRIPTION
## Introduction

A function to get text from SysHeader32 (listview header) controls, to complement `ListViewGetContent()`.

An acceptable alternative would be to implement a `RemoteBuffer` class (e.g. #268).
To make it easy to write a simple/understandable custom `ListViewHeaderGetContent` function.

## Documentation

```
List := ListViewHeaderGetContent([Options, Control, WinTitle, WinText, ExcludeTitle, ExcludeText])
```

The function returns the text of the listview header as a tab-separated string, in a similar way to how `ListViewGetContent` returns rows of text.
The control specified can either be a listview control (SysListView32) or a listview header control (SysHeader32).
The 'ColXXX' option, e.g. 'Col4', can be specified, where 'XXX' is a series of digits, to return only the nth column header item, rather than all column header items.

## Test code

```
;test code: ListViewHeaderGetContent() (AHK v2)

q:: ;test ListViewHeaderGetContent
{
	vFoc := 1 + SendMessage(0x121B, 0, 0, "SysHeader321", "A") ;HDM_GETFOCUSEDITEM := 0x121B
	vText1 := ListViewHeaderGetContent("Col2", "SysListView321", "A")
	vText2 := ListViewHeaderGetContent("Col2", "SysHeader321", "A")
	vText3 := ListViewHeaderGetContent("", "SysListView321", "A")
	vText4 := ListViewHeaderGetContent("", "SysHeader321", "A")
	vText5 := ListViewHeaderGetContent("Col" vFoc, "SysListView321", "A")
	vText6 := ListViewHeaderGetContent("Col" vFoc, "SysHeader321", "A")
	MsgBox(StrLen(vText1) "`r`n" vText1)
	MsgBox(StrLen(vText2) "`r`n" vText2)
	MsgBox(StrLen(vText3) "`r`n" vText3)
	MsgBox(StrLen(vText4) "`r`n" vText4)
	MsgBox(StrLen(vText5) "`r`n" vText5)
	MsgBox(StrLen(vText6) "`r`n" vText6)
}
```