### PR TITLE
Format x86call.asm

### DIFF
--- a/source/x86call.asm
+++ b/source/x86call.asm
@@ -26,17 +26,17 @@ DynaCall proc cargs:dword, pargs:dword, pfn:dword, opt:dword
 over:
     call pfn
     
-	ret
+    ret
 DynaCall endp
 
 GetFloatRetval proc
-	; Nothing is actually done here - we just declare the appropriate return type in C++.
-	ret
+    ; Nothing is actually done here - we just declare the appropriate return type in C++.
+    ret
 GetFloatRetval endp
 
 GetDoubleRetval proc
-	; See above.
-	ret
+    ; See above.
+    ret
 GetDoubleRetval endp
 
 end

--- a/source/x86call.asm
+++ b/source/x86call.asm
@@ -1,4 +1,3 @@
-
 .model flat, C
 .code
 


### PR DESCRIPTION
I have formatted the file `source/x86call.asm` by doing the following:
- Removed a new line from the the start of the file
- Converted tabs to spaces to keep consistency within the file