### PR TITLE
Fix BIF_Hotkey's Action assignment via Strings.

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -2438,7 +2438,7 @@ bif_impl FResult BIF_Hotkey(StrArg aName, ExprTokenType *aAction, optl<StrArg> a
 			// I.e., find the function implicitly defined by "x::action".
 			for (int i = 0; i < Hotkey::sHotkeyCount; ++i)
 			{
-				if (_tcscmp(Hotkey::shk[i]->mName, aName))
+				if (_tcscmp(Hotkey::shk[i]->mName, action_string))
 					continue;
 				
 				for (HotkeyVariant* v = Hotkey::shk[i]->mFirstVariant; v; v = v->mNextVariant)


### PR DESCRIPTION
https://www.autohotkey.com/boards/viewtopic.php?f=82&t=113764

Restores the currently documented behavior, specifically:

"If Action is a hotkey name, its original function is used; specifically, the original function of the hotkey variant corresponding to the current HotIf criteria. This is usually used to restore a hotkey's original function after having changed it, but can be used to assign the function of a different hotkey, provided that both hotkeys use the same HotIf criteria."

Broken by 9d9cd3b. (See also Helgef PR 7931ec7.)