### PR TITLE
v2: Added BinCopy() and BinCompare().

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -36,6 +36,8 @@ FuncEntry g_BIF[] =
 	BIFn(ACos, 1, 1, BIF_ASinACos),
 	BIFn(ASin, 1, 1, BIF_ASinACos),
 	BIF1(ATan, 1, 1),
+	BIFn(BinCompare, 2, 3, BIF_BinCopyCompare),
+	BIFn(BinCopy, 2, 3, BIF_BinCopyCompare),
 	BIF1(CaretGetPos, 0, 2, {1, 2}),
 	BIFn(Ceil, 1, 1, BIF_FloorCeil),
 	BIF1(Chr, 1, 1),

--- a/source/script.h
+++ b/source/script.h
@@ -652,6 +652,7 @@ enum BuiltInFunctionID {
 	FID_RegRead = 0, FID_RegWrite, FID_RegCreateKey, FID_RegDelete, FID_RegDeleteKey,
 	FID_SoundGetVolume = 0, FID_SoundGetMute, FID_SoundGetName, FID_SoundGetInterface, FID_SoundSetVolume, FID_SoundSetMute,
 	FID_RunWait = 0, FID_ClipWait, FID_KeyWait, FID_WinWait, FID_WinWaitClose, FID_WinWaitActive, FID_WinWaitNotActive,
+	FID_BinCopy = 0, FID_BinCompare,
 	// Hotkey/HotIf/...
 	FID_HotIfWinActive = HOT_IF_ACTIVE, FID_HotIfWinNotActive = HOT_IF_NOT_ACTIVE,
 		FID_HotIfWinExist = HOT_IF_EXIST, FID_HotIfWinNotExist = HOT_IF_NOT_EXIST,
@@ -3279,6 +3280,7 @@ BIF_DECL(BIF_Sound);
 BIF_DECL(BIF_SplitPath);
 BIF_DECL(BIF_CaretGetPos);
 BIF_DECL(BIF_RunWait);
+BIF_DECL(BIF_BinCopyCompare);
 
 
 BOOL ResultToBOOL(LPTSTR aResult);


### PR DESCRIPTION
## Introduction

Replaces #280. Simplified versions of 2 of the 5 functions.
2 small functions, wrappers for `memmove` and `memcmp`.

```
BinCompare(Buffer1, Buffer2 [, Size])
BinCopy(SourceBuffer, DestBuffer [, Size])
```
`Buffer1` and `Buffer2` can be integers.
`SourceBuffer` and `DestBuffer` can be integers.
If exactly one is an integer, `Size` can be omitted.
If both are buffers of equal size, `Size` can be omitted.
The `BinCopy` parameter order differs from `memmove`.

## Rationale

It seemed pretty practical to have these built-in, because they're used a lot.
But no problem if you don't want them.

## Implementation

Anything can be changed as desired, e.g. the function names, internal variable names, all the various details for handling integers versus buffers.

## `ST_UNICODE` undefined and `bin_debug`
Visual Studio 2017 complained that `ST_UNICODE` (value 8, in error.cpp) was undefined.
It might be helpful for people editing the source code, to add a directive to define it if it's undefined.

It might also be helpful to add `bin_debug` to .gitignore.