### PR TITLE
v2: Added '0b' prefix binary integer support.

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -5549,7 +5549,7 @@ ResultType Script::ParseOperands(LPTSTR aArgText, LPTSTR aArgMap, DerefList &aDe
 		{
 			// Behaviour here should match the similar section in ExpressionToPostfix().
 			istrtoi64(op_begin, &op_end);
-			if (!IS_HEX(op_begin)) // This check is probably only needed on VC++ 2015 and later, where _tcstod allows hex.
+			if (!IS_HEX(op_begin) && !IS_BIN(op_begin)) // This hex check is probably only needed on VC++ 2015 and later, where _tcstod allows hex.
 			{
 				LPTSTR d_end;
 				_tcstod(op_begin, &d_end);
@@ -8459,7 +8459,7 @@ unquoted_literal:
 						// elsewhere in the code, such as in IsNumeric().
 						LPTSTR i_end, d_end;
 						__int64 i = istrtoi64(cp, &i_end);
-						if (!IsHex(cp))
+						if (!IsHex(cp) && !IsBin(cp))
 						{
 							double d = _tcstod(cp, &d_end);
 							if (d_end > i_end && _tcschr(EXPR_OPERAND_TERMINATORS, *d_end))

--- a/source/util.cpp
+++ b/source/util.cpp
@@ -344,8 +344,9 @@ SymbolType IsNumeric(LPCTSTR aBuf, BOOL aAllowNegative, BOOL aAllowAllWhitespace
 
 	// Relies on short circuit boolean order to prevent reading beyond the end of the string:
 	BOOL is_hex = IS_HEX(aBuf); // BOOL vs. bool might squeeze a little more performance out this frequently-called function.
-	if (is_hex)
-		aBuf += 2;  // Skip over the 0x prefix.
+	BOOL is_bin = IS_BIN(aBuf);
+	if (is_hex || is_bin)
+		aBuf += 2;  // Skip over the 0x/0b prefix.
 
 	// Set defaults:
 	BOOL has_decimal_point = false;
@@ -370,7 +371,7 @@ SymbolType IsNumeric(LPCTSTR aBuf, BOOL aAllowNegative, BOOL aAllowAllWhitespace
 			break; // The number qualifies as pure, so fall through to the logic at the bottom. (It would already have returned elsewhere in the loop if the number is impure).
 		if (c == '.')
 		{
-			if (!aAllowFloat || has_decimal_point || is_hex) // If aAllowFloat==false, a decimal point at the very end of the number is considered non-numeric even if aAllowImpure==true.  Some callers might rely on this.
+			if (!aAllowFloat || has_decimal_point || is_hex || is_bin) // If aAllowFloat==false, a decimal point at the very end of the number is considered non-numeric even if aAllowImpure==true.  Some callers might rely on this.
 				// i.e. if aBuf contains 2 decimal points, it can't be a valid number.
 				// Note that decimal points are allowed in hexadecimal strings, e.g. 0xFF.EE.
 				// But since that format doesn't seem to be supported by VC++'s atof() and probably
@@ -381,7 +382,7 @@ SymbolType IsNumeric(LPCTSTR aBuf, BOOL aAllowNegative, BOOL aAllowAllWhitespace
 		}
 		else
 		{
-			if (is_hex ? !_istxdigit(c) : (c < '0' || c > '9')) // And since we're here, it's not '.' either.
+			if (is_hex ? !_istxdigit(c) : is_bin ? (c < '0' || c > '1') : (c < '0' || c > '9')) // And since we're here, it's not '.' either.
 			{
 				if (aAllowImpure) // Since aStr starts with a number (as verified above), it is considered a number.
 				{
@@ -933,6 +934,23 @@ template<typename T> T xdigitsTo(LPCTSTR p, LPCTSTR &end)
 }
 
 
+template<typename T> T bdigitsTo(LPCTSTR p, LPCTSTR &end)
+{
+	T i = 0;
+	for (;; ++p)
+	{
+		int c = *p;
+		if (c <= '1' && c >= '0')
+			c -= '0';
+		else
+			break;
+		i = i * 2 + c;
+	}
+	end = p;
+	return i;
+}
+
+
 // istrtoi64(): like _tcstoi64, but allows wrapping overflow consistent with
 // arithmetic expressions.  Some behaviour may be unlike _tcstoi64/strtoll:
 //  - Decimal and hexadecimal are always supported; caller cannot specify base.
@@ -959,6 +977,11 @@ __int64 istrtoi64(LPCTSTR buf, LPCTSTR *endptr)
 	{
 		p += 2;
 		i = xdigitsTo<UINT64>(p, end);
+	}
+	else if (IS_BIN(p))
+	{
+		p += 2;
+		i = bdigitsTo<UINT64>(p, end);
 	}
 	else
 	{
@@ -992,6 +1015,11 @@ __int64 nstrtoi64(LPCTSTR buf)
 	{
 		p += 2;
 		i = xdigitsTo<UINT64>(p, p);
+	}
+	else if (IS_BIN(p))
+	{
+		p += 2;
+		i = bdigitsTo<UINT64>(p, p);
 	}
 	else // Decimal.
 	{

--- a/source/util.h
+++ b/source/util.h
@@ -427,6 +427,20 @@ inline bool IsHex(LPCTSTR aBuf) // 10/17/2006: __forceinline worsens performance
 
 
 
+inline bool IsBin(LPCTSTR aBuf)
+{
+	aBuf = omit_leading_whitespace(aBuf); // i.e. caller doesn't have to have ltrimmed.
+	if (!*aBuf)
+		return false;
+	if (*aBuf == '-' || *aBuf == '+')
+		++aBuf;
+	// The "0b" prefix must be followed by at least one bin digit, otherwise it's not considered bin:
+	#define IS_BIN(buf) (*buf == '0' && (*(buf + 1) == 'b' || *(buf + 1) == 'B') && (*(buf + 2) == '0' || *(buf + 2) == '1'))
+	return IS_BIN(aBuf);
+}
+
+
+
 __int64 istrtoi64(LPCTSTR buf, LPCTSTR *endptr);
 
 inline __int64 istrtoi64(LPTSTR buf, LPTSTR *endptr)
@@ -504,7 +518,7 @@ inline double ATOF(LPCTSTR buf)
 // such as "0xFF" automatically.  So this macro must check for hex because some callers rely on that.
 // Also, it uses _strtoi64() vs. strtol() so that more of a double's capacity can be utilized:
 {
-	return IsHex(buf) ? (double)_tcstoi64(buf, NULL, 16) : _tstof(buf);
+	return IsHex(buf) ? (double)_tcstoi64(buf, NULL, 16) : IsBin(buf) ? (double)_tcstoi64(buf+2, NULL, 2) : _tstof(buf);
 }
 
 int FTOA(double aValue, LPTSTR aBuf, int aBufSize);


### PR DESCRIPTION
## Introduction

This PR adds `0b`/`0B` support to integers, equivalent to `0x`/`0X` support.

## Implementation

Equivalents were added for existing hex functionality: e.g. `IS_BIN`, `IsBin`, `bdigitsTo`.
Apologies if anything was overlooked.
Since 'bin' can also refer to binary data, any desire to rename such functions would be understandable.

Perhaps `bdigitsTo` could be rejigged slightly, to save 2 lines. I wrote it as it is currently to match the structure of `xdigitsTo`, and because the compiler should be able to figure out the same optimisation.

## Test code

```
;==================================================

;test code: '0b' prefix (binary integer support) (AHK v2)

;==================================================

;loadtime errors:
;var := 0xZZZ ;Error:  This variable name starts with a number, which is not allowed
;var := 0bZZZ ;Error:  This variable name starts with a number, which is not allowed
;var := 0b999 ;Error:  This variable name starts with a number, which is not allowed
;var := 0b1112 ;Error:  This variable name starts with a number, which is not allowed
;var := 0x ;Error:  This variable name starts with a number, which is not allowed
;var := 0b ;Error:  This variable name starts with a number, which is not allowed

;==================================================

;confirm that digits beyond 0xFFFFFFFFFFFFFFFF are 'ignored' (left-shifted away during calculations):
var := 0xF000000000000000F ;17 hex digits
Assert(var, 15)
var := 0b10000000000000000000000000000000000000000000000000000000000000111 ;65 bin digits
Assert(var, 7)
var := 0xFFFFFFFFFFFFFFFFF ;17 hex digits
Assert(var, -1)
var := 0b11111111111111111111111111111111111111111111111111111111111111111 ;65 bin digits
Assert(var, -1)

var := 0b111
Assert(var, 7)
var := Integer("0b1111")
Assert(var, 15)
var := Float("0b1111")
Assert(var, 15.0)

var := 0x1
Assert(var, 1)
var := Integer("0x11")
Assert(var, 17)
var := Float("0x11")
Assert(var, 17.0)

;5 tests from adding binary support to Format (AHK v1):
Assert(Format("{:u}", "0b000"), 0)
Assert(Format("{:u}", "0b111"), 7)
Assert(Format("{:u}", "0b00000111"), 7)
Assert(Format("{:i}", "0b1111111111111111111111111111111111111111111111111111111111111111"), -1)
Assert(Format("{:u}", "0b1111111111111111111111111111111111111111111111111111111111111111"), "18446744073709551615")

var := 0b1111
Assert(Format("{:04}", var), 0015)
Assert(Format("{:04}", 0b1111), 0015)
Assert(Format("{:08}", "0b1111"), "000b1111")
Assert(Format("{:u}", "0b1111"), 15)

var := 0x11
Assert(Format("{:04}", var), 0017)
Assert(Format("{:04}", 0x11), 0017)
Assert(Format("{:08}", "0x11"), "00000x11")
Assert(Format("{:u}", "0x11"), 17)

MsgBox("done")
return

;==================================================

Assert(vValue1, vValue2)
{
	if (vValue1 != vValue2)
		throw Error("Assert mismatch.`r`n" "Return value: " vValue1 "`r`n" "Expected value: " vValue2, -1)
}

;==================================================
```