### PR TITLE
v2: Added support for structes that passed by value

### DIFF
--- a/source/script.h
+++ b/source/script.h
@@ -598,6 +598,7 @@ enum DllArgTypes {
 	, DLL_ARG_FLOAT
 	, DLL_ARG_DOUBLE
 	, DLL_ARG_WSTR
+	, DLL_ARG_STRUCT
 	, DLL_ARG_STR  = UorA(DLL_ARG_WSTR, DLL_ARG_ASTR)
 	, DLL_ARG_xSTR = UorA(DLL_ARG_ASTR, DLL_ARG_WSTR) // To simplify some sections.
 };  // Some sections might rely on DLL_ARG_INVALID being 0.

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -10609,9 +10609,14 @@ struct DYNAPARM
 	// Might help reduce struct size to keep other members last and adjacent to each other (due to
 	// 8-byte alignment caused by the presence of double and __int64 members in the union above).
 	DllArgTypes type;
-	bool passed_by_address;
-	bool is_unsigned; // Allows return value and output parameters to be interpreted as unsigned vs. signed.
-	bool is_hresult; // Only used for the return value.
+	union {
+		int struct_size;
+		struct {
+			bool passed_by_address;
+			bool is_unsigned; // Allows return value and output parameters to be interpreted as unsigned vs. signed.
+			bool is_hresult; // Only used for the return value.
+		};
+	};
 };
 
 #ifdef _WIN64
@@ -10635,9 +10640,9 @@ static inline UINT_PTR DynaParamToElement(DYNAPARM& parm)
 
 #ifdef WIN32_PLATFORM
 DYNARESULT DynaCall(int aFlags, void *aFunction, DYNAPARM aParam[], int aParamCount, DWORD &aException
-	, void *aRet, int aRetSize)
+	, void *aRet, int aRetSize, DWORD aExtraStackSize = 0)
 #elif defined(_WIN64)
-DYNARESULT DynaCall(void *aFunction, DYNAPARM aParam[], int aParamCount, DWORD &aException)
+DYNARESULT DynaCall(void *aFunction, DYNAPARM aParam[], int aParamCount, DWORD &aException, void* aRet = nullptr)
 #else
 #error DllCall not supported on this platform
 #endif
