### PR TITLE
Adding AddRef/Release to Closure::Call

### DIFF
--- a/source/script_object.cpp
+++ b/source/script_object.cpp
@@ -2602,7 +2602,10 @@ BoundFunc::~BoundFunc()
 
 bool Closure::Call(ResultToken &aResultToken, ExprTokenType *aParam[], int aParamCount)
 {
-	return mFunc->Call(aResultToken, aParam, aParamCount, mVars);
+	AddRef();	// Avoid it being deleted during the call.
+	auto result = mFunc->Call(aResultToken, aParam, aParamCount, mVars);
+	Release();
+	return result;
 }
 
 Closure::~Closure()


### PR DESCRIPTION
__Reason__ 

To avoid the closure being deleted during the call.

__Issue example__

```autohotkey
f(){
	a := 1
	hotkey 'q', g
	g(t){
		hotkey t, t=>0 ; current branch: closure deleted
		(a) 
	}
}
f
```
Similar examples can be made with at least `onmessage` and `gui.onevent`.