### PR TITLE
v1: Fixed new threads being unable to prevent a message check with Critical. (like in v2 is already done)

### DIFF
--- a/source/defines.h
+++ b/source/defines.h
@@ -884,7 +884,8 @@ inline void global_init(global_struct &g)
 	// Not sure what the optimal default is.  1 seems too low (scripts would be very slow by default):
 	g.LinesPerCycle = -1;
 	g.IntervalBeforeRest = 10;  // sleep for 10ms every 10ms
-	#define DEFAULT_PEEK_FREQUENCY 5
+	#define DEFAULT_PEEK_FREQUENCY 5 // Default peek frequency for an interruptible/non-critical thread.
+	#define UNINTERRUPTIBLE_PEEK_FREQUENCY 16 // Used during a thread's uninterruptible period to ensure it has a chance to call Critical() before MsgSleep() is called.
 	g.PeekFrequency = DEFAULT_PEEK_FREQUENCY; // v1.0.46. See comments in ACT_CRITICAL.
 	g.AllowThreadToBeInterrupted = true; // Separate from g_AllowInterruption so that they can have independent values.
 	g.UninterruptibleDuration = 0; // 0 means uninterruptibility times out instantly.  Some callers may want this so that this "g" can be used to launch other threads (e.g. threadless callbacks) using 0 as their default.

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -11892,7 +11892,10 @@ ResultType Line::ExecUntil(ExecUntilMode aMode, ExprTokenType *aResultToken, Lin
 			// THIS SECTION DOES NOT CHECK g.ThreadStartTime because that only needs to be
 			// checked on demand by callers of IsInterruptible().
 			if (g.UninterruptedLineCount > g_script.mUninterruptedLineCountMax) // See above.
+			{
 				g.AllowThreadToBeInterrupted = true;
+				g.PeekFrequency = DEFAULT_PEEK_FREQUENCY;
+			}
 			else
 				// Incrementing this unconditionally makes it a cruder measure than g.LinesPerCycle,
 				// but it seems okay to be less accurate for this purpose:
@@ -15248,7 +15251,7 @@ __forceinline ResultType Line::Perform() // As of 2/9/2009, __forceinline() redu
 		// DON'T GO TOO HIGH because this setting reduces response time for ALL messages, even those that
 		// don't launch script threads (especially painting/drawing and other screen-update events).
 		// Some hardware has a tickcount granularity of 15 instead of 10, so this covers more variations.
-		DWORD peek_frequency_when_critical_is_on = 16; // Set default.  See below.
+		DWORD peek_frequency_when_critical_is_on = UNINTERRUPTIBLE_PEEK_FREQUENCY; // Set default.  See below.
 		// v1.0.48: Below supports "Critical 0" as meaning "Off" to improve compatibility with A_IsCritical.
 		// In fact, for performance, only the following are no recognized as turning on Critical:
 		//     - "On"


### PR DESCRIPTION
Fixed new threads being unable to prevent a message check with Critical. (like in v2 is already done)