### PR TITLE
v2: Changed ControlClick to use fewer parameters.

### DIFF
--- a/source/keyboard_mouse.cpp
+++ b/source/keyboard_mouse.cpp
@@ -1876,6 +1876,8 @@ void ParseClickOptions(LPTSTR aOptions, int &aX, int &aY, vk_type &aVK, KeyEvent
 	// Set defaults for all output parameters for caller.
 	aX = COORD_UNSPECIFIED;
 	aY = COORD_UNSPECIFIED;
+	int x_alt = COORD_UNSPECIFIED;
+	int y_alt = COORD_UNSPECIFIED;
 	aVK = VK_LBUTTON;
 	aEventType = KEYDOWNANDUP;
 	aRepeatCount = 1;
@@ -1924,6 +1926,14 @@ void ParseClickOptions(LPTSTR aOptions, int &aX, int &aY, vk_type &aVK, KeyEvent
 				case 'D': aEventType = KEYDOWN; break;
 				case 'U': aEventType = KEYUP; break;
 				case 'R': aMoveOffset = true; break; // Since it wasn't recognized as the right mouse button, it must have other letters after it, e.g. Rel/Relative.
+				case 'C': aRepeatCount = ATOI(next_option+1); break;
+
+				// For the below:
+				// Use atoi() vs. ATOI() to avoid interpreting something like 0x01D as hex
+				// when in fact the D was meant to be an option letter:
+				case 'X': x_alt = _ttoi(next_option+1); break;
+				case 'Y': y_alt = _ttoi(next_option+1); break;
+
 				// default: Ignore anything else to reserve them for future use.
 				}
 			}
@@ -1940,6 +1950,11 @@ break_both:
 		aRepeatCount = aX;
 		aX = COORD_UNSPECIFIED;
 	}
+
+	if (x_alt != COORD_UNSPECIFIED)
+		aX = x_alt;
+	if (y_alt != COORD_UNSPECIFIED)
+		aY = y_alt;
 }
 
 

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -61,7 +61,7 @@ FuncEntry g_BIF[] =
 	BIFn(ControlAddItem, 2, 6, BIF_Control),
 	BIFn(ControlChooseIndex, 2, 6, BIF_Control),
 	BIFn(ControlChooseString, 2, 6, BIF_Control),
-	BIF1(ControlClick, 0, 8),
+	BIF1(ControlClick, 0, 6),
 	BIFn(ControlDeleteItem, 2, 6, BIF_Control),
 	BIFn(ControlFindItem, 2, 6, BIF_ControlGet),
 	BIF1(ControlFocus, 1, 5),

--- a/source/script.h
+++ b/source/script.h
@@ -1269,8 +1269,8 @@ public:
 			return VK_LBUTTON; // Some callers rely on this default when !*aBuf.
 		if (!_tcsicmp(aBuf, _T("Right")) || !_tcsicmp(aBuf, _T("R"))) return VK_RBUTTON;
 		if (!_tcsicmp(aBuf, _T("Middle")) || !_tcsicmp(aBuf, _T("M"))) return VK_MBUTTON;
