### PR TITLE
v1: Backported Buffer() from alpha branch. And NumXXX/StrXXX/File.RawXXX/A_Clipboard/DllCall support.

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8721,6 +8721,12 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 	}
 	else if (!_tcsicmp(func_name, _T("IsSet")))
 		bif = BIF_IsSet;
+	else if (!_tcsicmp(func_name, _T("Buffer")))
+	{
+		bif = BIF_Buffer;
+		min_params = 0;
+		max_params = 2;
+	}
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -239,6 +239,11 @@ void DoIncrementalMouseMove(int aX1, int aY1, int aX2, int aY2, int aSpeed);
 DWORD ProcessExist(LPTSTR aProcess);
 DWORD GetProcessName(DWORD aProcessID, LPTSTR aBuf, DWORD aBufSize, bool aGetNameOnly);
 
+bool GetBufferObjectPtr(ExprTokenType &aResultToken, BufferObject *obj, size_t &aPtr, size_t &aSize);
+bool GetBufferObjectPtr(ExprTokenType &aResultToken, BufferObject *obj, size_t &aPtr);
+bool GetBufferObjectPtr(ExprTokenType &aResultToken, Object *obj, size_t &aPtr, size_t &aSize);
+bool GetBufferObjectPtr(ExprTokenType &aResultToken, Object *obj, size_t &aPtr);
+
 bool Util_Shutdown(int nFlag);
 BOOL Util_ShutdownHandler(HWND hwnd, DWORD lParam);
 void Util_WinKill(HWND hWnd);
@@ -3373,6 +3378,7 @@ BIF_DECL(BIF_Trim); // L31: Also handles LTrim and RTrim.
 
 BIF_DECL(BIF_Hotstring);
 BIF_DECL(BIF_InputHook);
+BIF_DECL(BIF_Buffer);
 
 
 BIF_DECL(BIF_IsObject);

--- a/source/script_object.h
+++ b/source/script_object.h
@@ -445,3 +445,22 @@ public:
 	void DebugWriteProperty(IDebugProperties *, int aPage, int aPageSize, int aDepth);
 #endif
 };
+
+
+//
+// Buffer
+//
+class BufferObject : public ObjectBase
+{
+	void *mData;
+	size_t mSize;
+	BufferObject() : mData(nullptr), mSize(0) {}
+
+	~BufferObject() { free(mData); }
+
+public:
+	static BufferObject *Create(size_t aSize);
+
+	ResultType STDMETHODCALLTYPE Invoke(ExprTokenType &aResultToken, ExprTokenType &aThisToken, int aFlags, ExprTokenType *aParam[], int aParamCount);
+	IObject_Type_Impl("Buffer")
+};

--- a/source/var.cpp
+++ b/source/var.cpp
@@ -743,6 +743,20 @@ ResultType Var::AssignSkipAddRef(IObject *aValueToAssign)
 
 	if (var.mType != VAR_NORMAL)
 	{
+		if (var.mType == VAR_CLIPBOARD)
+		{
+			if (MetaObject::Object *obj = dynamic_cast<MetaObject::Object *>(aValueToAssign))
+			{
+				ExprTokenType t1;
+				ExprTokenType t2;
+				if ((obj->GetItem(t1, _T("Ptr")))
+				&& (obj->GetItem(t2, _T("Size"))))
+				{
+					SetClipboardAll((CHAR *)TokenToInt64(t1), (size_t)TokenToInt64(t2));
+					return OK;
+				}
+			}
+		}
 		aValueToAssign->Release();
 		return g_script.ScriptError(ERR_INVALID_VALUE, _T("An object."));
 	}


### PR DESCRIPTION
## Introduction

This PR replaces and improves upon #237.
This PR also makes use of and improves the code for `Buffer` in #268.

This PR adds the `Buffer` function and class to AutoHotkey v1.
This PR adds `Buffer` support to: `NumPut`, `NumGet`, `StrPut`, `StrGet`, `File.RawRead`, `File.RawWrite`, `Clipboard`/`A_Clipboard`, and `DllCall`.
The functions can handle Buffer objects proper and Buffer-like objects (i.e. an AHK object with Ptr/Size properties/keys).
When using `DllCall`, the `Size` property can be omitted.

## Integration with custom backport functions.

The `Clipboard`/`A_Clipboard` variable can now receive a Buffer or Buffer-like object, as produced by a `ClipboardAll` function backport (AHK code).

In AHK code, I have backports for `ClipboardAll`/`FileAppend`/`FileRead`/`PostMessage`/`SendMessage` that handle Buffer and Buffer-like objects.
(And a `Buffer` class backport, although this PR would make that unnecessary.)

## Rationale
The benefits are for people writing code in AHK v1, to increase their readiness for moving to AHK v2.
And for people regularly working in both versions.

