### PR TITLE
Fix for AutoHotkey.exe not appearing in the context menu for "Open with"

### DIFF
--- a/source/resources/AutoHotkey.rc
+++ b/source/resources/AutoHotkey.rc
@@ -190,6 +190,7 @@ BEGIN
             VALUE "FileVersion", AHK_VERSION
             VALUE "InternalName", ""
             VALUE "LegalCopyright", ""
+            VALUE "CompanyName", ""
             VALUE "OriginalFilename", ""
             VALUE "ProductName", ""
             VALUE "ProductVersion", AHK_VERSION
@@ -198,6 +199,7 @@ BEGIN
             VALUE "FileVersion", AHK_VERSION
             VALUE "InternalName", "AutoHotkey"
             VALUE "LegalCopyright", "Copyright (C) 2003-2013"
+            VALUE "CompanyName", "The AutoHotkey Foundation"
             VALUE "OriginalFilename", "AutoHotkey.exe"
             VALUE "ProductName", "AutoHotkey"
             VALUE "ProductVersion", AHK_VERSION


### PR DESCRIPTION
Fixes the issue described in https://www.autohotkey.com/boards/viewtopic.php?f=13&t=108223

AutoHotkey.exe does not appear in the context menu for "Open with".