### PR TITLE
v1: Added DecToBase() and BaseToDec().

### DIFF
--- a/source/script.cpp
+++ b/source/script.cpp
@@ -8747,6 +8747,18 @@ Func *Script::FindFunc(LPCTSTR aFuncName, size_t aFuncNameLength, int *apInsertP
 		min_params = 2;
 		max_params = 2;
 	}
+	else if (!_tcsicmp(func_name, _T("DecToBase")))
+	{
+		bif = BIF_DecToBase;
+		min_params = 2;
+		max_params = 3;
+	}
+	else if (!_tcsicmp(func_name, _T("BaseToDec")))
+	{
+		bif = BIF_BaseToDec;
+		min_params = 2;
+		max_params = 2;
+	}
 	else
 		return NULL; // Maint: There may be other lines above that also return NULL.
 

--- a/source/script.h
+++ b/source/script.h
@@ -3377,6 +3377,8 @@ BIF_DECL(BIF_Trim); // L31: Also handles LTrim and RTrim.
 BIF_DECL(BIF_Hotstring);
 BIF_DECL(BIF_InputHook);
 BIF_DECL(BIF_VerCompare);
+BIF_DECL(BIF_DecToBase);
+BIF_DECL(BIF_BaseToDec);
 
 
 BIF_DECL(BIF_IsObject);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -18892,6 +18892,54 @@ BIF_DECL(BIF_VerCompare)
 
 
 
+BIF_DECL(BIF_DecToBase)
+{
+	aResultToken.symbol = SYM_STRING;
+	aResultToken.marker = _T("");
+	unsigned __int64 num = (unsigned __int64)ParamIndexToInt64(0);
+	int base = ParamIndexToInt(1);
+	int len_min = ParamIndexToOptionalInt(2, 1);
+	if (base < 2 || base > 36)
+		_f_throw(ERR_PARAM2_INVALID);
+	if (len_min < 0)
+		_f_throw(ERR_PARAM3_INVALID);
+
+	TCHAR buf[65];
+	_ui64tot(num, buf, base);
+	int len_buf = _tcslen(buf);
+	int len_out = len_min > len_buf ? len_min : len_buf;
+	LPTSTR output = tmalloc(len_out+1);
+
+	LPTSTR cp;
+	int i;
+	for (cp = output, i = 0; i < len_out-len_buf; ++i, ++cp)
+		*cp = '0'; // literal zero
+	tmemcpy(cp, buf, len_buf+1);
+	aResultToken.marker = output;
+	aResultToken.mem_to_free = output;
+	aResultToken.marker_length = len_out;
+}
+
+
+
+BIF_DECL(BIF_BaseToDec)
+{
+	TCHAR buf[MAX_NUMBER_SIZE];
+	LPTSTR str = ParamIndexToString(0, buf);
+	int base = ParamIndexToInt(1);
+	if (base < 2 || base > 36)
+	{
+		aResultToken.symbol = SYM_STRING;
+		aResultToken.marker = _T("");
+		_f_throw(ERR_PARAM2_INVALID);
+	}
+
+	aResultToken.symbol = SYM_INTEGER;
+	aResultToken.value_int64 = (__int64)_tcstoui64(str, NULL, base);
+}
+
+
+
 ////////////////////////////////////////////////////////
 // HELPER FUNCTIONS FOR TOKENS AND BUILT-IN FUNCTIONS //
 ////////////////////////////////////////////////////////


### PR DESCRIPTION
## Introduction

An alternative to #292. This function is more versatile, and simpler to implement.

```
BaseToDec(Str, Base) [a wrapper for _wcstoui64/_strtoui64] [similar to JavaScript's parseInt(str, base)]
DecToBase(Num, Base, MinLen:=1) [a wrapper for _ui64tow/_ui64toa] [similar to JavaScript's num.toString(base)]
```

`MinLen` can be used to pad the output with leading zeros.

`Base` must be between 2 and 36 inclusive, else it throws.
`MinLen` must be positive or 0, else it throws.

## Implementation

The output is currently lower case, this can be changed if desired.
(I'm very 50/50 on this, I tend to lean towards upper case for bases, hex, RGB values and CRC-32 hashes, but I've often seen hashes written as lower case, and RGB values fairly often.)

## Rationale

These can be surprisingly useful in a variety of circumstances, including for newbies, hence why I leaned towards them being built-in.
E.g. for generating lists of combinations/permutations.
E.g. for selecting (including/excluding) items in an array.
E.g. for handling binary integers.
E.g. `DecToBase` is convenient for displaying an Int64 as a UInt64 or hex. (Versus `Format`.)

That said, equivalent custom functions can be relatively short.
So, no problem if you don't want them.