## Implementation
The `StrPut`/`StrGet` fixes were a little complex, slight errors are possible, in which case, apologies.

Of all the code I have viewed, I think AHK v1/v2 `StrPut`/`StrGet` could really benefit from slight comment additions/clarifications.
And possibly some refactoring to emphasise simplicity and clarity.
A special refactoring of the functions in both AHK v1 and v2, to keep the 2 in sync, could be worthwhile.
(No other source code area jumps out at me like `BIF_StrGetPut`.)
(I essentially completed code to add UTF-32 support to it, but it makes the function *even more complicated*, so I'm tempted to just give it to people as machine code. It's in my branch `strxxx_utf32`.)

Any refactoring is completely fine and most welcome. Any of the code may be changed as desired.

## Test code
```
;==================================================

;test code: Buffer (AHK v1)
;for a PR that creates a Buffer class,
;and adds Buffer support to NumXXX/StrXXX/File.RawXXX/A_Clipboard/DllCall

;note: the File.RawRead/File.RawWrite test, creates a new text file in the script folder each time using A_Now, which is then sent to the recycle bin
;note: the Clipboard test (the final test), requires user input, a MsgBox will appear with instructions

;contains tests:
;test Buffer - NumPut/NumGet:
;test Buffer - DllCall:
;test Buffer - StrPut/StrGet:
;test Buffer - File.RawRead/File.RawWrite:
;test Buffer - Clipboard (assign object):

;==================================================

;test Buffer - NumPut/NumGet:

oBuf := Buffer(8)
oBuf2 := {Ptr:oBuf.Ptr, Size:oBuf.Size}

vNum := 123
NumPut(vNum, oBuf.Ptr, 0, "UInt")
Assert(NumGet(oBuf.Ptr, 0, "UInt"), vNum)
Assert(NumGet(oBuf2.Ptr, 0, "UInt"), vNum)
Assert(NumGet(oBuf, 0, "UInt"), vNum)
Assert(NumGet(oBuf2, 0, "UInt"), vNum)

vNum := 456
NumPut(vNum, oBuf, 0, "UInt")
Assert(NumGet(oBuf.Ptr, 0, "UInt"), vNum)
Assert(NumGet(oBuf2.Ptr, 0, "UInt"), vNum)
Assert(NumGet(oBuf, 0, "UInt"), vNum)
Assert(NumGet(oBuf2, 0, "UInt"), vNum)

VarSetCapacity(vData, 4)

;buffer direct:
NumPut(111, {Ptr:&vData, Size:4}, 0, "UInt")
Assert(NumGet({Ptr:&vData, Size:4}, 0, "UInt"), 111)

;buffer variable:
oBuf := {Ptr:&vData, Size:4}
NumPut(222, oBuf, 0, "UInt")
Assert(NumGet(oBuf, 0, "UInt"), 222)

;string variable:
NumPut(333, vData, 0, "UInt")
Assert(NumGet(vData, 0, "UInt"), 333)

;string address (&):
NumPut(444, &vData, 0, "UInt")
Assert(NumGet(&vData, 0, "UInt"), 444)

;string address (+0):
pData := &vData
NumPut(555, pData+0, 0, "UInt")
Assert(NumGet(pData+0, 0, "UInt"), 555)

;buffer variable (buffer size too small) (should fail, returning a blank):
oBuf := {Ptr:&vData, Size:2}
NumPut(666, oBuf, 0, "UInt")
Assert(NumGet(oBuf, 0, "UInt"), "") ;(blank)

;adress 0 (+0) (invalid address) (should fail, returning a blank):
pData := &vData
NumPut(777, 0+0, 0, "UInt")
Assert(NumGet(0+0, 0, "UInt"), "") ;(blank)

Assert(NumGet(pData+0, 0, "UInt"), 555) ;(should show the last successful write value)

;==================================================

;test Buffer - DllCall:

vText := "abcde"
oBuf := {Ptr:&vText, Size:StrLen(vText)*2}
DllCall("msvcrt\_wcsrev", "Ptr",oBuf, "Cdecl Ptr")
Assert(vText, "edcba")

vText := "abcde"
oBuf := {Ptr:&vText}
DllCall("msvcrt\_wcsrev", "Ptr",oBuf, "Cdecl Ptr")
Assert(vText, "edcba")

vText := "abcde"
oBuf := {}
try DllCall("msvcrt\_wcsrev", "Ptr",oBuf, "Cdecl Ptr"), vIsError := 0
catch
	vIsError := 1
Assert(vIsError, 1)

;==================================================

;test Buffer - StrPut/StrGet:

VarSetCapacity(vData, 4)

;buffer direct:
StrPut("aaa", {Ptr:&vData, Size:4}, "CP0")
Assert(StrGet({Ptr:&vData, Size:4}, "CP0"), "aaa")

;buffer variable:
oBuf := {Ptr:&vData, Size:4}
StrPut("bbb", oBuf, "CP0")
Assert(StrGet(oBuf, "CP0"), "bbb")

;buffer direct:
try StrPut("ccc", {Ptr:&vData, Size:4}, "UTF-16"), vIsError := 0
catch
	vIsError := 1
Assert(vIsError, 1)
try StrGet({Ptr:&vData, Size:4}, "UTF-16"), vIsError := 0
catch
	vIsError := 1
Assert(vIsError, 1)

;buffer variable:
oBuf := {Ptr:&vData, Size:4}
try StrPut("ddd", oBuf, "UTF-16"), vIsError := 0
catch
	vIsError := 1
Assert(vIsError, 1)
try StrGet(oBuf, "UTF-16"), vIsError := 0
catch
	vIsError := 1
Assert(vIsError, 1)

;buffer variable:
oBuf := {Ptr:&vData, Size:4}
StrPut("e", oBuf, "UTF-16")
Assert(StrGet(oBuf, "UTF-16"), "e")

StrPut("f", {Ptr:&vData, Size:4}, "UTF-16")
Assert(StrGet({Ptr:&vData, Size:4}, "UTF-16"), "f")

Assert(StrGet(oBuf, "CP0"), "f")

;==================================================

;test Buffer - File.RawRead/File.RawWrite:
;note: creates a text file in the script folder

vPath := A_ScriptDir "\test Buffer - File object " A_Now ".txt"
if FileExist(vPath)
{
	MsgBox("error: file already exists, will close AHK script")
	ExitApp
}
if !FileExist(vPath)
	FileAppend, % "abcdefghijklmnopqrstuvwxyz", % "*" vPath, CP0

FileRead, vText, % vPath, *P0
Assert(vText, "abcdefghijklmnopqrstuvwxyz")

VarSetCapacity(vDataOut, 4)
StrPut("wxyz", &vDataOut, 4, "CP0")
oBufOut := {Ptr:&vDataOut, Size:4}

VarSetCapacity(vData, 4)
oBuf := {Ptr:&vData, Size:4}
oFile := FileOpen(vPath, "rw")
oFile.RawRead(oBuf, 4)
Assert(StrGet(oBuf, 4, "CP0"), "abcd")

Assert(StrGet(oBufOut, 4, "CP0"), "wxyz")

oFile.Pos := 0
oFile.RawWrite(oBufOut, 4)
oFile.Pos := 0
oFile.RawRead(oBuf, 4)
Assert(StrGet(oBuf, 4, "CP0"), "wxyz")

StrPut("abcd", oBufOut, 4, "CP0")
oFile.Pos := 0
oFile.RawWrite(oBufOut, 4)
oFile.Pos := 0
oFile.RawRead({Ptr:&vDataOut, Size:4}, 4)
Assert(StrGet({Ptr:&vDataOut, Size:4}, 4, "CP0"), "abcd") ;[FIXME]
oFile.Close()

FileRecycle, % vPath

;==================================================

test_paint:
;test Buffer - Clipboard (assign object):
;note: the code tests both Clipboard and A_Clipboard

MsgBox("the final test, involving the clipboard, requires user input, instructions will follow:")

MsgBox("open MS Paint, (before you press OK ...) copy some image data to the clipboard, e.g. use Ctrl+A and Ctrl+C")
oClipSaved := ClipboardAll

Clipboard := "abc"
MsgBox("we have now set the clipboard contents to this value:`r`n" Clipboard)

;buffer direct:
vSize := VarSetCapacity(oClipSaved)
Clipboard := {Ptr:&oClipSaved, Size:vSize}
;manually: paste image data in MS Paint
MsgBox("the MS Paint data has been restored to the clipboard, (before you press OK ...) try pasting thr image data to confirm this, e.g. use Ctrl+V")

A_Clipboard := "def"
MsgBox("we have now set the clipboard contents to this value:`r`n" Clipboard)

;buffer variable:
vSize := VarSetCapacity(oClipSaved)
oBuf := {Ptr:&oClipSaved, Size:vSize}
A_Clipboard := oBuf
MsgBox("the end: the MS Paint data has been restored to the clipboard")
return

;==================================================
;==================================================
;==================================================

;simplified version of function:
MsgBox(Text)
{
	MsgBox, % Text
}

;==================================================

Assert(vValue1, vValue2)
{
	if (vValue1 != vValue2)
		throw Error("Assert mismatch.`r`n" "Return value: " vValue1 "`r`n" "Expected value: " vValue2, -1)
}

;==================================================

Error(Message, Params*) ;Message, What, Extra
{
	local What
	if (Params.Length() > 2)
		throw Exception("Too many parameters passed to function.", -1)
	if !Params.HasKey(1)
		Params[1] := 0
	What := Params[1]
	if What is integer
		Params[1]--
	return Exception(Message, Params*)
}

;==================================================
```