### PR TITLE
Adding ability to specify arbitrary expressions for parameter defaults.

### DIFF
--- a/source/script.h
+++ b/source/script.h
@@ -1520,7 +1520,6 @@ struct ScriptItemList
 	ResultType Alloc(int aAllocCount);
 };
 
-class Func;
 typedef ScriptItemList<Func, 4> FuncList; // Initial count is small since functions aren't expected to contain many nested functions.
 typedef ScriptItemList<Var, VARLIST_INITIAL_SIZE> VarList;
 

--- a/source/script.h
+++ b/source/script.h
@@ -1487,13 +1487,13 @@ public:
 
 
 
-enum FuncParamDefaults {PARAM_DEFAULT_NONE, PARAM_DEFAULT_STR, PARAM_DEFAULT_INT, PARAM_DEFAULT_FLOAT, PARAM_DEFAULT_UNSET};
+enum FuncParamDefaults {PARAM_DEFAULT_NONE, PARAM_DEFAULT_STR, PARAM_DEFAULT_INT, PARAM_DEFAULT_FLOAT, PARAM_DEFAULT_EXPR, PARAM_DEFAULT_UNSET};
 struct FuncParam
 {
 	Var *var;
 	WORD is_byref; // Boolean, but defined as WORD in case it helps data alignment and/or performance (BOOL vs. WORD didn't help benchmarks).
 	WORD default_type;
-	union {LPTSTR default_str; __int64 default_int64; double default_double;};
+	union { LPTSTR default_str; __int64 default_int64; double default_double; UserFunc *default_expr; };
 };
 
 struct FuncResult : public ResultToken
@@ -1674,6 +1674,7 @@ public:
 #define VAR_DECLARE_STATIC (VAR_DECLARED | VAR_LOCAL | VAR_LOCAL_STATIC)
 	UCHAR mDefaultVarType = VAR_DECLARE_LOCAL;
 
+	bool mHasParamExpr = false; // Indicates that this function has at least one parameter with a default expr, eg, f(param := expr)
 	UserFunc(LPCTSTR aName) : Func(aName) {}
 
 	bool IsBuiltIn() override { return false; }
@@ -3020,6 +3021,8 @@ public:
 	LineNumberType CurrentLine();
 	LPTSTR CurrentFile();
 	static ActionTypeType ConvertActionType(LPCTSTR aActionTypeString);
+
+	ResultType DefineParamExpr(UserFunc* aFunc);
 
 	enum SetTimerFlags
 	{

--- a/source/script.h
+++ b/source/script.h
@@ -1707,12 +1707,13 @@ public:
 	// Execute the body of the function.
 	ResultType Execute(ResultToken *aResultToken)
 	{
+		// Caller must manage the setting and restoring of g->CurrentFunc if appropriate.
+		
 		// The performance gain of conditionally passing NULL in place of result (when this is the
 		// outermost function call of a line consisting only of function calls, namely ACT_EXPRESSION)
 		// would not be significant because the Return command's expression (arg1) must still be evaluated
 		// in case it calls any functions that have side-effects, e.g. "return LogThisError()".
-		auto prev_func = g->CurrentFunc; // This will be non-NULL when a function is called from inside another function.
-		g->CurrentFunc = this;
+		
 		// Although a GOTO that jumps to a position outside of the function's body could be supported,
 		// it seems best not to for these reasons:
 		// 1) The extreme rarity of a legitimate desire to intentionally do so.
@@ -1754,11 +1755,6 @@ public:
 			}
 		}
 #endif
-
-		// Restore the original value in case this function is called from inside another function.
-		// Due to the synchronous nature of recursion and recursion-collapse, this should keep
-		// g->CurrentFunc accurate, even amidst the asynchronous saving and restoring of "g" itself:
-		g->CurrentFunc = prev_func;
 		return result;
 	}
 


### PR DESCRIPTION
**New**
```autohotkey
f(param := expr) { ... }
```
where _expr_ is evaluated and its result is assigned to _param_ each time _param_ is omitted when calling _f_. _expr_ is evaluated in an unnamed nested function in _f_.  All nested functions are added first in _f's_ function body (after the opening brace). This implies the behaviour and scope of the expression evaluation. A notable difference being that if _f_ is a method/prop, the keyword _super_ is supported.

**About**
`FuncParamDefaults::PARAM_DEFAULT_EXPR` is added to indicate that a parameter uses an expression for its value if omitted. This is detected in `DefineFunc` and there the expression string is temporarily stored in `FuncParam::default_str`. `AddLine` then calls `DefineParamExpr` for each function which has any parameters with default expressions. `DefineParamExpr` inserts the expressions as nested functions.

Previous code for handling default values are mostly unchanged, these are kept as optimisations. The debugger have not been considered.

**Pro**

* Convenience, flexibility and brevity (if not misused).
* Minor performance in some cases (guess).
* You can reference **previously assigned** parameters, eg `shape(width, height := width) => ...`
* Simple implementation (a weak argument I suppose, but the only reason I even considered implementing it)

**Con**

* You can reference static variables, but they risk not being assigned a value. Typical trap,
```autothotkey
f(x := y) { 
    static y := 0
}
f    ; y not assigned
f 1  ; no issue
f    ; now it works
```
* Although it makes sense that you cannot reference a parameter (without a run time error) to the right of _expr_, eg, in `f(x := y, y := '')` `y` is not assigned a value when `x` is being assigned, this might be surprising if `y` was passed a value as in `f(, 0)`. 
* Any reference to `A_ThisFunc` in _expr_ results in a blank string, which is counter-intuitive. I guess this is easy to fix.
* For the same reason `A_ThisFunc` is blank, error reporting is affected when _expr_ fails. 
* Although the implementation is simple, it _piles on_ the code base, without improving it. Also could imply incompatibility and/or inconsitency with a theoretical future `#directive expr` (although that is probably natural).
* __edit__, Added handling of `f(x := "y" z)` which isn't _missing comma_ but concatenation. I suppose that is a bit unfortunate. For example, if you do miss a comma in `f(x := "y" z := "w")` you will not be notified, unless you attempt to call _f_, passing a second parameter.


**Neutral**

* _expr_ is evaluated each time the parameter is omitted, so these aren't _default values_, which might be unexpected in case of something like `f(x:=[])`, where `[]` will be a new array each time _x_ is omitted.


Likely, I forgot something.