### PR TITLE
v2: Added Pow().

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -254,6 +254,7 @@ FuncEntry g_BIF[] =
 	BIF1(PixelGetColor, 2, 3),
 	BIF1(PixelSearch, 7, 8, {1, 2}),
 	BIFn(PostMessage, 1, 8, BIF_PostSendMessage),
+	BIF1(Pow, 2, 2),
 	BIFn(ProcessClose, 1, 1, BIF_Process),
 	BIFn(ProcessExist, 0, 1, BIF_Process),
 	BIF1(ProcessSetPriority, 1, 2),

--- a/source/script.h
+++ b/source/script.h
@@ -3436,6 +3436,7 @@ BIF_DECL(BIF_Process);
 BIF_DECL(BIF_ProcessSetPriority);
 BIF_DECL(BIF_MonitorGet);
 BIF_DECL(BIF_Wait);
+BIF_DECL(BIF_Pow);
 
 BIF_DECL(BIF_PerformAction);
 BIF_DECL(BIF_SetBIV);


### PR DESCRIPTION
## Introduction

A `Pow()` function to exactly match the `**` (power) operator.
It also acts as a replacement for AHK v1's `Transform-Pow`.

## Rationale

- Almost all programming languages have a `Pow` function/method.
- When converting code between different programming languages, replacing functions with operators, and vice versa, can require fiddly refactoring, and can create otherwise completely avoidable bugs. (I.e. multiple programming languages lack a power operator.)
- I'd prefer that something commonplace like `Pow` work 'right out of the box', even if it may be relatively simple to recreate it as a custom function.

Additional minor points:
- `**` has better integer handling in AHK v2 than AHK v1. A custom or official backport of `Pow()` would bring that better integer handling to AHK v1.
- The `**` code is in multiple places in the source code, it would be good to have it in one place, that could also ease any possible future optimisations.
- `Pow(` is a better search term than `**`, which is often used in text barriers, struct definitions / pointers to pointers, RegEx e.g. `\**`, placeholder/redacted characters. I.e. sometimes in programming you use one alternative over another because it doesn't clash with a commonly searched item. E.g. `InputBox` and Chrome.ahk's `Evaluate` unfortunately both use `.Value`, e.g. `{}` v. `Noop(`.

## Documentation

`Value := Pow(Base, Exponent)`

## Test code

```
;test code: Pow() (AHK v2)

;test Pow(n,n) for 1 to 32:
vOutput := ""
Loop 32
	vOutput .= A_Index "`t" Pow(A_Index, A_Index) "`r`n"
A_Clipboard := A_Index "`t" vOutput "`r`n"
MsgBox(vOutput)

;15**15 = 437893890380859375 = 0x613B62C597707EF
;16**16 = 18446744073709551616 = 0x10000000000000000 = 0xFFFFFFFFFFFFFFFF + 1

;test Pow against ** for random integers (they should match exactly):
;note: uncomment 2 lines to test random floats:
Loop 1000000
{
	vNum := Random(-0x8000000000000000, 0x7FFFFFFFFFFFFFFF)
	vPow := Random(-0x8000000000000000, 0x7FFFFFFFFFFFFFFF)
	;vNum := Float(vNum) / Random(2, 10)
	;vPow := Float(vPow) / Random(2, 10)

	try
		vRet1 := Pow(vNum, vPow)
	catch
		vRet1 := 0
	try
		vRet2 := vNum ** vPow
	catch
		vRet2 := 0

	;MsgBox(vNum " " vPow "`r`n" vRet1 "`r`n" vRet2)
	if !("" vRet1 = "" vRet2)
		MsgBox(vNum " " vPow "`r`n" vRet1 "`r`n" vRet2)
}
MsgBox("done")
return
```