### PR TITLE
v1: Backported operators >>> and >>>= from alpha branch.

### DIFF
--- a/source/defines.h
+++ b/source/defines.h
@@ -183,7 +183,7 @@ enum SymbolType // For use with ExpandExpression() and IsPureNumeric().
 #define SYM_OPAREN_FOR_CPAREN(symbol) ((symbol) + (SYM_OPAREN - SYM_CPAREN)) // Caller must confirm it is CPAREN or CBRACKET.
 #define YIELDS_AN_OPERAND(symbol) ((symbol) < SYM_OPAREN) // CPAREN also covers the tail end of a function call.  Post-inc/dec yields an operand for things like Var++ + 2.  Definitely needs the parentheses around symbol.
 	, SYM_ASSIGN, SYM_ASSIGN_ADD, SYM_ASSIGN_SUBTRACT, SYM_ASSIGN_MULTIPLY, SYM_ASSIGN_DIVIDE, SYM_ASSIGN_FLOORDIVIDE
-	, SYM_ASSIGN_BITOR, SYM_ASSIGN_BITXOR, SYM_ASSIGN_BITAND, SYM_ASSIGN_BITSHIFTLEFT, SYM_ASSIGN_BITSHIFTRIGHT
+	, SYM_ASSIGN_BITOR, SYM_ASSIGN_BITXOR, SYM_ASSIGN_BITAND, SYM_ASSIGN_BITSHIFTLEFT, SYM_ASSIGN_BITSHIFTRIGHT, SYM_ASSIGN_BITSHIFTRIGHT_LOGICAL // SYM_ASSIGN_BITSHIFTLEFT_LOGICAL doesn't exist but <<<= is the same as <<=
 	, SYM_ASSIGN_CONCAT // THIS MUST BE KEPT AS THE LAST (AND SYM_ASSIGN THE FIRST) BECAUSE THEY'RE USED IN A RANGE-CHECK.
 #define IS_ASSIGNMENT_EXCEPT_POST_AND_PRE(symbol) (symbol <= SYM_ASSIGN_CONCAT && symbol >= SYM_ASSIGN) // Check upper bound first for short-circuit performance.
 #define IS_ASSIGNMENT_OR_POST_OP(symbol) (IS_ASSIGNMENT_EXCEPT_POST_AND_PRE(symbol) || symbol == SYM_POST_INCREMENT || symbol == SYM_POST_DECREMENT)
@@ -197,7 +197,7 @@ enum SymbolType // For use with ExpandExpression() and IsPureNumeric().
 	, SYM_BITOR // Seems more intuitive to have these higher in prec. than the above, unlike C and Perl, but like Python.
 	, SYM_BITXOR // SYM_BITOR (ABOVE) MUST BE KEPT FIRST AMONG THE BIT OPERATORS BECAUSE IT'S USED IN A RANGE-CHECK.
 	, SYM_BITAND
