### PR TITLE
v1: Added Array support to NumGet/NumPut.

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8460,7 +8460,7 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 	else if (!_tcsicmp(func_name, _T("NumGet")))
 	{
 		bif = BIF_NumGet;
-		max_params = 3;
+		max_params = 4;
 	}
 	else if (!_tcsicmp(func_name, _T("NumPut")))
 	{


### PR DESCRIPTION
## Documentation

`NumGet`:
A `Count` parameter is added.
If the `Count` parameter is used, `NumGet` returns an array with that many values.
If the `Count` parameter is omitted, `NumGet` returns an Integer or Float.

`NumPut`:
For the `Number` parameter, an array can be specified, allowing multiple values of the same type to be written consecutively.

```
Number := NumGet(VarOrAddress , [, Offset := 0][, Type := "UPtr"][, Count])
NumPut(Number, VarOrAddress [, Offset := 0][, Type := "UPtr"])
```

## Implementation

`Type` would be compulsory for both functions in AHK v2 (as they are currently).

An alternative implementation for `NumGet` might have `Type` accept an object with type and count properties.

At present, `Type` can't be an array.
I didn't intend to implement this, but wouldn't oppose it.
(E.g. a Type array would let you tailor a `NumPut` call for a 64-bit or 32-bit struct by picking the appropriate array. But I prefer to use custom/built-in struct handling for such situations.)

## Array parameters v. parameter lists

Is there any general objection to the increased use of arrays as input parameters in built-in functions? E.g. some concern such as overhead or speed.

E.g. when I wrote a `StrContains` function, would the main developer be happy with the regular use of arrays in the needle parameter, or would that be 'slow'.
Would it be sufficiently slow that hardcoded arrays in a script should be optimised at loadtime?

I had wondered why the current AHK v2 `NumPut` implementation uses Type/Value pairs instead of say accepting a Type array and a Value array. If this was the reason.

## Comments

Here are 6 examples where array functionality can be useful:
POINT, RECT, SYSTEMTIME, IAudioVolumeLevel::SetLevelAllChannels, LB_GETSELITEMS, SetDeviceGammaRamp.
As well as general reading from buffers (Chars/Shorts/Ints/Int64s/Floats/Doubles/Ptrs).

What about `NumPut` in AHK v2?
- I would find 'classic NumPut plus array support' more practical than the 'DllCall-style NumPut', because you don't have to intersperse the types, and because arrays can be used by both `NumGet` and `NumPut`.
- (I also like and find useful when coding at speed, the symmetry between the function pair, and other read/write and get/set function pairs.)
- However, I do not oppose the existence of a 'DllCall-style NumPut' function.
- I would suggest that `NumPut` be split into 2 functions in AHK v2: `NumPut` as demonstrated here (but with a compulsory `Type` parameter), and a separate 'DllCall-style NumPut' called `NumPutPairs` or something else.

## Test code
```
;==================================================

;test code: NumGet/NumPut (Array support) (AHK v1)

;==================================================

oBuf := JEE_BufferSimple(100)

;test put/get individual item still works:
for _, vType in StrSplit("UInt,UInt64,Int,Int64,Short,UShort,Char,UChar,Double,Float,Ptr,UPtr", ",")
{
	NumPut(1, oBuf.Ptr, 0, vType)
	Assert(NumGet(oBuf.Ptr, 0, vType), 1)

	if (Ord(vType) = Ord("U"))
		continue
	NumPut(-1, oBuf.Ptr, 0, vType)
	Assert(NumGet(oBuf.Ptr, 0, vType), -1)
}

;test put/get to array:
Loop 10
	NumPut(A_Index, oBuf.Ptr, A_Index-1, "UChar")
oArray := NumGet(oBuf.Ptr, 0, "UChar", 10)
Assert(JEE_StrJoin(",", oArray*), "1,2,3,4,5,6,7,8,9,10")

NumPut([11,22,33,44,55,66,77,88,99,0], oBuf.Ptr, 0, "UChar")
oArray := NumGet(oBuf.Ptr, 0, "UChar", 10)
Assert(JEE_StrJoin(",", oArray*), "11,22,33,44,55,66,77,88,99,0")

;==================================================

AssertError("NumGet", [oBuf.Ptr, 0, "UChar", -1], "Invalid item count.")

;==================================================

Loop 10
	NumPut(A_Index+0.5, oBuf.Ptr, A_Index*8-8, "Double")
oArray := NumGet(oBuf.Ptr, 0, "Double", 10)
Assert(JEE_StrJoin(",", oArray*), "1.500000,2.500000,3.500000,4.500000,5.500000,6.500000,7.500000,8.500000,9.500000,10.500000")

NumPut([11.5,22.5,33.5,44.5,55.5,66.5,77.5,88.5,99.5,0.5], oBuf.Ptr, 0, "Double")
oArray := NumGet(oBuf.Ptr, 0, "Double", 10)
Assert(JEE_StrJoin(",", oArray*), "11.500000,22.500000,33.500000,44.500000,55.500000,66.500000,77.500000,88.500000,99.500000,0.500000")

;==================================================

MsgBox("done")
return

;==================================================

JEE_BufferSimple(vByteCount, vFillByte:="")
{
	static vIsV1 := (InStr(A_AhkVersion, "1.") == 1)
	static oBuffers, vIsReady
	if !vIsV1
	{
		vClassName := "Buffer"
		return %vClassName%(vByteCount, (vFillByte=""?[]:[vFillByte])*)
	}
	if !VarSetStrCapacity(vIsReady)
	{
		oBuffers := []
		vIsReady := "1"
	}
	oBuffers.Push("")
	oBuffers.SetCapacity(oBuffers.Length(), vByteCount)
	if !(vFillByte = "")
		DllCall("kernel32\RtlFillMemory", "Ptr",oBuffers.GetAddress(oBuffers.Length()), "UPtr",vByteCount, "UChar",vFillByte)
	return {Ptr:oBuffers.GetAddress(oBuffers.Length()), Size:vByteCount}
}

;==================================================

VarSetStrCapacity(ByRef TargetVar, RequestedCapacity:="")
{
	static ChrSize, IsReady
	if !VarSetCapacity(IsReady)
	{
		ChrSize := A_IsUnicode ? 2 : 1
		IsReady := "1"
	}
	if (RequestedCapacity = "")
		return VarSetCapacity(TargetVar) // ChrSize
	else if (RequestedCapacity = -1)
		return VarSetCapacity(TargetVar, -1) // ChrSize
	return VarSetCapacity(TargetVar, RequestedCapacity*ChrSize) // ChrSize
}

;==================================================

;simplified version of function:
MsgBox(Text)
{
	MsgBox, % Text
}

;==================================================

JEE_StrJoin(vSep, oArray*)
{
	local
	VarSetStrCapacity(vOutput, oArray.Length()*200)
	if IsObject(vSep) && (vSep.Length() = 1) ;convert 1-item array to string
		vSep := vSep[1]
	if !IsObject(vSep)
	{
		Loop % oArray.Length()-1
			vOutput .= oArray[A_Index] vSep
		vOutput .= oArray[oArray.Length()]
	}
	else
	{
		oSep := vSep
		vLast := oSep.Length()
		vIndex := 0
		Loop % oArray.Length()-1
		{
			;vIndex := Mod(A_Index-1, vLast)+1
			vIndex := (vIndex = vLast) ? 1 : vIndex + 1
			vOutput .= oArray[A_Index] oSep[vIndex]
		}
		vOutput .= oArray[oArray.Length()]
	}
	return vOutput
}

;==================================================

Assert(vValue1, vValue2)
{
	;Clipboard := vValue1
	;return

	if (vValue1 != vValue2)
		throw Error("Assert mismatch.`r`n" "Return value: " vValue1 "`r`n" "Expected value: " vValue2, -1)
}

;==================================================

AssertError(oFunc, oParams, vMsg)
{
	vIsSuccess := 0
	try
	{
		vRet := %oFunc%(oParams*)
		vIsSuccess := 1
	}
	catch oError
	{
		if (oError.Message != vMsg)
			throw Error("Function failed as expected, but with unexpected message.`r`n" "Message thrown: " oError.Message "`r`n" "Message expected: " vMsg, -1)
	}
	if vIsSuccess
		throw Error("Function unexpectedly succeeded.`r`n" "Return value: " vRet, -1)
}

;==================================================

Error(Message, Params*) ;Message, What, Extra
{
	local What
	if (Params.Length() > 2)
		throw Exception("Too many parameters passed to function.", -1)
	if !Params.HasKey(1)
		Params[1] := 0
	What := Params[1]
	if What is integer
		Params[1]--
	return Exception(Message, Params*)
}

;==================================================
```