### PR TITLE
v1: Added HexGet/HexPut/Base64Get/Base64Put functions. (Algorithm.)

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8661,6 +8661,18 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 0;
 		max_params = 3;
 	}
+	else if (!_tcsicmp(func_name, _T("Base64Get")) || !_tcsicmp(func_name, _T("HexGet")))
+	{
+		bif = BIF_HexBase64Get;
+		min_params = 1;
+		max_params = 2;
+	}
+	else if (!_tcsicmp(func_name, _T("Base64Put")) || !_tcsicmp(func_name, _T("HexPut")))
+	{
+		bif = BIF_HexBase64Put;
+		min_params = 1;
+		max_params = 3;
+	}
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3356,6 +3356,8 @@ BIF_DECL(BIF_Trim); // L31: Also handles LTrim and RTrim.
 
 BIF_DECL(BIF_Hotstring);
 BIF_DECL(BIF_InputHook);
+BIF_DECL(BIF_HexBase64Get);
+BIF_DECL(BIF_HexBase64Put);
 
 
 BIF_DECL(BIF_IsObject);


### PR DESCRIPTION
A replacement for #212, which I have yet to close,  because it might still have some value.

PR #212 uses Winapi functions, and uses an `#include`. It may give a smaller exe.
PR #281 uses faster in-house algorithms, and has test code examples.

## Documentation

```
String := HexGet(Source [, Size])
String := Base64Get(Source [, Size])

ByteCount := HexPut(String)
ByteCount := HexPut(String, Target [, Length])
ByteCount := Base64Put(String)
ByteCount := Base64Put(String, Target [, Length])
```

## `Base64Get`/`HexGet`:
Reads binary data from a memory address, as a base64 string.
Reads binary data from a memory address, as a hex string.
Source can be a buffer object.
Size can be omitted if Source is a buffer object.

## `Base64Put`/`HexPut`:
Writes binary data to a memory address, based on a base64 string.
Writes binary data to a memory address, based on a hex string.
Target can be a buffer object.

If no Target was given, it returns the required buffer size in bytes.
`HexPut` throws if an odd number of hex characters is specified.
`Base64Put` throws if an invalid number of base64 characters is specified, specifically where length modulo 4 = 1.

The hex characters can be any of: `0123456789ABCDEFabcdef`.

The base64 characters can be any of: `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/`.
Where `-_` are considered invalid.
There can be any number of trailing equals signs.

## Rationale

Some uses:
- Storing image/icon or wave/MIDI resources.
- Storing machine code functions. Or code from dll files.
- Displaying/inspecting binary data.
- Performing operations on binary data.
- Handling big endian data/integers.
- Handling hex strings used with `RegRead`/`RegWrite`.

Avoids:
- Workarounds such as using hex, or arrays stuffed with integers, with `NumPut` and `Loop`, when `Base64Put` would be shorter.
- Multiple incompatible custom functions.
- `XXXGet` functions that are relatively short but don't support Windows XP or earlier.

## Implementation

- The function uses in-house algorithms for all 4 functions.
- `HexGet` returns upper case. I find this more readable/elegant, but this could be changed if desired.
- Buffer support has been added.
- For both `Base64Get` and `Base64Put`, when writing algorithms, a choice had to made to use or not use a temporary buffer. Where I used one algorithm in the commit, I provided the other as a comment in the test code.
- The functions were written to be fast, and coincidentally happen to validate any strings in a similar way to JavaScript's `atob`. When you do 'binary to base64 string', the number of chars (minus padding/nulls) will be 4n / 4n+2 / 4n+3, but never 4n+1. `atob` throws if you pass a string (minus padding/nulls) that is 4n+1 in length. Also, `atob` accepts `+/` but disallows `-_` as base64 chars. All things considered, I agreed with these 2 rules.
- One advantage of an in-house algorithm, is that it can be ported to IronAHK/SharpKeys more easily.

