### PR TITLE
v1: Fixed ControlGet-List 'Selected' option repeating output on 64-bit builds.

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -3130,7 +3130,7 @@ ResultType Line::ControlGetListView(Var &aOutputVar, HWND aHwnd, LPTSTR aOptions
 			//    mouse/key lag would occur).
 			if (!SendMessageTimeout(aHwnd, LVM_GETNEXTITEM, next, include_focused_only ? LVNI_FOCUSED : LVNI_SELECTED
 				, SMTO_ABORTIFHUNG, 2000, (PDWORD_PTR)&next) // Timed out or failed.
-				|| next == -1) // No next item.  Relies on short-circuit boolean order.
+				|| next == -1 || (int)next == -1) // No next item.  Relies on short-circuit boolean order.
 				break; // End of estimation phase (if estimate is too small, the text retrieval below will truncate it).
 		}
 		else


### PR DESCRIPTION
This problem affects AHK v1 (`ControlGet-List`) and AHK v2 (`ListViewGetContent`).

When `ControlGet-List` gets text from a listview, using the `Selected` option, internally, `LVM_GETNEXTITEM` returns -1 when there are no more matching listview items.
But when AHK is 64-bit, and the external process is 32-bit, the return value is misinterpreted.

The internal code gets text from each selected item, '-1' is misinterpreted, and the items are retrieved again, in what would be an infinite loop, however, `i < row_count` eventually returns false, ending the loop.

(This PR uses a one-line fix, perhaps a more permanent solution is desirable.)
It is reasonably likely that other bugs of this nature reside in the source code. One possible solution would be a custom macro/function version of `SendMessageTimeout`, that considers the bitness of AHK and of external processes (when the return value is outside the range 0x0 to 0x7FFFFFFF).

(I only experienced this, because I moved to 64-bit AHK this year, as part of shoring up my code before a mass migration to AHK v2.)

Example code:
```
;==============================

;script 1 (an AHK script, needs to be run as 64-bit):

q:: ;64-bit AHK against 32-bit process, ControlGet-List 'Selected' repeats output
;ControlGet, hCtl, Hwnd,, SysListView321, ahk_class SearchMyFiles
ControlGet, hCtl, Hwnd,, SysListView321, listview demo ahk_class AutoHotkeyGUI
ControlGet, vText, List, Selected Col1,, % "ahk_id " hCtl
Clipboard := vText
MsgBox, % A_AhkVersion "`r`n" (A_PtrSize*8) "`r`n`r`n" vText
return

;==============================

;script 2 (a sample GUI with a listview, needs to be run as 32-bit):

Gui, New, +HwndhGui, listview demo
Gui, Add, ListView, r20, LVH 1|LVH 2|LVH 3
Loop, 20
{
	if (A_Index = 1)
		LV_Add("Select", "LV A" A_Index, "LV B" A_Index, "LV C" A_Index)
	else
		LV_Add("", "LV A" A_Index, "LV B" A_Index, "LV C" A_Index)
}
Gui, Show, w300 h400
return

GuiClose:
ExitApp
return

;==============================
```