### PR TITLE
Added CaseSense check to Map::Create

### DIFF
--- a/source/script_object.cpp
+++ b/source/script_object.cpp
@@ -127,6 +127,17 @@ Map *Map::Create(ExprTokenType *aParam[], int aParamCount)
 
 	Map *map = new Map();
 	map->SetBase(Map::sPrototype);
+	// Check whether CaseSense is already defined in a base and set mFlags if necessary.
+	ExprTokenType casesense;
+	for (Object* that = map->Base(); that; that = that->Base())
+	{
+		if (that->GetOwnProp(casesense, _T("CaseSense")) && casesense.marker_length)
+		{
+			ExprTokenType* param[] = { &casesense };
+			map->CaseSense(ResultToken(), 0, IT_SET, param, 0);
+			break;
+		}
+	}
 	if (aParamCount && !map->SetItems(aParam, aParamCount))
 	{
 		// Out of memory.


### PR DESCRIPTION
To turn off case-sensitivity for all Maps, one obvious solution would be `Map.Prototype.DefineProp("CaseSense",{value: "Off"})`. Unfortunately this doesn't work, because the case-sensitivity flag is stored in `ObjectBase.mFlags` and `Map::Create` doesn't update it when the base is copied over. 

This pull request adds a check whether any `Map` object bases contain a `CaseSense` property with a set value and calls `Map::CaseSense` to update it if one is found.

Test cases:
```
test := Map("test", 1, "TEST", 2)
MsgBox "CaseSense: " test.CaseSense "`n" test["test"] " " test["TEST"] ; On, 1 and 2
```
```
Map.Prototype.DefineProp("Casesense",{value: "Off"})
test := Map("test", 1, "TEST", 2)
MsgBox "CaseSense: " test.CaseSense "`n" test["test"] " " test["TEST"] ; Off, 2 and 2
```
```
__ObjDefineProp := Object.Prototype.DefineProp
__ObjDefineProp(Object.Prototype, "CaseSense", {value:"Off"})
test := Map("test", 1, "TEST", 2)
MsgBox "CaseSense: " test.CaseSense "`n" test["test"] " " test["TEST"] ; Off, 2 and 2
```

I am only getting started with C++, so likely a better solution exists and feel free to delete this request in that case.