### PR TITLE
v2: Added ShortcutKey parameter to FileGetShortcut.

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -140,7 +140,7 @@ FuncEntry g_BIF[] =
 	BIFn(FileEncoding, 1, 1, BIF_SetBIV),
 	BIFn(FileExist, 1, 1, BIF_FileExist),
 	BIF1(FileGetAttrib, 0, 1),
-	BIF1(FileGetShortcut, 1, 8, {2, 3, 4, 5, 6, 7, 8}),
+	BIF1(FileGetShortcut, 1, 9, {2, 3, 4, 5, 6, 7, 8, 9}),
 	BIF1(FileGetSize, 0, 2),
 	BIF1(FileGetTime, 0, 2),
 	BIF1(FileGetVersion, 0, 1),

--- a/source/script.h
+++ b/source/script.h
@@ -1874,7 +1874,7 @@ public:
 		mData = aData;
 	}
 
-#define MAX_FUNC_OUTPUT_VAR 7
+#define MAX_FUNC_OUTPUT_VAR 8
 	bool ArgIsOutputVar(int aIndex) override
 	{
 		if (!mOutputVars)


### PR DESCRIPTION
## Introduction

Adds a ShortcutKey parameter to FileGetShortcut:
```
FileGetShortcut(LinkFile [, &OutTarget, &OutDir, &OutArgs, &OutDescription, &OutIcon, >>>&ShortcutKey<<<, &OutIconNum, &OutRunState])
FileCreateShortcut(Target, LinkFile [, WorkingDir, Args, Description, IconFile, ShortcutKey, IconNumber, RunState])
```
Note: `FileGetShortcut` and `FileCreateShortcut` would thus have the same number of parameters, although the `LinkFile` and `Target` parameters would still have a different order.
Note: `FileCreateShortcut` can still only create `Ctrl+Alt+XXX` shortcut keys. I only noticed that recently, and will look at changing that in a new PR.

## Documentation
```
FileGetShortcut(LinkFile [, &OutTarget, &OutDir, &OutArgs, &OutDescription, &OutIcon, &ShortcutKey, &OutIconNum, &OutRunState])
```
For example, the hotkey `CTRL + ALT + Q` would be returned as `^!q` in a similar syntax to hotkeys.

## Implementation

I couldn't find any definitive information on the meaning of `HOTKEYF_EXT`.

Here's the link for `GetHotkey` method:
[IShellLinkA::GetHotkey (shobjidl_core.h) - Win32 apps | Microsoft Docs](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ishelllinka-gethotkey)

Although this link: [TIP:Windows Search deskbar shortcut / hotkey (XP/Srv2003)](https://social.msdn.microsoft.com/Forums/en-US/e85fd2e1-a095-414a-837e-afe7ac7f0a97/tipwindows-search-deskbar-shortcut-hotkey-xpsrv2003), suggests it means the Windows key, and that's how I've implemented it.

The documentation could simply state: the `ShortcutKey` string will contain a '#' (as one of the leading characters indicating modifier keys) if the extended key flag is set.

[EDIT:]
[[MS-SHLLINK]: Shell Link (.LNK) Binary File Format | Microsoft Docs](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-shllink/16cb4ca1-9339-4d0c-a68d-bf1d6cc0f943)
Under HighByte, if references Shift/Control/Alt, but states that the value should never include 0x8.
I think the best approach is simply what I stated above: when setting the hotkey, `#` sets the 0x8 flag, and when getting the hotkey, if 0x8 is present, it's read as `#`, regardless of whether there is any meaning to it.

## Test code
```
;test code: FileGetShortcut(): added ShortcutKey parameter (AHK v2)

Target := A_AhkPath
LinkFile := A_ScriptDir "\MyLink.lnk"
WorkingDir := A_ScriptDir
Args := "a"
Description := "desc"
IconFile := A_AhkPath
ShortcutKey := "a"
IconNumber := "3"
RunState := "7"
if !FileExist(LinkFile)
	FileCreateShortcut(Target, LinkFile, WorkingDir, Args, Description, IconFile, ShortcutKey, IconNumber, RunState)

FileGetShortcut(LinkFile, &OutTarget, &OutDir, &OutArgs, &OutDescription, &OutIcon, &OutShortcutKey, &OutIconNum, &OutRunState)

oArray := [OutTarget, OutDir, OutArgs, OutDescription, OutIcon, OutShortcutKey, OutIconNum, OutRunState]
vOutput := ""
for vKey, vValue in oArray
	vOutput .= vKey " " vValue "`r`n"
MsgBox(vOutput) ;shortcut key presented as '^!a'
return
```