### PR TITLE
v2.1: Implements A_HotstringRecognizer

### DIFF
--- a/source/lib/vars.cpp
+++ b/source/lib/vars.cpp
@@ -489,6 +489,23 @@ BIV_DECL_W(BIV_Hotkey_Set)
 		g_HotkeyModifierTimeout = value;
 }
 
+BIV_DECL_R(BIV_HotstringRecognizer)
+{
+	wcscpy(_f_retval_buf, g_HSBuf);
+	_f_return_p(_f_retval_buf, g_HSBufLength);
+}
+
+BIV_DECL_W(BIV_HotstringRecognizer_Set)
+{
+	auto value = BivRValueToString();
+	auto size = wcslen(value);
+	if (size > (HS_BUF_SIZE - 1)) // Avoid overflow
+		_f_throw_value(ERR_INVALID_LENGTH);
+	wcscpy(g_HSBuf, value);
+	g_HSBufLength = size;
+	g_HShwnd = GetForegroundWindow(); // Also reset active window
+}
+
 BIV_DECL_R(BIV_MenuMaskKey)
 {
 	if (!g_MenuMaskKeyVK && !g_MenuMaskKeySC)

--- a/source/lib/vars.cpp
+++ b/source/lib/vars.cpp
@@ -498,10 +498,10 @@ BIV_DECL_R(BIV_HotstringRecognizer)
 BIV_DECL_W(BIV_HotstringRecognizer_Set)
 {
 	auto value = BivRValueToString();
-	auto size = wcslen(value);
-	if (size > (HS_BUF_SIZE - 1)) // Avoid overflow
-		_f_throw_value(ERR_INVALID_LENGTH);
-	wcscpy(g_HSBuf, value);
+	auto len = wcslen(value);
+	auto size = min(len, HS_BUF_SIZE - 1); // Avoid overflow
+	wcsncpy(g_HSBuf, &value[len-size], size);
+	g_HSBuf[size] = '\0';
 	g_HSBufLength = size;
 	g_HShwnd = GetForegroundWindow(); // Also reset active window
 }

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -185,6 +185,7 @@ VarEntry g_BIV_A[] =
 	A_w(FileEncoding),
 	A_wx(HotkeyInterval, BIV_Hotkey, BIV_Hotkey_Set),
 	A_wx(HotkeyModifierTimeout, BIV_Hotkey, BIV_Hotkey_Set),
+	A_w(HotstringRecognizer),
 	A_x(Hour, BIV_DateTime),
 	A_(IconFile),
 	A_w(IconHidden),

--- a/source/script.h
+++ b/source/script.h
@@ -3168,6 +3168,7 @@ BIV_DECL_RW(BIV_SendMode);
 BIV_DECL_RW(BIV_SendLevel);
 BIV_DECL_RW(BIV_StoreCapsLockMode);
 BIV_DECL_RW(BIV_Hotkey);
+BIV_DECL_RW(BIV_HotstringRecognizer);
 BIV_DECL_R (BIV_KeybdHookInstalled);
 BIV_DECL_R (BIV_MouseHookInstalled);
 BIV_DECL_RW(BIV_MenuMaskKey);


### PR DESCRIPTION
### Introduction
This PR gives access to the `g_HSBuf` internal variable, allowing read-write to the hotstring recognizer. It was mainly created from the desire to determine the hotstring trigger word case conformity, eg whether `::btw::` was triggered by `btw`, `Btw` or `BTW`. An alternative solution would be to implement something like `A_LastHotstringTrigger`, but this way seems more flexible, as it also provides a way to debug hotstrings more easily, and perhaps implement custom methods around hotstrings (eg restoring the hotstring recognizer after the user tabs to another window, interacts with it, and then tabs back to the old one).

### Documentation
`A_HotstringRecognizer`
Can be used to get or set the hotstring recognizer. If the assigned string is longer than 89 characters then it's automatically trimmed from the beginning to fit 89 characters.

### Example
```
F1::ToolTip '"' A_HotstringRecognizer '"'
F2::A_HotstringRecognizer := "Btw"
:B0:btw::
{
	MsgBox 'ThisHotkey: "' ThisHotkey '"`nA_HotstringRecognizer: "' A_HotstringRecognizer '"'
}
```
F1 displays the current recognizer state
F2 sets it to `Btw`, after which pressing spacebar will trigger the hotstring.