### PR TITLE
v1: Backported operator !== from alpha branch.

### DIFF
--- a/source/defines.h
+++ b/source/defines.h
@@ -190,7 +190,7 @@ enum SymbolType // For use with ExpandExpression() and IsPureNumeric().
 	, SYM_IFF_ELSE, SYM_IFF_THEN // THESE TERNARY OPERATORS MUST BE KEPT IN THIS ORDER AND ADJACENT TO THE BELOW.
 	, SYM_OR, SYM_AND // MUST BE KEPT IN THIS ORDER AND ADJACENT TO THE ABOVE because infix-to-postfix is optimized to check a range rather than a series of equalities.
 	, SYM_LOWNOT  // LOWNOT is the word "not", the low precedence counterpart of !
-	, SYM_EQUAL, SYM_EQUALCASE, SYM_NOTEQUAL // =, ==, <> ... Keep this in sync with IS_RELATIONAL_OPERATOR() below.
+	, SYM_EQUAL, SYM_EQUALCASE, SYM_NOTEQUAL, SYM_NOTEQUALCASE // =, ==, <> and !=, !== ... Keep this in sync with IS_RELATIONAL_OPERATOR() below.
 	, SYM_GT, SYM_LT, SYM_GTOE, SYM_LTOE  // >, <, >=, <= ... Keep this in sync with IS_RELATIONAL_OPERATOR() below.
 #define IS_RELATIONAL_OPERATOR(symbol) (symbol >= SYM_EQUAL && symbol <= SYM_LTOE)
 	, SYM_CONCAT

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -10149,7 +10149,7 @@ ResultType Line::ExpressionToPostfix(ArgStruct &aArg)
 		, 20             // SYM_AND
 		, 25             // SYM_LOWNOT (the word "NOT": the low precedence version of logical-not).  HAS AN ODD NUMBER to indicate right-to-left evaluation order so that things like "not not var" are supports (which can be used to convert a variable into a pure 1/0 boolean value).
 //		, 26             // THIS VALUE MUST BE LEFT UNUSED so that the one above can be promoted to it by the infix-to-postfix routine.
-		, 30, 30, 30     // SYM_EQUAL, SYM_EQUALCASE, SYM_NOTEQUAL (lower prec. than the below so that "x < 5 = var" means "result of comparison is the boolean value in var".
+		, 30, 30, 30, 30 // SYM_EQUAL, SYM_EQUALCASE, SYM_NOTEQUAL, SYM_NOTEQUALCASE (lower prec. than the below so that "x < 5 = var" means "result of comparison is the boolean value in var".
 		, 34, 34, 34, 34 // SYM_GT, SYM_LT, SYM_GTOE, SYM_LTOE
 		, 38             // SYM_CONCAT
 		, 42             // SYM_BITOR -- Seems more intuitive to have these three higher in prec. than the above, unlike C and Perl, but like Python.
@@ -10395,10 +10395,12 @@ ResultType Line::ExpressionToPostfix(ArgStruct &aArg)
 					}
 					break;
 				case '!':
-					if (cp1 == '=') // i.e. != is synonymous with <>, which is also already supported by legacy.
+					if (cp1 == '=') // i.e. != is synonymous with <>, which is also already supported by legacy, or !==.
 					{
-						++cp; // An additional increment to have loop skip over the '=' too.
-						this_infix_item.symbol = SYM_NOTEQUAL;
+						// An additional increment for each '=' to have loop skip over the '=' too.
+						++cp, this_infix_item.symbol	= cp[1] == '=' // note, cp[1] is not equal to cp1 here due to ++cp
+														? (++cp, SYM_NOTEQUALCASE)	// !==
+														: SYM_NOTEQUAL;				// != 
 					}
 					else
 						// If what lies to its left is a CPARAN or OPERAND, SYM_CONCAT is not auto-inserted because:

