### PR TITLE
Added CueText for Edit controls

### DIFF
--- a/source/script.h
+++ b/source/script.h
@@ -2279,6 +2279,7 @@ struct GuiControlType : public Object
 	static ObjectMemberMd sMembersList[]; // Tab, ListBox, ComboBox, DDL
 	static ObjectMemberMd sMembersTab[];
 	static ObjectMemberMd sMembersDate[];
+	static ObjectMemberMd sMemberEdit[];
 	static ObjectMemberMd sMembersLV[];
 	static ObjectMemberMd sMembersTV[];
 	static ObjectMemberMd sMembersSB[];
@@ -2339,7 +2340,9 @@ struct GuiControlType : public Object
 	FResult SB_SetIcon(StrArg aFilename, optl<int> aIconNumber, optl<UINT> aPartNumber, UINT_PTR &aRetVal);
 	FResult SB_SetParts(VariantParams &aParam, UINT& aRetVal);
 	FResult SB_SetText(StrArg aNewText, optl<UINT> aPartNumber, optl<UINT> aStyle);
-	
+
+	FResult Edit_CueText(StrArg aCueText, optl<BOOL> aExact);
+
 	FResult Tab_UseTab(ExprTokenType *aTab, optl<BOOL> aExact);
 	
 	FResult TV_AddModify(bool aAdd, UINT_PTR aItemID, UINT_PTR aParentItemID, optl<StrArg> aOptions, optl<StrArg> aName, UINT_PTR &aRetVal);

--- a/source/script.h
+++ b/source/script.h
@@ -2279,10 +2279,10 @@ struct GuiControlType : public Object
 	static ObjectMemberMd sMembersList[]; // Tab, ListBox, ComboBox, DDL
 	static ObjectMemberMd sMembersTab[];
 	static ObjectMemberMd sMembersDate[];
-	static ObjectMemberMd sMemberEdit[];
 	static ObjectMemberMd sMembersLV[];
 	static ObjectMemberMd sMembersTV[];
 	static ObjectMemberMd sMembersSB[];
+	static ObjectMemberMd sMembersEdit[];
 
 	static Object *sPrototype, *sPrototypeList;
 	static Object *sPrototypes[GUI_CONTROL_TYPE_COUNT];

--- a/source/script_gui.cpp
+++ b/source/script_gui.cpp
@@ -626,7 +626,7 @@ ObjectMemberMd GuiControlType::sMembersSB[] =
 	md_member_x(GuiControlType, SetText, SB_SetText, CALL, (In, String, NewText), (In_Opt, UInt32, PartNumber), (In_Opt, UInt32, Style))
 };
 
-ObjectMemberMd GuiControlType::sMemberEdit[] =
+ObjectMemberMd GuiControlType::sMembersEdit[] =
 {
 	md_member_x(GuiControlType, CueText, Edit_CueText, CALL, (In, String, CueText), (In_Opt, Bool32, ExactMatch))
 };
@@ -670,7 +670,7 @@ void GuiControlType::DefineControlClasses()
 		case GUI_CONTROL_LISTVIEW: more_items = sMembersLV; how_many = _countof(sMembersLV); break;
 		case GUI_CONTROL_TREEVIEW: more_items = sMembersTV; how_many = _countof(sMembersTV); break;
 		case GUI_CONTROL_STATUSBAR: more_items = sMembersSB; how_many = _countof(sMembersSB); break;
-		case GUI_CONTROL_EDIT: more_items = sMemberEdit; how_many = _countof(sMemberEdit); break;
+		case GUI_CONTROL_EDIT: more_items = sMembersEdit; how_many = _countof(sMembersEdit); break;
 		}
 		TCHAR buf[32];
 		_sntprintf(buf, 32, _T("Gui.%s"), sTypeNames[i]);

--- a/source/script_gui.cpp
+++ b/source/script_gui.cpp
@@ -626,6 +626,11 @@ ObjectMemberMd GuiControlType::sMembersSB[] =
 	md_member_x(GuiControlType, SetText, SB_SetText, CALL, (In, String, NewText), (In_Opt, UInt32, PartNumber), (In_Opt, UInt32, Style))
 };
 
+ObjectMemberMd GuiControlType::sMemberEdit[] =
+{
+	md_member_x(GuiControlType, CueText, Edit_CueText, CALL, (In, String, CueText), (In_Opt, Bool32, ExactMatch))
+};
+
 #undef FUN1
 #undef FUNn
 
@@ -665,6 +670,7 @@ void GuiControlType::DefineControlClasses()
 		case GUI_CONTROL_LISTVIEW: more_items = sMembersLV; how_many = _countof(sMembersLV); break;
 		case GUI_CONTROL_TREEVIEW: more_items = sMembersTV; how_many = _countof(sMembersTV); break;
 		case GUI_CONTROL_STATUSBAR: more_items = sMembersSB; how_many = _countof(sMembersSB); break;
+		case GUI_CONTROL_EDIT: more_items = sMemberEdit; how_many = _countof(sMemberEdit); break;
 		}
 		TCHAR buf[32];
 		_sntprintf(buf, 32, _T("Gui.%s"), sTypeNames[i]);
@@ -891,6 +897,18 @@ FResult GuiControlType::set_Visible(BOOL aValue)
 	CTRL_THROW_IF_DESTROYED;
 	gui->ControlSetVisible(*this, aValue);
 	return OK;
+}
+
+
+FResult GuiControlType::Edit_CueText(StrArg aCueText, optl<BOOL> aExact)
+{
+	LONG style = GetWindowLong(hwnd, GWL_STYLE);
+	if (!(style & ES_MULTILINE)) // cue banner cannot be set on multiline edit controls
+	{
+		BOOL whole_match = aExact.value_or(FALSE);
+		return SendMessage(hwnd, EM_SETCUEBANNER, whole_match, (LPARAM)aCueText) ? OK : FR_E_FAILED;
+	}
+	return NULL;
 }
 
 


### PR DESCRIPTION
Working example:
```Autohotkey
Main := Gui()
Main.AddEdit("xm ym w200")
ED1 := Main.AddEdit("xm y+5 w200")
ED1.CueText("cue banner")
ED2 := Main.AddEdit("xm y+5 w200")
ED2.CueText("cue banner with option true", true)
ED3 := Main.AddEdit("xm y+5 w200 r2")
ED3.CueText("multiline edit control is not supported")
Main.OnEvent("Close", (*) => ExitApp)
Main.Show("AutoSize")
```

Forum: https://www.autohotkey.com/boards/viewtopic.php?f=13&t=70852