### PR TITLE
Fixed variable's object value being deleted before marking the variable as uninitialised

### DIFF
--- a/source/MdFunc.cpp
+++ b/source/MdFunc.cpp
@@ -458,8 +458,7 @@ bool MdFunc::Call(ResultToken &aResultToken, ExprTokenType *aParam[], int aParam
 		{
 			// Although 0 or "" is a fairly conventional default, it might not be safe.
 			// For error-detection and to avoid unexpected behaviour, "unset" the var.
-			var->Assign();
-			var->MarkUninitialized();
+			var->Uninitialize();
 		}
 	}
 

--- a/source/script_object.cpp
+++ b/source/script_object.cpp
@@ -2089,9 +2089,11 @@ ResultType Array::GetEnumItem(UINT &aIndex, Var *aVal, Var *aReserved, int aVarC
 			switch (item.symbol)
 			{
 			default:
-				aVal->AssignString(item.string, item.string.Length());
 				if (item.symbol == SYM_MISSING)
-					aVal->MarkUninitialized();
+					aVal->Uninitialize();
+				else
+					aVal->AssignString(item.string, item.string.Length());
+				
 				break;
 			case SYM_INTEGER:	aVal->Assign(item.n_int64);			break;
 			case SYM_FLOAT:		aVal->Assign(item.n_double);		break;

--- a/source/var.cpp
+++ b/source/var.cpp
@@ -43,8 +43,7 @@ ResultType Var::Assign(Var &aVar)
 
 	if (source_var.mAttrib & VAR_ATTRIB_UNINITIALIZED)
 	{
-		target_var.Assign();
-		target_var.MarkUninitialized();
+		target_var.Uninitialize();
 		return OK;
 	}
 
@@ -84,10 +83,7 @@ ResultType Var::Assign(ExprTokenType &aToken)
 	default:
 		ASSERT(!"Unhandled symbol");
 	case SYM_MISSING:
-		if (!Assign())
-			return FAIL;
-		MarkUninitialized();
-		return OK;
+		return Uninitialize() ? OK : FAIL;
 	}
 	// Since above didn't return, it can only be SYM_STRING.
 	return Assign(aToken.marker, aToken.marker_length);

--- a/source/var.h
+++ b/source/var.h
@@ -926,8 +926,22 @@ public:
 
 	void MarkUninitialized()
 	{
-		Var &var = *ResolveAlias();
+		Var& var = *ResolveAlias();
 		var.mAttrib |= VAR_ATTRIB_UNINITIALIZED;
+	}
+	ResultType Uninitialize() 
+	{
+		Var& var = *ResolveAlias();
+		auto obj = (var.mAttrib & VAR_ATTRIB_IS_OBJECT) ? mObject : nullptr;
+		if (obj)
+			obj -> AddRef();
+		auto result = var.Assign();
+		if (result)
+			var.MarkUninitialized();
+		if (obj)
+			obj->Release();
+		
+		return result;
 	}
 
 }; // class Var


### PR DESCRIPTION
__Reason__, the variable might be read, directly or indirectly, under the false impression that the variable is set (with the object as its value), from the objects `__delete`, routine.

Example,
```autohotkey
x := {__delete : t=>msgbox(isset(x))}
x := unset
```