--- a/source/script_expression.cpp
+++ b/source/script_expression.cpp
@@ -1033,25 +1033,26 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ExprTokenType 
 			// earlier stage (for performance).
 			if (this_token.symbol == SYM_CONCAT || !right_is_number || !(left_is_number = TokenIsPureNumeric(left))) // See comment above.
 			{
-				// L31: Handle binary ops supported by objects (= == !=).
+				// L31: Handle binary ops supported by objects (= == != !==).
 				switch (this_token.symbol)
 				{
 				case SYM_EQUAL:
 				case SYM_EQUALCASE:
 				case SYM_NOTEQUAL:
+				case SYM_NOTEQUALCASE:
 					IObject *right_obj = TokenToObject(right);
 					IObject *left_obj = TokenToObject(left);
 					// To support a future "implicit default value" feature, both operands must be objects.
 					// Otherwise, an object operand will be treated as its default value, currently always "".
 					// This is also consistent with unsupported operands such as < and > - i.e. because obj<""
 					// and obj>"" are always false and obj<="" and obj>="" are always true, obj must be "".
-					// When the default value feature is implemented all operators (excluding =, == and !=
+					// When the default value feature is implemented all operators (excluding =, ==, !== and !=
 					// if both operands are objects) may use the default value of any object operand.
 					// UPDATE: Above is not done because it seems more intuitive to document the other
 					// comparison operators as unsupported than for (obj == "") to evaluate to true.
 					if (right_obj || left_obj)
 					{
-						this_token.value_int64 = (this_token.symbol != SYM_NOTEQUAL) == (right_obj == left_obj);
+						this_token.value_int64 = (this_token.symbol != SYM_NOTEQUAL && this_token.symbol != SYM_NOTEQUALCASE) == (right_obj == left_obj);
 						this_token.symbol = SYM_INTEGER; // Must be set *after* above checks symbol.
 						goto push_this_token;
 					}
@@ -1069,6 +1070,7 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ExprTokenType 
 										? _tcsicmp(left_string, right_string)
 										: lstrcmpi(left_string, right_string)); break; // i.e. use the "more correct mode" except when explicitly told to use the fast mode (v1.0.43.03).
 				case SYM_EQUALCASE: this_token.value_int64 = !_tcscmp(left_string, right_string); break; // Case sensitive.
+				case SYM_NOTEQUALCASE:	this_token.value_int64 = _tcscmp(left_string, right_string) ? 1 : 0; break;
 				// The rest all obey g->StringCaseSense since they have no case sensitive counterparts:
 				case SYM_NOTEQUAL:  this_token.value_int64 = g_tcscmp(left_string, right_string) ? 1 : 0; break;
 				case SYM_GT:        this_token.value_int64 = g_tcscmp(left_string, right_string) > 0; break;
@@ -1259,6 +1261,7 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ExprTokenType 
 				// always yield a one or a zero rather than arbitrary non-zero values:
 				case SYM_EQUALCASE: // Same behavior as SYM_EQUAL for numeric operands.
 				case SYM_EQUAL:    this_token.value_int64 = left_int64 == right_int64; break;
+				case SYM_NOTEQUALCASE: // Same behavior as SYM_NOTEQUAL for numeric operands.
 				case SYM_NOTEQUAL: this_token.value_int64 = left_int64 != right_int64; break;
 				case SYM_GT:       this_token.value_int64 = left_int64 > right_int64; break;
 				case SYM_LT:       this_token.value_int64 = left_int64 < right_int64; break;
@@ -1334,6 +1337,7 @@ LPTSTR Line::ExpandExpression(int aArgIndex, ResultType &aResult, ExprTokenType 
 					break;
 				case SYM_EQUALCASE: // Same behavior as SYM_EQUAL for numeric operands.
 				case SYM_EQUAL:    this_token.value_int64 = left_double == right_double; break;
+				case SYM_NOTEQUALCASE: // Same behavior as SYM_NOTEQUAL for numeric operands.
 				case SYM_NOTEQUAL: this_token.value_int64 = left_double != right_double; break;
 				case SYM_GT:       this_token.value_int64 = left_double > right_double; break;
 				case SYM_LT:       this_token.value_int64 = left_double < right_double; break;


### PR DESCRIPTION
## Test code

```
;test code: !== (case-sensitive not-equal operator) (AHK v1)

oArray1 := []
oArray2 := []
vText1 := "ABC"
vText2 := "abc"
vNum1 := 1
vNum2 := 0

oOutput1 := [""
, oArray1 != oArray1
, oArray1 != oArray2
, vText1 != vText1
, vText1 != vText2
, vNum1 != vNum1
, vNum1 != vNum2]

oOutput2 := [""
, oArray1 !== oArray1
, oArray1 !== oArray2
, vText1 !== vText1
, vText1 !== vText2
, vNum1 !== vNum1
, vNum1 !== vNum2]

vOutput1 := ""
for _, vValue in oOutput1
	vOutput1 .= vValue
vOutput2 := ""
for _, vValue in oOutput2
	vOutput2 .= vValue
vOutput := vOutput1 "`r`n" vOutput2

Clipboard := vOutput
MsgBox, % vOutput ;010001 010101
return
```