-	, SYM_BITSHIFTLEFT, SYM_BITSHIFTRIGHT // << >>  ALSO: SYM_BITSHIFTRIGHT MUST BE KEPT LAST AMONG THE BIT OPERATORS BECAUSE IT'S USED IN A RANGE-CHECK.
+	, SYM_BITSHIFTLEFT, SYM_BITSHIFTRIGHT, SYM_BITSHIFTRIGHT_LOGICAL // << >> >>>  ALSO: SYM_BITSHIFTRIGHT_LOGICAL MUST BE KEPT LAST AMONG THE BIT OPERATORS BECAUSE IT'S USED IN A RANGE-CHECK. <<< is the same as SYM_BITSHIFTLEFT
 	, SYM_ADD, SYM_SUBTRACT
 	, SYM_MULTIPLY, SYM_DIVIDE, SYM_FLOORDIVIDE
 	, SYM_NEGATIVE, SYM_HIGHNOT, SYM_BITNOT, SYM_ADDRESS, SYM_DEREF  // Don't change position or order of these because Infix-to-postfix converter's special handling for SYM_POWER relies on them being adjacent to each other.

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -4482,7 +4482,8 @@ ResultType Script::ParseAndAddLine(LPTSTR aLineText, ActionTypeType aActionType,
 			// checked later, only after action_name has been checked to see if it's a valid command.
 			case '>':
 			case '<':
-				if (action_args_2nd_char == *action_args && action_args[2] == '=') // i.e. >>= and <<=
+				if (action_args_2nd_char == *action_args && ( action_args[2] == '='	// i.e. >>= and <<=
+					|| (action_args_2nd_char == '>' && action_args[2] == '>' && action_args[3] == '=') )) // >>>=
 					aActionType = ACT_EXPRESSION; // Mark this line as a stand-alone expression.
 				break;
 			case '.': // L34: Handle dot differently now that dot is considered an action end flag. Detects some more errors and allows some valid expressions which weren't previously allowed.
@@ -4508,9 +4509,12 @@ ResultType Script::ParseAndAddLine(LPTSTR aLineText, ActionTypeType aActionType,
 						cp = omit_leading_whitespace(cp);
 						if (*cp == '[' || !*cp // x.y[z] or x.y
 							|| cp[1] == '=' && _tcschr(_T(":+-*/|&^."), cp[0]) // Two-char assignment operator.
+							// or there are two repeated characters 
 							|| cp[1] == cp[0]
-								&& (   _tcschr(_T("/<>"), cp[0]) && cp[2] == '=' // //=, <<= or >>=
-									|| *cp == '+' || *cp == '-'   )) // x.y++ or x.y--
+							&& ( ( _tcschr(_T("/<>"), cp[0]) && cp[2] == '=' // //=, <<= or >>=
+										|| *cp == '+' || *cp == '-' ) // x.y++ or x.y--
+								// or three repeated characters:
+								|| (cp[0] == '>' && cp[2] == '>' && cp[3] == '=') )	) // >>>=
 						{	// Allow Set and bracketed Get as standalone expression.
 							aActionType = ACT_EXPRESSION;
 							break;
@@ -10140,7 +10144,7 @@ ResultType Line::ExpressionToPostfix(ArgStruct &aArg)
 		, 86             // SYM_DOT
 		, 4,4,4,4,4,4    // SYM_CPAREN, SYM_CBRACKET, SYM_CBRACE, SYM_OPAREN, SYM_OBRACKET, SYM_OBRACE (to simplify the code, parentheses/brackets/braces must be lower than all operators in precedence).
 		, 6              // SYM_COMMA -- Must be just above SYM_OPAREN so it doesn't pop OPARENs off the stack.
-		, 7,7,7,7,7,7,7,7,7,7,7,7  // SYM_ASSIGN_*. THESE HAVE AN ODD NUMBER to indicate right-to-left evaluation order, which is necessary for cascading assignments such as x:=y:=1 to work.
+		, 7,7,7,7,7,7,7,7,7,7,7,7,7  // SYM_ASSIGN_*. THESE HAVE AN ODD NUMBER to indicate right-to-left evaluation order, which is necessary for cascading assignments such as x:=y:=1 to work.
 //		, 8              // THIS VALUE MUST BE LEFT UNUSED so that the one above can be promoted to it by the infix-to-postfix routine.
 		, 11, 11         // SYM_IFF_ELSE, SYM_IFF_THEN (ternary conditional).  HAS AN ODD NUMBER to indicate right-to-left evaluation order, which is necessary for ternaries to perform traditionally when nested in each other without parentheses.
 //		, 12             // THIS VALUE MUST BE LEFT UNUSED so that the one above can be promoted to it by the infix-to-postfix routine.
@@ -10154,7 +10158,7 @@ ResultType Line::ExpressionToPostfix(ArgStruct &aArg)
 		, 42             // SYM_BITOR -- Seems more intuitive to have these three higher in prec. than the above, unlike C and Perl, but like Python.
 		, 46             // SYM_BITXOR
 		, 50             // SYM_BITAND
-		, 54, 54         // SYM_BITSHIFTLEFT, SYM_BITSHIFTRIGHT
+		, 54, 54, 54     // SYM_BITSHIFTLEFT, SYM_BITSHIFTRIGHT, SYM_BITSHIFTRIGHT_LOGICAL
 		, 58, 58         // SYM_ADD, SYM_SUBTRACT
 		, 62, 62, 62     // SYM_MULTIPLY, SYM_DIVIDE, SYM_FLOORDIVIDE
 		, 67,67,67,67,67 // SYM_NEGATIVE (unary minus), SYM_HIGHNOT (the high precedence "!" operator), SYM_BITNOT, SYM_ADDRESS, SYM_DEREF
@@ -10504,7 +10508,14 @@ ResultType Line::ExpressionToPostfix(ArgStruct &aArg)
 						else
 						{
 							++cp; // An additional increment to have loop skip over the second '>' too.
-							this_infix_item.symbol = SYM_BITSHIFTRIGHT;
+							if (cp[1] == '>') // look for a third '>'
+							{
+								++cp; // to have the loop skip the third '>'
+								// it is SYM_BITSHIFTRIGHT_LOGICAL or SYM_ASSIGN_BITSHIFTRIGHT_LOGICAL
+								this_infix_item.symbol = cp[1] == '=' ? (cp++, SYM_ASSIGN_BITSHIFTRIGHT_LOGICAL) : SYM_BITSHIFTRIGHT_LOGICAL;
+							}
+							else
+								this_infix_item.symbol = SYM_BITSHIFTRIGHT;
 						}
 						break;
 					default:
@@ -11579,17 +11590,18 @@ standard_pop_into_postfix: // Use of a goto slightly reduces code size.
 				{
 					switch (postfix_symbol)
 					{
-					case SYM_ASSIGN_ADD:           postfix_symbol = SYM_ADD; break;
-					case SYM_ASSIGN_SUBTRACT:      postfix_symbol = SYM_SUBTRACT; break;
-					case SYM_ASSIGN_MULTIPLY:      postfix_symbol = SYM_MULTIPLY; break;
-					case SYM_ASSIGN_DIVIDE:        postfix_symbol = SYM_DIVIDE; break;
-					case SYM_ASSIGN_FLOORDIVIDE:   postfix_symbol = SYM_FLOORDIVIDE; break;
-					case SYM_ASSIGN_BITOR:         postfix_symbol = SYM_BITOR; break;
-					case SYM_ASSIGN_BITXOR:        postfix_symbol = SYM_BITXOR; break;
-					case SYM_ASSIGN_BITAND:        postfix_symbol = SYM_BITAND; break;
-					case SYM_ASSIGN_BITSHIFTLEFT:  postfix_symbol = SYM_BITSHIFTLEFT; break;
-					case SYM_ASSIGN_BITSHIFTRIGHT: postfix_symbol = SYM_BITSHIFTRIGHT; break;
-					case SYM_ASSIGN_CONCAT:        postfix_symbol = SYM_CONCAT; break;
+					case SYM_ASSIGN_ADD:					postfix_symbol = SYM_ADD; break;
+					case SYM_ASSIGN_SUBTRACT:				postfix_symbol = SYM_SUBTRACT; break;
+					case SYM_ASSIGN_MULTIPLY:				postfix_symbol = SYM_MULTIPLY; break;
+					case SYM_ASSIGN_DIVIDE:					postfix_symbol = SYM_DIVIDE; break;
+					case SYM_ASSIGN_FLOORDIVIDE:			postfix_symbol = SYM_FLOORDIVIDE; break;
+					case SYM_ASSIGN_BITOR:					postfix_symbol = SYM_BITOR; break;
+					case SYM_ASSIGN_BITXOR:					postfix_symbol = SYM_BITXOR; break;
+					case SYM_ASSIGN_BITAND:					postfix_symbol = SYM_BITAND; break;
+					case SYM_ASSIGN_BITSHIFTLEFT:			postfix_symbol = SYM_BITSHIFTLEFT; break;
+					case SYM_ASSIGN_BITSHIFTRIGHT:			postfix_symbol = SYM_BITSHIFTRIGHT; break;
+					case SYM_ASSIGN_BITSHIFTRIGHT_LOGICAL:	postfix_symbol = SYM_BITSHIFTRIGHT_LOGICAL; break;
+					case SYM_ASSIGN_CONCAT:					postfix_symbol = SYM_CONCAT; break;
 					}
 					// Insert the concat or math operator before the assignment:
 					this_postfix = (ExprTokenType *)_alloca(sizeof(ExprTokenType));

--- a/source/script_expression.cpp
+++ b/source/script_expression.cpp
@@ -1004,17 +1004,18 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ExprTokenType 
 						this_token.symbol = SYM_VAR; // address can be taken, and it can be passed ByRef. e.g. &(x:=1)
 					}
 					goto push_this_token;
-				case SYM_ASSIGN_ADD:           this_token.symbol = SYM_ADD; break;
-				case SYM_ASSIGN_SUBTRACT:      this_token.symbol = SYM_SUBTRACT; break;
-				case SYM_ASSIGN_MULTIPLY:      this_token.symbol = SYM_MULTIPLY; break;
-				case SYM_ASSIGN_DIVIDE:        this_token.symbol = SYM_DIVIDE; break;
-				case SYM_ASSIGN_FLOORDIVIDE:   this_token.symbol = SYM_FLOORDIVIDE; break;
-				case SYM_ASSIGN_BITOR:         this_token.symbol = SYM_BITOR; break;
-				case SYM_ASSIGN_BITXOR:        this_token.symbol = SYM_BITXOR; break;
-				case SYM_ASSIGN_BITAND:        this_token.symbol = SYM_BITAND; break;
-				case SYM_ASSIGN_BITSHIFTLEFT:  this_token.symbol = SYM_BITSHIFTLEFT; break;
-				case SYM_ASSIGN_BITSHIFTRIGHT: this_token.symbol = SYM_BITSHIFTRIGHT; break;
-				case SYM_ASSIGN_CONCAT:        this_token.symbol = SYM_CONCAT; break;
+				case SYM_ASSIGN_ADD:					this_token.symbol = SYM_ADD; break;
+				case SYM_ASSIGN_SUBTRACT:				this_token.symbol = SYM_SUBTRACT; break;
+				case SYM_ASSIGN_MULTIPLY:				this_token.symbol = SYM_MULTIPLY; break;
+				case SYM_ASSIGN_DIVIDE:					this_token.symbol = SYM_DIVIDE; break;
+				case SYM_ASSIGN_FLOORDIVIDE:			this_token.symbol = SYM_FLOORDIVIDE; break;
+				case SYM_ASSIGN_BITOR:					this_token.symbol = SYM_BITOR; break;
+				case SYM_ASSIGN_BITXOR:					this_token.symbol = SYM_BITXOR; break;
+				case SYM_ASSIGN_BITAND:					this_token.symbol = SYM_BITAND; break;
+				case SYM_ASSIGN_BITSHIFTLEFT:			this_token.symbol = SYM_BITSHIFTLEFT; break;
+				case SYM_ASSIGN_BITSHIFTRIGHT:			this_token.symbol = SYM_BITSHIFTRIGHT; break;
+				case SYM_ASSIGN_BITSHIFTRIGHT_LOGICAL:	this_token.symbol = SYM_BITSHIFTRIGHT_LOGICAL; break;
+				case SYM_ASSIGN_CONCAT:					this_token.symbol = SYM_CONCAT; break;
 				}
 				// Since above didn't goto or break out of the outer loop, this is an assignment other than
 				// SYM_ASSIGN, so it needs further evaluation later below before the assignment will actually be made.
@@ -1239,7 +1240,7 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ExprTokenType 
 			}
 
 			else if (right_is_number == PURE_INTEGER && left_is_number == PURE_INTEGER && this_token.symbol != SYM_DIVIDE
-				|| this_token.symbol <= SYM_BITSHIFTRIGHT && this_token.symbol >= SYM_BITOR) // Check upper bound first for short-circuit performance (because operators like +-*/ are much more frequently used).
+				|| this_token.symbol <= SYM_BITSHIFTRIGHT_LOGICAL && this_token.symbol >= SYM_BITOR) // Check upper bound first for short-circuit performance (because operators like +-*/ are much more frequently used).
 			{
 				// Because both are integers and the operation isn't division, the result is integer.
 				// The result is also an integer for the bitwise operations listed in the if-statement
@@ -1269,6 +1270,7 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ExprTokenType 
 				case SYM_BITXOR:   this_token.value_int64 = left_int64 ^ right_int64; break;
 				case SYM_BITSHIFTLEFT:  this_token.value_int64 = left_int64 << right_int64; break;
 				case SYM_BITSHIFTRIGHT: this_token.value_int64 = left_int64 >> right_int64; break;
+				case SYM_BITSHIFTRIGHT_LOGICAL: this_token.value_int64 = (unsigned __int64)left_int64 >> right_int64; break;
 				case SYM_FLOORDIVIDE:
 					// Since it's integer division, no need for explicit floor() of the result.
 					// Also, performance is much higher for integer vs. float division, which is part


### PR DESCRIPTION
## Test code
```
;test code: >>> and >>>= (bitshift right logical) (AHK v1)

Loop 100000
{
	vNum := RandomInt64()
	Random, vShift, 0, 63
	vRet1 := BitShiftRightLogical(vNum, vShift, 1)
	vRet2 := BitShiftRightLogical(vNum, vShift, 2)
	vRet3 := BitShiftRightLogical(vNum, vShift, 3)
	MsgBox(vNum " " vShift "`r`n" vRet1 "`r`n" vRet2 "`r`n" vRet3)
	if !(vRet1 = vRet2)
	|| !(vRet1 = vRet3)
		MsgBox(vNum " " vShift)
}
MsgBox("done")

vOutput := ""
vNum := 0x7FFFFFFFFFFFFFFF
Loop 20
{
	vNum2 := BitShiftRightLogical(vNum, 1)
	vOutput .= Format("0x{:016X} 0x{:016X}", vNum, vNum2) "`r`n"

	vNum++

	vNum2 := BitShiftRightLogical(vNum, 1)
	vOutput .= Format("0x{:016X} 0x{:016X}", vNum, vNum2) "`r`n"

	vNum--
	vNum += 0x1000000000000000
}

Clipboard := vOutput
MsgBox("done")
return

RandomInt64()
{
	local
	Random, Rand1, -0x80000000, 0x7FFFFFFF
	Random, Rand2, -0x80000000, 0x7FFFFFFF
	Rand1 += 0x80000000
	Rand2 += 0x80000000
	return (Rand1 << 32) | Rand2
}

BitShiftRightLogical(vNum, vShift, vMode:=2)
{
	local
	if (vMode = 1)
	{
		if (vShift = 0)
			return vNum
		else if (vShift < 0) || (vShift > 63)
			throw Exception("Error evaluating expression.", -1)
		return (vNum >> vShift) & ((1 << (64-vShift))-1)
		;return (vNum >> vShift) & ((2**(64-vShift))-1) ;equivalent to line above
	}
	else if (vMode = 2)
	{
		return vNum >>> vShift
	}
	else (vMode = 3)
	{
		vNum >>>= vShift
		return vNum
	}
}

MsgBox(vText)
{
	MsgBox, % vText
}
```