### PR TITLE
v2: Added ShortcutKey parameter to FileGetShortcut.

### DIFF
--- a/source/MdFunc.cpp
+++ b/source/MdFunc.cpp
@@ -12,7 +12,7 @@ struct MdFuncEntry
 	LPCTSTR name;
 	void *function;
 	MdType rettype;
-	MdType argtype[23];
+	MdType argtype[25];
 };
 
 

--- a/source/lib/functions.h
+++ b/source/lib/functions.h
@@ -106,7 +106,7 @@ md_func_v(FileExist, (In, String, Pattern), (Ret, String, RetVal))
 md_func(FileGetAttrib, (In_Opt, String, Path), (Ret, String, RetVal))
 md_func(FileGetShortcut, (In, String, LinkFile), (Out_Opt, String, Target), (Out_Opt, String, WorkingDir),
 	(Out_Opt, String, Args), (Out_Opt, String, Description), (Out_Opt, String, IconFile),
-	(Out_Opt, Variant, IconNum), (Out_Opt, Int32, RunState))
+	(Out_Opt, Variant, IconNum), (Out_Opt, Int32, RunState), (Out_Opt, String, ShortcutKey))
 md_func(FileGetSize, (In_Opt, String, Path), (In_Opt, String, Units), (Ret, Int64, RetVal))
 md_func(FileGetTime, (In_Opt, String, Path), (In_Opt, String, WhichTime), (Ret, String, RetVal))
 md_func(FileGetVersion, (In_Opt, String, Path), (Ret, String, RetVal))

--- a/source/script_autoit.cpp
+++ b/source/script_autoit.cpp
@@ -1167,7 +1167,7 @@ bif_impl FResult DirSelect(optl<StrArg> aRootDir, optl<int> aOptions, optl<StrAr
 
 
 bif_impl FResult FileGetShortcut(StrArg aShortcutFile, StrRet *aTarget, StrRet *aWorkingDir
-	, StrRet *aArgs, StrRet *aDesc, StrRet *aIcon, ResultToken *aIconNum, int *aRunState)
+	, StrRet *aArgs, StrRet *aDesc, StrRet *aIcon, ResultToken *aIconNum, int *aRunState, StrRet *aHotkey)
 // Credited to Holger <Holger.Kotsch at GMX de>.
 {
 	CoInitialize(NULL);
@@ -1230,6 +1230,23 @@ bif_impl FResult FileGetShortcut(StrArg aShortcutFile, StrRet *aTarget, StrRet *
 					// creating the shortcut in case it happens to work.  Of course, that applies only
 					// to FileCreateShortcut, not here.  But it's done here so that this command is
 					// compatible with that one.
+				}
+				if (aHotkey)
+				{
+					UCHAR buf_hk[2];
+					psl->GetHotkey((WORD*)buf_hk);
+					// buf[MAX_PATH+1] has sufficient capacity: 4 modifier chars + 128 key name chars + 1 null = 133.
+					TCHAR *cp = buf;
+					if (buf_hk[1] & HOTKEYF_CONTROL)
+						*cp++ = '^';
+					if (buf_hk[1] & HOTKEYF_EXT) // Shell Link (.LNK) standard says this should never be set.
+						*cp++ = '#';
+					if (buf_hk[1] & HOTKEYF_ALT)
+						*cp++ = '!';
+					if (buf_hk[1] & HOTKEYF_SHIFT)
+						*cp++ = '+';
+					VKtoKeyName((vk_type)buf_hk[0], cp, 128, false);
+					aHotkey->Copy(buf);
 				}
 			}
 			ppf->Release();


### PR DESCRIPTION
Replaces #271.
This version of the PR, adds a `ShortcutKey` parameter as the **last** parameter.
Therefore it is backwards compatible with the current function.

(It has been nice to work with the new MdFunc set-up for the first time!)