### PR TITLE
v2: Improved error message for IniRead.

### DIFF
--- a/source/script_registry.cpp
+++ b/source/script_registry.cpp
@@ -81,7 +81,11 @@ BIF_DECL(BIF_IniRead)
 	if (g->LastError)
 	{
 		if (!aDefault)
+		{
+			if (g->LastError == 2)
+				_f_throw_value(_T("The requested key, section or file was not found."));
 			_f_throw_win32(g->LastError);
+		}
 		if (!*aKey)
 			_f_return(aDefault);
 	}


### PR DESCRIPTION
## Documentation

If error 2 occurs when using `IniRead`:
The previous error message and the new error message:
`Error:  (2) The system cannot find the file specified.`
`Error:  The requested key, section or file was not found.`

## Rationale

I agree with SKAN's reasoning here, and felt similarly after experiencing the same problem:
[IniRead Error handler - AutoHotkey Community](https://autohotkey.com/boards/viewtopic.php?f=82&t=94298)

`IniRead` errors are common, and the system message is misleading, whereas the new message is far clearer.
If I see the original message, I take it at face value: a missing file or file read error.
I wouldn't normally override a system message, but in this case, I felt it was for the best.
This PR (2-line commit) would save people a lot of time when debugging.

## Test code

```
;test code: IniRead(): improved error message (AHK v2)

vPathIni := A_ScriptDir "\MyIni.txt"
vPathNotAFile := A_ScriptDir "\NotAFile.txt"
IniWrite(123, vPathIni, "Section", "Key")

vValue := IniRead(vPathNotAFile, "Section", "Key")
vValue := IniRead(vPathIni, "Section", "NotAKey")
vValue := IniRead(vPathIni, "NotASection")

;the previous error message and the new error message:
;Error:  (2) The system cannot find the file specified.
;Error:  The requested key, section or file was not found.
```