@@ -10654,19 +10659,19 @@ DYNARESULT DynaCall(void *aFunction, DYNAPARM aParam[], int aParamCount, DWORD &
 
 	// Declaring all variables early should help minimize stack interference of C code with asm.
 	DWORD *our_stack;
-    int param_size;
-	DWORD stack_dword, our_stack_size = 0; // Both might have to be DWORD for _asm.
-	BYTE *cp;
-    DWORD esp_start, esp_end, dwEAX, dwEDX;
+	// Used to read the structure
+	DWORD *pdword;
+	DWORD esp_start, esp_end, dwEAX, dwEDX;
 	int i, esp_delta; // Declare this here rather than later to prevent C code from interfering with esp.
 
 	// Reserve enough space on the stack to handle the worst case of our args (which is currently a
 	// maximum of 8 bytes per arg). This avoids any chance that compiler-generated code will use
 	// the stack in a way that disrupts our insertion of args onto the stack.
-	DWORD reserved_stack_size = aParamCount * 8;
+	DWORD reserved_stack_size = aParamCount * 8 + aExtraStackSize;
 	_asm
 	{
 		mov our_stack, esp  // our_stack is the location where we will write our args (bypassing "push").
+		mov esp_start, esp  // For detecting whether a DC_CALL_STD function was sent too many or too few args.
 		sub esp, reserved_stack_size  // The stack grows downward, so this "allocates" space on the stack.
 	}
 
@@ -10675,37 +10680,32 @@ DYNARESULT DynaCall(void *aFunction, DYNAPARM aParam[], int aParamCount, DWORD &
 	for (i = aParamCount - 1; i > -1; --i)
 	{
 		DYNAPARM &this_param = aParam[i]; // For performance and convenience.
-		// Push the arg or its address onto the portion of the stack that was reserved for our use above.
-		if (this_param.passed_by_address)
+		if (this_param.type == DLL_ARG_STRUCT)
 		{
-			stack_dword = (DWORD)(size_t)&this_param.value_int; // Any union member would work.
-			--our_stack;              // ESP = ESP - 4
-			*our_stack = stack_dword; // SS:[ESP] = stack_dword
-			our_stack_size += 4;      // Keep track of how many bytes are on our reserved portion of the stack.
+			int& size = this_param.struct_size;
+			ASSERT(!(size % 4));
+			for (pdword = (DWORD*)(this_param.value_uintptr + size); size; size -= 4)
+				*--our_stack = *--pdword;
 		}
+		// Push the arg or its address onto the portion of the stack that was reserved for our use above.
+		else if (this_param.passed_by_address)
+			*--our_stack = (DWORD)&this_param.value_int; // Any union member would work.
 		else // this_param's value is contained directly inside the union.
 		{
-			param_size = (this_param.type == DLL_ARG_INT64 || this_param.type == DLL_ARG_DOUBLE) ? 8 : 4;
-			our_stack_size += param_size; // Must be done before our_stack_size is decremented below.  Keep track of how many bytes are on our reserved portion of the stack.
-			cp = (BYTE *)&this_param.value_int + param_size - 4; // Start at the right side of the arg and work leftward.
-			while (param_size > 0)
-			{
-				stack_dword = *(DWORD *)cp;  // Get first four bytes
-				cp -= 4;                     // Next part of argument
-				--our_stack;                 // ESP = ESP - 4
-				*our_stack = stack_dword;    // SS:[ESP] = stack_dword
-				param_size -= 4;
+			if (this_param.type == DLL_ARG_INT64 || this_param.type == DLL_ARG_DOUBLE) {
+				our_stack -= 2;
+				*(__int64*)our_stack = this_param.value_int64;
 			}
+			else
+				*--our_stack = this_param.value_uintptr;
 		}
-    }
+	}
 
 	if ((aRet != NULL) && ((aFlags & DC_BORLAND) || (aRetSize > 8)))
 	{
 		// Return value isn't passed through registers, memory copy
 		// is performed instead. Pass the pointer as hidden arg.
-		our_stack_size += 4;       // Add stack size
-		--our_stack;               // ESP = ESP - 4
-		*our_stack = (DWORD)(size_t)aRet;  // SS:[ESP] = pMem
+		*--our_stack = (DWORD)aRet;	// ESP = ESP - 4, SS:[ESP] = pMem
 	}
 
 	// Call the function.
@@ -10713,10 +10713,8 @@ DYNARESULT DynaCall(void *aFunction, DYNAPARM aParam[], int aParamCount, DWORD &
 	{
 		_asm
 		{
-			add esp, reserved_stack_size // Restore to original position
-			mov esp_start, esp      // For detecting whether a DC_CALL_STD function was sent too many or too few args.
-			sub esp, our_stack_size // Adjust ESP to indicate that the args have already been pushed onto the stack.
-			call [aFunction]        // Stack is now properly built, we can call the function
+			mov esp, our_stack	   // Adjust ESP to indicate that the args have already been pushed onto the stack.
+			call[aFunction]        // Stack is now properly built, we can call the function
 		}
 	}
 	__except(EXCEPTION_EXECUTE_HANDLER)
@@ -10764,7 +10762,7 @@ DYNARESULT DynaCall(void *aFunction, DYNAPARM aParam[], int aParamCount, DWORD &
 	else if (((aFlags & DC_BORLAND) == 0) && (aRetSize <= 8))
 	{
 		// Microsoft optimized less than 8-bytes structure passing
-        _asm
+		_asm
 		{
 			mov ecx, DWORD PTR [aRet]
 			mov eax, [dwEAX]
@@ -10777,13 +10775,15 @@ DYNARESULT DynaCall(void *aFunction, DYNAPARM aParam[], int aParamCount, DWORD &
 #endif // WIN32_PLATFORM
 #ifdef _WIN64
 
-	int params_left = aParamCount;
+	int params_left = aParamCount, i = 0;
 	DWORD_PTR regArgs[4];
 	DWORD_PTR* stackArgs = NULL;
 	size_t stackArgsSize = 0;
 
 	// The first four parameters are passed in x64 through registers... like ARM :D
-	for(int i = 0; (i < 4) && params_left; i++, params_left--)
+	if (aRet)
+		regArgs[i++] = (DWORD_PTR)aRet;
+	for(; (i < 4) && params_left; i++, params_left--)
 		regArgs[i] = DynaParamToElement(aParam[i]);
 
 	// Copy the remaining parameters
@@ -10908,8 +10908,14 @@ void ConvertDllArgType(LPTSTR aBuf, DYNAPARM &aDynaParam)
 #undef TEST_TYPE
 	else // It's non-blank but an unknown type.
 	{
-		aDynaParam.type = DLL_ARG_INVALID; 
-		return;
+		int b = 0;
+		if (!aDynaParam.passed_by_address && !aDynaParam.is_unsigned && (isdigit(buf[b]) || !_tcsnicmp(buf, _T("Struct"), b = 6) && isdigit(buf[b]))) {
+			int i = b + 1, n = buf[b] - '0';
+			while (isdigit(buf[i])) n = n * 10 + (buf[i++] - '0');
+			aDynaParam.struct_size = n;
+			aDynaParam.type = n && buf[i] == 0 ? DLL_ARG_STRUCT : DLL_ARG_INVALID;
+		}
+		else aDynaParam.type = DLL_ARG_INVALID;
 	}
 	return; // Since above didn't "return", the type is explicitly valid
 	
@@ -11074,9 +11080,37 @@ BIF_DECL(BIF_DllCall)
 
 	// Determine the type of return value.
 	DYNAPARM return_attrib = {0}; // Init all to default in case ConvertDllArgType() isn't called below. This struct holds the type and other attributes of the function's return value.
+	void* return_struct_ptr = nullptr;
+	int return_struct_size = 0;
 #ifdef WIN32_PLATFORM
 	int dll_call_mode = DC_CALL_STD; // Set default.  Can be overridden to DC_CALL_CDECL and flags can be OR'd into it.
+	int struct_extra_size = 0;
 #endif
+
+#ifdef UNICODE
+#define UorA_(u, a) u
+#else
+#define UorA_(u, a) a
+#endif // UNICODE
+	// for Unicode <-> ANSI charset conversion
+	UorA_(CStringA**, CStringW**) pStr;
+	struct _AutoFree {
+		HMODULE hmodule_to_free;
+		BufferObject* return_struct_obj;
+		UorA_(CStringA**, CStringW**) ptr;
+		int len;
+		~_AutoFree() {
+			for (int i = 0; i < len; i++)
+				if (ptr[i])
+					delete ptr[i];
+			if (return_struct_obj)
+				return_struct_obj->Release();
+			if (hmodule_to_free)
+				FreeLibrary(hmodule_to_free);
+		}
+	} free_after_exit{0};	// Avoid memory leaks when _f_throw_xxx
+#undef UorA_
+
 	if ( !(aParamCount % 2) ) // An even number of parameters indicates the return type has been omitted. aParamCount excludes DllCall's first parameter at this point.
 	{
 		return_attrib.type = DLL_ARG_INT;
@@ -11112,8 +11146,16 @@ BIF_DECL(BIF_DllCall)
 		}
 		else
 			ConvertDllArgType(return_type_string, return_attrib);
-		if (return_attrib.type == DLL_ARG_INVALID)
-			_f_throw_value(ERR_INVALID_RETURN_TYPE);
+		if (return_attrib.type == DLL_ARG_INVALID) {	// integer is considered structure size
+			int size;
+			if (TokenIsPureNumeric(token) != SYM_INTEGER || (size = (int)TokenToInt64(token)) < 1)
+				_f_throw_value(ERR_INVALID_RETURN_TYPE);
+			return_attrib.type = DLL_ARG_STRUCT;
+			return_struct_size = size;
+		}
+		else if (return_attrib.type == DLL_ARG_STRUCT)
+			return_struct_size = return_attrib.struct_size, return_attrib.struct_size = 0;
+
 has_valid_return_type:
 		--aParamCount;  // Remove the last parameter from further consideration.
 #ifdef WIN32_PLATFORM
@@ -11125,6 +11167,20 @@ has_valid_return_type:
 				dll_call_mode |= DC_RETVAL_MATH4;
 		}
 #endif
+	}
+
+	if (return_struct_size) {
+		if (auto p = malloc(return_struct_size))
+			free_after_exit.return_struct_obj = BufferObject::Create(p, return_struct_size);
+		else
+			_f_throw_oom;
+
+		if (!(return_struct_size == 1 || return_struct_size == 2 || return_struct_size == 4 || return_struct_size == 8)) {
+			return_struct_ptr = free_after_exit.return_struct_obj->Data();
+#ifdef WIN32_PLATFORM
+			dll_call_mode |= DC_BORLAND;
+#endif
+		}
 	}
 
 	// Using stack memory, create an array of dll args large enough to hold the actual number of args present.
@@ -11139,14 +11195,11 @@ has_valid_return_type:
 
 	LPTSTR arg_type_string;
 	int i = arg_count * sizeof(void *);
-	// for Unicode <-> ANSI charset conversion
-#ifdef UNICODE
-	CStringA **pStr = (CStringA **)
-#else
-	CStringW **pStr = (CStringW **)
-#endif
-	_alloca(i); // _alloca vs malloc can make a significant difference to performance in some cases.
+
+	pStr = UorA(CStringA**, CStringW**)_alloca(i); // _alloca vs malloc can make a significant difference to performance in some cases.
 	memset(pStr, 0, i);
+	free_after_exit.ptr = pStr;
+	free_after_exit.len = arg_count;
 
 	// Above has already ensured that after the first parameter, there are either zero additional parameters
 	// or an even number of them.  In other words, each arg type will have an arg value to go with it.
@@ -11158,11 +11211,16 @@ has_valid_return_type:
 
 		arg_type_string = TokenToString(*aParam[i]); // aBuf not needed since numbers and "" are equally invalid.
 		ConvertDllArgType(arg_type_string, this_dyna_param);
-		if (this_dyna_param.type == DLL_ARG_INVALID)
-			_f_throw_value(ERR_INVALID_ARG_TYPE);
+		if (this_dyna_param.type == DLL_ARG_INVALID) {
+			int size;
+			if (TokenIsPureNumeric(*aParam[i]) != SYM_INTEGER || (size = (int)TokenToInt64(*aParam[i])) < 1)
+				_f_throw_value(ERR_INVALID_ARG_TYPE);
+			this_dyna_param.type = DLL_ARG_STRUCT;
+			this_dyna_param.struct_size = size;
+		}
 
 		IObject *this_param_obj = TokenToObject(*aParam[i + 1]);
-		if (this_param_obj)
+		if (this_param_obj && this_dyna_param.type != DLL_ARG_STRUCT)
 		{
 			if ((this_dyna_param.passed_by_address || this_dyna_param.type == DLL_ARG_STR)
 				&& dynamic_cast<VarRef*>(this_param_obj))
@@ -11248,6 +11306,43 @@ has_valid_return_type:
 				this_dyna_param.value_float = (float)this_dyna_param.value_double;
 			break;
 
+		case DLL_ARG_STRUCT: {
+			if (this_param_obj) {
+				GetBufferObjectPtr(aResultToken, this_param_obj, this_dyna_param.value_uintptr);
+				if (aResultToken.Exited())
+					return;
+			}
+			else if (TokenIsPureNumeric(this_param) == SYM_INTEGER)
+				this_dyna_param.value_int64 = TokenToInt64(this_param);
+			else
+				_o_throw_type(_T("Integer"), this_param);
+			if (this_dyna_param.value_uintptr < 65536)
+				_o_throw_value(ERR_INVALID_VALUE);
+
+			int& size = this_dyna_param.struct_size;
+#ifdef _WIN64
+			this_dyna_param.type = DLL_ARG_INT64;
+			if (size <= 8)
+				this_dyna_param.value_int64 = *(__int64*)this_dyna_param.ptr;
+			size = 0;
+#else
+			size = (size + sizeof(void*) - 1) & -(int)sizeof(void*);
+			if (size > 8)
+				struct_extra_size += size - 8;
+			else if (size > 4) {
+				this_dyna_param.type = DLL_ARG_INT64;
+				this_dyna_param.value_int64 = *(__int64*)this_dyna_param.ptr;
+				size = 0;
+			}
+			else {
+				this_dyna_param.type = DLL_ARG_INT;
+				this_dyna_param.value_int = *(int*)this_dyna_param.ptr;
+				size = 0;
+			}
+#endif // _WIN64
+			break;
+		}
+
 		default: // Namely:
 		//case DLL_ARG_INT:
 		//case DLL_ARG_SHORT:
@@ -11275,12 +11370,12 @@ has_valid_return_type:
 	}
 	else if (!function) // The function's address hasn't yet been determined.
 	{
-		function = GetDllProcAddress(function_name, &hmodule_to_free);
+		function = GetDllProcAddress(function_name, &free_after_exit.hmodule_to_free);
 		if (!function)
 		{
 			// GetDllProcAddress has thrown the appropriate exception.
 			aResultToken.SetExitResult(FAIL);
-			goto end;
+			return;
 		}
 	}
 
@@ -11290,10 +11385,11 @@ has_valid_return_type:
 	DWORD exception_occurred; // Must not be named "exception_code" to avoid interfering with MSVC macros.
 	DYNARESULT return_value;  // Doing assignment (below) as separate step avoids compiler warning about "goto end" skipping it.
 #ifdef WIN32_PLATFORM
-	return_value = DynaCall(dll_call_mode, function, dyna_param, arg_count, exception_occurred, NULL, 0);
+	return_value = DynaCall(dll_call_mode, function, dyna_param, arg_count, exception_occurred
+		, return_struct_ptr, return_struct_size, struct_extra_size + (return_struct_ptr ? 4 : 0));
 #endif
 #ifdef _WIN64
-	return_value = DynaCall(function, dyna_param, arg_count, exception_occurred);
+	return_value = DynaCall(function, dyna_param, arg_count, exception_occurred, return_struct_ptr);
 #endif
 
 	if (*Var::sEmptyString)
@@ -11447,6 +11543,11 @@ has_valid_return_type:
 			aResultToken.symbol = SYM_FLOAT; // There is no SYM_DOUBLE since all floats are stored as doubles.
 			aResultToken.value_double = return_value.Double;
 			break;
+		case DLL_ARG_STRUCT:
+			if (!return_struct_ptr)
+				memcpy(free_after_exit.return_struct_obj->Data(), &return_value.Int64, return_struct_size);
+			aResultToken.SetValue(free_after_exit.return_struct_obj);
+			break;
 		//default: // Should never be reached unless there's a bug.
 		//	aResultToken.symbol = SYM_STRING;
 		//	aResultToken.marker = "";
@@ -11463,7 +11564,7 @@ has_valid_return_type:
 		if (IObject * obj = TokenToObject(this_param)) // Implies the type is "Ptr" or "Ptr*".
 		{
 			if (this_dyna_param.passed_by_address)
-				SetObjectIntProperty(obj, _T("Ptr"), this_dyna_param.value_int64, aResultToken);
+				SetObjectIntProperty(obj, _T("Ptr"), this_dyna_param.value_uintptr, aResultToken);
 			continue;
 		}
 
@@ -11538,12 +11639,8 @@ has_valid_return_type:
 		}
 	}
 
-end:
-	for (arg_count = (aParamCount / 2) - 1; arg_count >= 0; --arg_count)
-		if (pStr[arg_count])
-			delete pStr[arg_count];
-	if (hmodule_to_free)
-		FreeLibrary(hmodule_to_free);
+	if (aResultToken.symbol == SYM_OBJECT)
+		free_after_exit.return_struct_obj = nullptr;	// Avoid buffer obj be released
 }
 
 #endif


### PR DESCRIPTION
Currently, the supported invocation methods are as follows.
```
DllCall(func, structsize := 16, structptr, retsize := 32)
DllCall(func, 'struct16', structptr, 'cdecl struct32')
DllCall(func, '16', structptr, 'cdecl 32')
ComCall(index, thisptr, structsize := 16, structptr, retsize := 32)
...
```