-		if (!_tcsicmp(aBuf, _T("X1"))) return VK_XBUTTON1;
-		if (!_tcsicmp(aBuf, _T("X2"))) return VK_XBUTTON2;
+		if (!_tcsicmp(aBuf, _T("XB1"))) return VK_XBUTTON1;
+		if (!_tcsicmp(aBuf, _T("XB2"))) return VK_XBUTTON2;
 		if (aAllowWheel)
 		{
 			if (!_tcsicmp(aBuf, _T("WheelUp")) || !_tcsicmp(aBuf, _T("WU"))) return VK_WHEEL_UP;


### PR DESCRIPTION
## Introduction

This PR is a simplification of `ControlClick` to make it more like `ControlSend`.

`Control-or-Pos/WhichButton/ClickCount/Options` are replaced with `Options`. 3 fewer parameters.
A `Control` parameter is added. 1 additional parameter.
Net difference: 2 fewer parameters.
The parameters match `ControlSend`.

Before/after:
```
ControlClick Control-or-Pos, WinTitle, WinText, WhichButton, ClickCount, Options, ExcludeTitle, ExcludeText

ControlClick Options, Control, WinTitle, WinText, ExcludeTitle, ExcludeText
```

The `Options` parameter is parsed by `ParseClickOptions`.
`BIF_ControlClick` then checks `Options` for `NA`.
The `Pos` option was removed.

## Changes to `ParseClickOptions` and `ConvertMouseButton`

`ParseClickOptions` now handles `C#/X#/Y#`. (Click count / X position / Y position.)

To simplify the code internally, any values specified by `X#` and `Y#`:
- Are stored separately from any X/Y values specified by `# #` / `# # #`.
- Are applied at the end, so take precedence over `# #` / `# # #`.

`ConvertMouseButton` is used by `ParseClickOptions`.
It now expects `XB1/XB2` to specify XButtons.
`X1/X2` no longer specify XButtons, they specify the X position.

(The `NA` handling is not done by `ParseClickOptions` or `ConvertMouseButton`.)

## Documentation

```
ControlClick Options, Control, WinTitle, WinText, ExcludeTitle, ExcludeText
```

Options:
- `#`: Click count.
- `# #`: X and Y coordinates.
- `# # #`: X and Y coordinates and click count.
- C#: Click count.
- X#: X coordinate.
- Y#: Y coordinate.
- Left/Right/Middle/L/R/M/XB1/XB2: mouse buttons. (But not 'XButton1'/'XButton2'.) (8 labels.)
- WheelUp/WU/WheelDown/WD/WheelLeft/WL/WheelRight/WR: mouse buttons. (8 labels.)
- D/U: Down/up options.
- NA: 'NA' mode.

(Internally, `ConvertMouseButton` handles the 16 button labels.)
(To simplify the code internally, `X#` / `Y#` take precedence over `# #` / `# # #`.)

## Mice functionality

Re. mice:
- `MouseClickDrag` should probably become `MouseDrag`.
- I think `MouseClick` can be removed, however I think `Click` needs an `S` option (equivalent to the `MouseClick` `Speed` parameter), to allow setting the speed. (E.g. sometimes you want to 'see' the click, when you do it, sometimes you want it to be instant.)
- This PR adds a `C` option to `ParseClickOptions`. (But I think the '1 number = count, 2 numbers = X Y, 3 numbers = X Y count' syntax is worth keeping because a number alone, representing a count, is consistent with other buttons when using `Send("{a 2}{Click 2}")` syntax.)
- This PR adds `X`/`Y` options to `ParseClickOptions`. (But I think the '2 numbers = X Y' syntax is useful for avoiding awkward concatenations with X/Y and numbers.)
- This PR changes `ConvertMouseButton` (and therefore `ParseClickOptions` also) to expect `XB1/XB2` for XButtons, not `X1/X2`.

## Test code

```
;==================================================

;test code: ControlClick (v2)

;==================================================

q:: ;test ControlClick
{
	;ControlClick("X100", "Edit1", "A")
	;ControlClick("Y100", "Edit1", "A")
	;ControlClick("Y200", "Edit1", "A")
	;ControlClick("Y200 1", "Edit1", "A")
	;ControlClick("Y200 2", "Edit1", "A")
	;ControlClick("Y200 0", "Edit1", "A")
	;ControlClick("Y200 C0", "Edit1", "A")
	;ControlClick("Y200 C2", "Edit1", "A")
	;ControlClick("X01", "Edit1", "A") ;X01 position
	;ControlClick("X1", "Edit1", "A") ;X1 button
	;ControlClick("X5", "Edit1", "A")
	;ControlClick("X15", "Edit1", "A")
}

;==================================================
```