### PR TITLE
v2.1: Implemented callback for SendMessage

### DIFF
--- a/source/lib/functions.h
+++ b/source/lib/functions.h
@@ -246,7 +246,7 @@ md_func_v(SendInput, (In, String, Keys))
 md_func(SendLevel, (In, Int32, Level), (Ret, Int32, RetVal))
 
 #undef SendMessage
-md_func_x(SendMessage, ScriptSendMessage, FResult, (In, UInt32, Msg), (In_Opt, Variant, wParam), (In_Opt, Variant, lParam), MD_CONTROL_ARGS_OPT, (In_Opt, Int32, Timeout), (Ret, UIntPtr, RetVal))
+md_func_x(SendMessage, ScriptSendMessage, FResult, (In, UInt32, Msg), (In_Opt, Variant, wParam), (In_Opt, Variant, lParam), MD_CONTROL_ARGS_OPT, (In_Opt, Variant, Timeout), (Ret, UIntPtr, RetVal))
 
 md_func(SendMode, (In, String, Mode), (Ret, Variant, RetVal))
 md_func_v(SendPlay, (In, String, Keys))

--- a/source/lib/win.cpp
+++ b/source/lib/win.cpp
@@ -1329,7 +1329,7 @@ static FResult PostSendMessage(UINT aMsg, ExprTokenType *aWParam, ExprTokenType 
 		}
 	}
 
-	DWORD_PTR dwResult = 0;
+	DWORD_PTR dwResult;
 	if (aSendRetVal)
 	{
 		IObject* aFunc = nullptr;
@@ -1340,6 +1340,7 @@ static FResult PostSendMessage(UINT aMsg, ExprTokenType *aWParam, ExprTokenType 
 			if (fr != OK)
 				return fr;
 			successful = SendMessageCallback(control_window, aMsg, (WPARAM)param[0], (LPARAM)param[1], (SENDASYNCPROC)&SendMessageCallbackProc, (ULONG_PTR)aFunc);
+			dwResult = successful;
 			if (successful)
 				aFunc->AddRef(); // potential memory leak if the callback function is never called
 		}


### PR DESCRIPTION
This pull request implements the use of a callback function with SendMessage to get the result asynchronously. This is done with the use of SendMessageCallback in PostSendMessage in addition to SendMessageTimeout. 

The user defined callback function (hereby referred to as aFunc) is passed via the timeout argument. This is safe to use because SendMessageCallback doesn't use a timeout, and the previous version of SendMessage didn't allow non-integer types for the timeout argument. Thus this change should be backwards-compatible.
Because aTimeout is now of type ExprTokenType not optl<int>, TypeErrors are not automatically thrown any more for invalid argument types. I opted to default to the 5000ms timeout in case of strings and floats, but additional checks for them could be implemented.

SendMessageCallbackProc is used as an interim callback function that is passed into SendMessageCallback, and the pointer to aFunc is passed via the dwData argument. SendMessageCallbackProc is used because I couldn't figure out how to use aFunc directly with SendMessageCallback, if it even is possible. The loss of the dwData argument isn't important for the user, because it's trivial to replace using a BoundFunc.
Alternatively I considered using CallbackCreate and returning the created pointer with the SendMessage call, but that would require the user to explicitly use CallbackFree inside the callback function. That would be less convenient than the implementation proposed in this PR.

This implementation uses `aFunc->AddRef();` and releases in SendMessageCallbackProc. This theoretically creates a possibility for a memory leak if the callback function is never called, but that risk should be negligible if the SendMessageCallback call is successful. Alternatively the obligation to keep aFunc alive could be passed to the user instead, but I couldn't figure out how to do that.

**Example**
Receiver.ahk
```
#Requires AutoHotkey v2.0

MsgNum := DllCall("RegisterWindowMessage", "Str", "AHKSendMessageCallback")
OnMessage(MsgNum, SendMessageReceiver)
Persistent()

SendMessageReceiver(wParam, lParam, msg, hwnd) {
    Loop {
        ib := InputBox("Script with hWnd " hwnd " sent message:`n`nwParam: " wParam "`nlParam: " lParam "`n`nReply:", "Message")
        if ib.Result = "Cancel"
            return 0
        else if !IsInteger(IB.Value)
            MsgBox "The reply can only be a number", "Error"
        else
            return IB.Value
    }
}
```

Sender.ahk
```
#Requires AutoHotkey v2.0
DetectHiddenWindows 1 ; Receiver.ahk is windowless

receiverhWnd := WinExist("Receiver.ahk ahk_class AutoHotkey")
MsgNum := DllCall("RegisterWindowMessage", "Str", "AHKSendMessageCallback")
reply := SendMessage(MsgNum, 123, -456,, receiverhWnd,,,, SendMessageCallback)
Persistent()

SendMessageCallback(hWnd, msg, result) {
	MsgBox("Callback result:`nhWnd: " hWnd "`nmsg: " msg "`nresult: " result)
}
```

I'm not quite sure how useful this addition would even be though, because SendMessageCallback can also be rather easily used via a DllCall (`DllCall("SendMessageCallback", "ptr", receiverHwnd, "uint", MsgNum, "ptr", 123, "ptr", -456, "ptr", CallbackCreate(SendMessageCallback), "ptr", 0)`), which compared to this PR is only marginally harder to use and necessitates the additional use of CallbackFree. Since I would consider using SendMessage with a callback an advanced technique and advanced users should know how to use a simple DllCall anyway, then implementing this PR may not be worth it? Although the same could be said for the regular SendMessage...