## Issues with other implementations

`Debugger::Base64Encode` (binary to string):
- Like the debugger, I *do* use a temporary buffer to combine values. [Using the combined buffer was fractionally faster.]

`Debugger::Base64Decode` (string to binary):
- I validate the hex/base64 strings using a lookup table. IIRC the debugger didn't do any validation, it just ignored higher bits beyond 63. [I tried `_tcsspn`, but it was much slower than using a lookup table.]
- Unlike the debugger, I *do not* use a temporary buffer to combine values. [Using the combined buffer was a bit slower.]
- For string to binary, I use a lookup table. [Using `strchr` was much slower than using a lookup table.]
`#define BASE64_CHAR_TO_BINARY(q) (strchr(sBase64Chars, q)-sBase64Chars)`
- Curiously the debugger appends a null when decoding *and* encoding. [It makes sense for encoding.]

JavaScript's `atob` (ASCII to binary):
- The code uses the same permissible base64 characters as JavaScript's `atob`. Note: `-_` are excluded.
- The code requires that the length of the base64 string (modulo 4) must not be 1, as with JavaScript's `atob`.
- Here is a link to a polyfill implementation of `atob`. [core-js](https://github.com/zloirock/core-js#base64-utility-methods).

Winapi functions (`CryptStringToBinary` and `CryptBinaryToString`):
- `CryptStringToBinary` appears to have a bug. If the length of the base64 string (modulo 4) is 1, it appears to 'round up', and writes 1 more byte than one would expect, with an unpredictable/undocumented value. (When the remainder is 2 or 3, it rounds down.) `Base64Put` like `atob` throws an error.
- `CryptStringToBinary` allows `-_` (in addition to `+/`) in base64 strings, unlike `Base64Put` and `atob`.
- `CryptStringToBinary` fails for empty strings. `Base64Put` and `HexPut` permit empty strings.

## Test code

```
;==================================================

;test code: HexGet/HexPut/Base64Get/Base64Put functions (AHK v1)

;==================================================

;e.g. speeds:
;get: 109 1844 78 344 [AHK hex, MS hex, AHK b64, MS b64]
;put:  78  672 94 187 [AHK hex, MS hex, AHK b64, MS b64]

;==================================================

test_Errors:

oBuf := JEE_BufferSimple(1, 0)

HexPut := "HexPut"
Base64Put := "Base64Put"

AssertError(HexPut, ["0", oBuf], "Parameter #1 invalid.")
AssertError(HexPut, ["00", oBuf, 1], "Parameter #3 invalid.")
AssertError(HexPut, ["00", oBuf, -1], "Parameter #3 invalid.")
AssertError(HexPut, ["00", oBuf, 4], "Parameter #3 invalid.")
AssertError(HexPut, ["!!", oBuf], "Parameter #1 invalid.")
AssertError(HexPut, ["00",, 2], "Parameter #2 invalid.")
AssertError(HexPut, ["0000", oBuf], "Buffer too small.")
AssertError(HexPut, ["0000", {Size:0, Ptr:0}], "Buffer too small.") ;(Size checked before Ptr)

AssertError(Base64Put, ["A", oBuf], "Parameter #1 invalid.")
AssertError(Base64Put, ["AAAA", oBuf, 1], "Parameter #3 invalid.")
AssertError(Base64Put, ["AAAA", oBuf, -1], "Parameter #3 invalid.")
AssertError(Base64Put, ["AAAA", oBuf, 8], "Parameter #3 invalid.")
AssertError(Base64Put, ["!!!!", oBuf], "Parameter #1 invalid.")
AssertError(Base64Put, ["AAAA",, 2], "Parameter #2 invalid.")
AssertError(Base64Put, ["AAAA", oBuf], "Buffer too small.")
AssertError(Base64Put, ["AAAA", {Size:0, Ptr:0}], "Buffer too small.") ;(Size checked before Ptr)

MsgBox("done (assert error tests)")

;==================================================

test_XXXGet:

oBuf1 := JEE_BufferSimple(4, 0)
oBuf2 := JEE_BufferSimple(4, 1)
oBuf3 := JEE_BufferSimple(4, 255)

Assert(HexGet(oBuf1), "00000000")
Assert(HexGet(oBuf2), "01010101")
Assert(HexGet(oBuf3), "FFFFFFFF")
Assert(Base64Get(oBuf1), "AAAAAA==")
Assert(Base64Get(oBuf2), "AQEBAQ==")
Assert(Base64Get(oBuf3), "/////w==")

;==============================

vText := JEE_StrRept("abcdefghijklmnopqrstuvwxyz", 1000)
pText := &vText
vBarrier := "=================================================="
for _, vSize in JEE_ArrRange(-5, 1000)
;for _, vSize in JEE_ArrRange(1, 100)
{
	vHex1 := vHex2 := ""
	vBase64_1 := vBase64_2 := ""

	try vHex1 := HexGet(pText, vSize)
	try vBase64_1 := Base64Get(pText, vSize)
	try vHex2 := JEE_HexGet(pText, vSize)
	try vBase64_2 := JEE_Base64Get(pText, vSize)

	if !(vHex1 == vHex2)
		MsgBox("hex:`r`n" vHex1 "`r`n" vHex2)
	if !(vBase64_1 == vBase64_2)
		MsgBox("base64:`r`n" vBase64_1 "`r`n" vBase64_2)
	;ToolTip(vSize)
	;MsgBox(JEE_StrJoin("`r`n`r`n", vBarrier, vHex1, vHex2, vBase64_1, vBase64_2))
}

;==============================

oTickCount := []
vText := JEE_StrRept("abcdefghijklmnopqrstuvwxyz", 1000000)
pText := &vText
vSize := StrLen(vText) / 2

vTickCount := A_TickCount
v1 := HexGet(pText, vSize)
oTickCount.Push(A_TickCount - vTickCount)

vTickCount := A_TickCount
v2 := JEE_HexGet(pText, vSize, "L")
oTickCount.Push(A_TickCount - vTickCount)

vTickCount := A_TickCount
v3 := Base64Get(pText, vSize)
oTickCount.Push(A_TickCount - vTickCount)

vTickCount := A_TickCount
v4 := JEE_Base64Get(pText, vSize)
oTickCount.Push(A_TickCount - vTickCount)

if (v1 != v2)
	MsgBox("data mismatch: 1 and 2")
if (v3 != v4)
	MsgBox("data mismatch: 3 and 4")

MsgBox(JEE_StrJoin("`r`n", oTickCount*))
;Clipboard := MsgBox(JEE_StrJoin("`r`n", oTickCount*))

;==============================

MsgBox("done (XXXGet)")

;==================================================

test_XXXPut:

Assert(HexPut(""), 0)
Assert(HexPut("00") , 1)
Assert(HexPut("0000"), 2)
;MsgBox(HexPut("0")) ;error
;MsgBox(HexPut("000")) ;error

Assert(Base64Put(""), 0)
Assert(Base64Put("AA"), 1)
Assert(Base64Put("AAA"), 2)
Assert(Base64Put("AAAA"), 3)
Assert(Base64Put("AAAAAA"), 4)
;MsgBox(Base64Put("A")) ;error
;MsgBox(Base64Put("AAAAA")) ;error

;==============================

vText := JEE_StrRept("0123456789ABCDEF", 1000)
pText := &vText
for _, vLen in JEE_ArrRange(-5, 1000)
{
	vTemp := SubStr(vText, 1, vLen)
	vSize1 := vSize2 := 0
	try vSize1 := HexPut(vTemp)
	try vSize2 := JEE_HexPut(vTemp)
	if (vSize1 != vSize2)
		MsgBox("hex mismatch size: " vLen " " vSize1 " " vSize2)
	oBuf1 := JEE_BufferSimple(vSize1, 0)
	oBuf2 := JEE_BufferSimple(vSize2, 0)
	try HexPut(vTemp, oBuf1)
	try JEE_HexPut(vTemp, oBuf2)

	if (vLen < 0)
		continue
	if JEE_BinCompare(oBuf1, oBuf2, vSize1)
		MsgBox("hex mismatch data: " vLen " " vSize1 " " vSize2)
}

vText := JEE_StrRept("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/", 1000)
pText := &vText
for _, vLen in JEE_ArrRange(-5, 1000)
{
	vTemp := SubStr(vText, 1, vLen)
	vSize1 := vSize2 := 0
	try vSize1 := Base64Put(vTemp)
	try vSize2 := JEE_Base64Put(vTemp)
	if (vSize1 != vSize2)
		MsgBox("base64 mismatch: " vLen " " vSize1 " " vSize2)
	oBuf1 := JEE_BufferSimple(vSize1, 0)
	oBuf2 := JEE_BufferSimple(vSize2, 0)
	try Base64Put(vTemp, oBuf1)
	try JEE_Base64Put(vTemp, oBuf2)

	if (vLen < 0)
		continue
	if JEE_BinCompare(oBuf1, oBuf2, vSize1)
		MsgBox("base64 mismatch: " vLen " " vSize1 " " vSize2)
}

;MsgBox(StrGet(oBuf1.Ptr, 20) "`r`n" StrGet(oBuf2.Ptr, 20))
;MsgBox(StrGet(oBuf1.Ptr, 20, "CP1252") "`r`n" StrGet(oBuf2.Ptr, 20, "CP1252"))

;==============================

;demonstrate that these AHK functions are faster than the Winapi equivalents:

oTickCount := []
vCount := 500000
vTextH := JEE_StrRept("0123456789ABCDEFabcedf", vCount)
vTextB := JEE_StrRept("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/", vCount)
vMin := Min(StrLen(vTextH), StrLen(vTextB))
vTextH := SubStr(vTextH, 1, vMin)
vTextB := SubStr(vTextB, 1, vMin)
pTextH := &vTextH
pTextB := &vTextB

	/*
	vCount := 5000000
	vTextB := JEE_StrRept("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/", vCount)
	;test speed of different base64 algorithms:
	vSize3 := Base64Put(vTextB)
	oBuf3 := JEE_BufferSimple(vSize3, 0)
	vTickCount := A_TickCount
	Base64Put(vTextB, oBuf3)
	oTickCount.Push(A_TickCount - vTickCount)
	MsgBox(Clipboard := oTickCount[1]) ;2063 (debugger 4 bytes into 1 algo), 2125 (4 separate bytes algo)
	return
	*/

;==============================

vSize1 := HexPut(vTextH)
oBuf1 := JEE_BufferSimple(vSize1, 0)
vSize2 := JEE_HexPut(vTextH)
oBuf2 := JEE_BufferSimple(vSize2, 0)
vSize3 := Base64Put(vTextB)
oBuf3 := JEE_BufferSimple(vSize3, 0)
vSize4 := JEE_Base64Put(vTextB)
oBuf4 := JEE_BufferSimple(vSize4, 0)

if (vSize1 != vSize2)
	MsgBox("size mismatch: 1 and 2")
if (vSize3 != vSize4)
	MsgBox("size mismatch: 3 and 4")

vTickCount := A_TickCount
HexPut(vTextH, oBuf1)
oTickCount.Push(A_TickCount - vTickCount)

vTickCount := A_TickCount
JEE_HexPut(vTextH, oBuf2)
oTickCount.Push(A_TickCount - vTickCount)

vTickCount := A_TickCount
Base64Put(vTextH, oBuf3)
oTickCount.Push(A_TickCount - vTickCount)

vTickCount := A_TickCount
JEE_Base64Put(vTextH, oBuf4)
oTickCount.Push(A_TickCount - vTickCount)

if JEE_BinCompare(oBuf1, oBuf2)
	MsgBox("data mismatch: 1 and 2")
vSize := Min(vSize1, 100)
if JEE_BinCompare(oBuf3, oBuf4)
	MsgBox("data mismatch: 3 and 4")

MsgBox(JEE_StrJoin("`r`n", oTickCount*))
;Clipboard := MsgBox(JEE_StrJoin("`r`n", oTickCount*))

;==============================

MsgBox("done (XXXPut)")

;==================================================

MsgBox("done")
return

;==================================================

JEE_HexGet(oBuf, vSize:="`f`a`b", vCase:="U")
{
	local
	static vIsVistaOrLater := (DllCall("kernel32\GetVersion", "UInt") & 0xFF) >= 6

	vAddr := IsObject(oBuf) ? oBuf.Ptr : oBuf
	if (vSize = "`f`a`b")
	{
		if !IsObject(oBuf)
			throw Error("Size not specified.", -1)
		vSize := oBuf.Size
	}
	if !IsNumber(vSize) || (vSize < 0)
		throw Error("Invalid size.", -1)
	if !vSize
		return ""

	;CRYPT_STRING_NOCRLF := 0x40000000 (not supported by Windows XP)
	;CRYPT_STRING_HEXRAW := 0xC ;to return raw hex but with a trailing enter (not supported by Windows XP)
	;CRYPT_STRING_HEX := 0x4 ;to return space/CRLF-separated text
	vFlags := vIsVistaOrLater ? 0x4000000C : 0x4
	vTChars := 0
	DllCall("crypt32\CryptBinaryToString", "Ptr",vAddr, "UInt",vSize, "UInt",vFlags, "Ptr",0, "UInt*",vTChars)
	VarSetStrCapacity(vHex, vTChars)
	DllCall("crypt32\CryptBinaryToString", "Ptr",vAddr, "UInt",vSize, "UInt",vFlags, "Str",vHex, "UInt*",vTChars)
	if !vIsVistaOrLater
	{
		vHex := StrReplace(vHex, "`r`n")
		vHex := StrReplace(vHex, " ")
	}
	return (vCase = "L") ? vHex : Format("{:U}", vHex)
}

JEE_Base64Get(oBuf, vSize:="`f`a`b")
{
	local
	static vIsVistaOrLater := (DllCall("kernel32\GetVersion", "UInt") & 0xFF) >= 6

	vAddr := IsObject(oBuf) ? oBuf.Ptr : oBuf
	if (vSize = "`f`a`b")
	{
		if !IsObject(oBuf)
			throw Error("Size not specified.", -1)
		vSize := oBuf.Size
	}
	if !IsNumber(vSize) || (vSize < 0)
		throw Error("Invalid size.", -1)
	if !vSize
		return ""

	;CRYPT_STRING_NOCRLF := 0x40000000
	;CRYPT_STRING_BASE64 := 0x1
	vTChars := 0
	vFlags := vIsVistaOrLater ? 0x40000001 : 0x1
	DllCall("crypt32\CryptBinaryToString", "Ptr",vAddr, "UInt",vSize, "UInt",vFlags, "Ptr",0, "UInt*",vTChars)
	VarSetStrCapacity(vBase64, vTChars)
	DllCall("crypt32\CryptBinaryToString", "Ptr",vAddr, "UInt",vSize, "UInt",vFlags, "Str",vBase64, "UInt*",vTChars)
	return vIsVistaOrLater ? vBase64 : StrReplace(vBase64, "`r`n")
}

JEE_HexPut(vHex, oBuf:="`f`a`b", vChars:="`f`a`b")
{
	local
	if (vChars = "`f`a`b")
		vChars := StrLen(vHex)
	if (vChars < 0)
		throw Error("Invalid parameter 3.", -1)
	if (StrLen(vHex) & 1)
		throw Error("Char count is odd.", -1)
	if (vChars & 1)
		throw Error("Char count is odd.", -1)
	if (oBuf = "`f`a`b") && (vChars = "`f`a`b")
		return vChars // 2

	vAddr := IsObject(oBuf) ? oBuf.Ptr : oBuf

	;CRYPT_STRING_HEX := 0x4
	;CRYPT_STRING_HEXRAW := 0xC ;(not supported by Windows XP)
	;note: vChars is the number of letters (nibbles) (half-bytes) to write
	;note: if vChars is odd, CryptStringToBinary fails
	;note: by this point vChars is even (it was validated earlier)

	;vSize := 0
	;DllCall("crypt32\CryptStringToBinary", "Ptr",StrPtr(vHex), "UInt",vChars, "UInt",0x4, "Ptr",0, "UInt*",vSize, "Ptr",0, "Ptr",0)
	vSize := vChars // 2 ;equivalent to line above when vChars is even
	if IsObject(oBuf)
	&& (oBuf.Size < vSize)
		throw Error("Buffer too small.", -1)

	DllCall("crypt32\CryptStringToBinary", "Ptr",StrPtr(vHex), "UInt",vChars, "UInt",0x4, "Ptr",vAddr, "UInt*",vSize, "Ptr",0, "Ptr",0)
	return vSize ;bytes written
}

JEE_Base64Put(vBase64, oBuf:="`f`a`b", vChars:="`f`a`b")
{
	local
	vBase64 := RTrim(vBase64, "=")
	if (vChars = "`f`a`b")
		vChars := StrLen(vBase64)
	if (vChars < 0)
		throw Error("Invalid parameter 3.", -1)
	if (Mod(StrLen(vBase64), 4) == 1)
		throw Error("Invalid parameter 1.", -1)
	if (Mod(vChars, 4) == 1)
		throw Error("Invalid parameter 3.", -1)
	if (oBuf = "`f`a`b") && (vChars = "`f`a`b")
	{
		vSize := 0
		DllCall("crypt32\CryptStringToBinary", "Ptr",StrPtr(vBase64), "UInt",vChars, "UInt",0x1, "Ptr",0, "UInt*",vSize, "Ptr",0, "Ptr",0)
		return vSize
	}

	vAddr := IsObject(oBuf) ? oBuf.Ptr : oBuf
	vSize := 0
	;CRYPT_STRING_BASE64 := 0x1
	DllCall("crypt32\CryptStringToBinary", "Ptr",StrPtr(vBase64), "UInt",vChars, "UInt",0x1, "Ptr",0, "UInt*",vSize, "Ptr",0, "Ptr",0)
	if IsObject(oBuf)
	&& (oBuf.Size < vSize)
		throw Error("Buffer too small.", -1)

	DllCall("crypt32\CryptStringToBinary", "Ptr",StrPtr(vBase64), "UInt",vChars, "UInt",0x1, "Ptr",vAddr, "UInt*",vSize, "Ptr",0, "Ptr",0)
	return vSize ;bytes written
}

;==================================================

IsNumber(Value)
{
	if Value is % "number"
		return 0 + True
	return 0 + False
}

;==================================================

JEE_StrRept(vText, vNum)
{
	local
	if IsNumber(vNum)
	&& (vNum > 0)
		;return StrReplace(Format("{:0" vNum "}", 0), 0, vText)
		return StrReplace(Format("{:" vNum "}", ""), " ", vText)
	return ""
}

;==================================================

JEE_ArrRange(vStart, vEnd:="", vStep:=1)
{
	local
	if (vEnd == "")
	{
		vEnd := vStart
		vStart := 1
	}
	if !vStep || !IsNumber(vStart) || !IsNumber(vEnd) || !IsNumber(vStep)
		return ""
	vCount := Floor(Abs((vEnd-vStart)/vStep)) + 1
	vStep := (vEnd >= vStart ? 1 : -1) * Abs(vStep)
	oArray := []
	oArray.SetCapacity(vCount)
	;Loop % vCount
	while (A_Index <= vCount) ;AHK v1/v2 two-way compatible
		oArray.Push(vStart+(A_Index-1)*vStep)
	return oArray
}

;==================================================

StrPtr(ByRef Value) ;ByRef for performance
{
	static IsReady, StringArray
	if IsByRef(Value)
		return &Value

	;note: if a literal string is passed, it is stored permanently:
	if !VarSetCapacity(IsReady)
	{
		StringArray := []
		IsReady := "1"
	}
	StringArray.Push("" Value)
	return StringArray.GetAddress(StringArray.Length())
}

;==================================================

JEE_BinCompare(oBuf1, oBuf2, vSize:="`f`a`b")
{
	local
	vAddr1 := IsObject(oBuf1) ? oBuf1.Ptr : oBuf1
	vAddr2 := IsObject(oBuf2) ? oBuf2.Ptr : oBuf2

	if (vSize = "`f`a`b")
	{
		if !IsObject(oBuf1)
		|| !IsObject(oBuf2)
		|| !(oBuf1.Size = oBuf2.Size)
			throw Error("If Size is omitted, params 1 and 2 must be buffers of equal size.", -1)
		vSize := oBuf1.Size
	}
	if !IsNumber(vSize) || (vSize < 0)
		throw Error("", -1)
	if !vSize
		return 0
	return DllCall("msvcrt\memcmp", "Ptr",vAddr1, "Ptr",vAddr2, "UPtr",vSize, "Cdecl")
}

;==================================================

Error(Message, Params*) ;Message, What, Extra
{
	local What
	if (Params.Length() > 2)
		throw Exception("Too many parameters passed to function.", -1)
	if !Params.HasKey(1)
		Params[1] := 0
	What := Params[1]
	if What is integer
		Params[1]--
	return Exception(Message, Params*)
}

;==================================================

VarSetStrCapacity(ByRef TargetVar, RequestedCapacity:="")
{
	static ChrSize, IsReady
	if !VarSetCapacity(IsReady)
	{
		ChrSize := A_IsUnicode ? 2 : 1
		IsReady := "1"
	}
	if (RequestedCapacity = "")
		return VarSetCapacity(TargetVar) // ChrSize
	else if (RequestedCapacity = -1)
		return VarSetCapacity(TargetVar, -1) // ChrSize
	return VarSetCapacity(TargetVar, RequestedCapacity*ChrSize) // ChrSize
}

;==================================================

JEE_BufferSimple(vByteCount, vFillByte:="")
{
	static vIsV1 := (InStr(A_AhkVersion, "1.") == 1)
	static oBuffers, vIsReady
	if !vIsV1
	{
		vClassName := "Buffer"
		return %vClassName%(vByteCount, (vFillByte=""?[]:[vFillByte])*)
	}
	if !VarSetStrCapacity(vIsReady)
	{
		oBuffers := []
		vIsReady := "1"
	}
	oBuffers.Push("")
	oBuffers.SetCapacity(oBuffers.Length(), vByteCount)
	if !(vFillByte = "")
		DllCall("kernel32\RtlFillMemory", "Ptr",oBuffers.GetAddress(oBuffers.Length()), "UPtr",vByteCount, "UChar",vFillByte)
	return {Ptr:oBuffers.GetAddress(oBuffers.Length()), Size:vByteCount}
}

;==================================================

JEE_StrJoin(vSep, oArray*)
{
	local
	VarSetStrCapacity(vOutput, oArray.Length()*200)
	if IsObject(vSep) && (vSep.Length() = 1) ;convert 1-item array to string
		vSep := vSep[1]
	if !IsObject(vSep)
	{
		Loop % oArray.Length()-1
			vOutput .= oArray[A_Index] vSep
		vOutput .= oArray[oArray.Length()]
	}
	else
	{
		oSep := vSep
		vLast := oSep.Length()
		vIndex := 0
		Loop % oArray.Length()-1
		{
			;vIndex := Mod(A_Index-1, vLast)+1
			vIndex := (vIndex = vLast) ? 1 : vIndex + 1
			vOutput .= oArray[A_Index] oSep[vIndex]
		}
		vOutput .= oArray[oArray.Length()]
	}
	return vOutput
}

;==================================================

ToolTip(ByRef Text:="", X:="", Y:="", WhichToolTip:=1) ;ByRef for performance
{
	ToolTip, % Text, % X, % Y, % WhichToolTip
}

;==================================================

;simplified version of function:
MsgBox(Text)
{
	MsgBox, % Text
}

;==================================================

Assert(vValue1, vValue2)
{
	;Clipboard := vValue1
	;return

	if (vValue1 != vValue2)
		throw Error("Assert mismatch.`r`n" "Return value: " vValue1 "`r`n" "Expected value: " vValue2, -1)
}

;==================================================

AssertError(oFunc, oParams, vMsg)
{
	vIsSuccess := 0
	try
	{
		vRet := %oFunc%(oParams*)
		vIsSuccess := 1
	}
	catch oError
	{
		if (oError.Message != vMsg)
			throw Error("Function failed as expected, but with unexpected message.`r`n" "Message thrown: " oError.Message "`r`n" "Message expected: " vMsg, -1)
	}
	if vIsSuccess
		throw Error("Function unexpectedly succeeded.`r`n" "Return value: " vRet, -1)
}

;==================================================

;unused Base64Get/Base64Put C++ code:

/*
		// unused Base64Get C++ code:
		UINT_PTR buffer;
		for (int i = 0; i < size/3; ++i, address += 3)
		{
			buffer = (UCHAR)address[0] << 16 | (UCHAR)address[1] << 8 | (UCHAR)address[2];
			*cp++ = b64_chars[(buffer >> 18) & 63];
			*cp++ = b64_chars[(buffer >> 12) & 63];
			*cp++ = b64_chars[(buffer >> 6) & 63];
			*cp++ = b64_chars[buffer & 63];
		}
		if (int rem = size % 3) // 2 or 1.
		{
			buffer = (UCHAR)address[0] << 16;
			if (rem == 2)
				buffer |= (UCHAR)address[1] << 8;
			*cp++ = b64_chars[(buffer >> 18) & 63];
			*cp++ = b64_chars[(buffer >> 12) & 63];
			*cp++ = (rem == 2) ? b64_chars[(buffer >> 6) & 63] : '=';
			*cp++ = '=';
		}
*/

/*
		// unused Base64Put C++ code:
		for (int i = 0; i < chars/4; ++i, cp += 4)
		{
			BYTE bits1 = b64_table[cp[0]];
			BYTE bits2 = b64_table[cp[1]];
			BYTE bits3 = b64_table[cp[2]];
			BYTE bits4 = b64_table[cp[3]];
			*address++ = (bits1 & 0x3F) << 2 | (bits2 & 0x30) >> 4;
			*address++ = (bits2 & 0x0F) << 4 | (bits3 & 0x3C) >> 2;
			*address++ = (bits3 & 0x03) << 6 | bits4;
		}
		if (chars % 4) // 3 or 2.
		{
			BYTE bits1 = b64_table[text[0]];
			BYTE bits2 = b64_table[text[1]];
			BYTE bits3 = b64_table[text[2]];
			*address++ = (bits1 & 0x3F) << 2 | (bits2 & 0x30) >> 4;
			if (chars & 1)
				*address++ = (bits2 & 0x0F) << 4 | (bits3 & 0x3C) >> 2;
		}
*/

;==================================================
```