### PR TITLE
Catch MouseGetPos failure

### DIFF
--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -1325,7 +1325,8 @@ VOID CALLBACK DerefTimeout(HWND hWnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime)
 bif_impl FResult MouseGetPos(int *aX, int *aY, ResultToken *aParent, ResultToken *aChild, optl<int> aFlag)
 {
 	POINT point;
-	GetCursorPos(&point);  // Realistically, can't fail?
+	if (GetCursorPos(&point))  // fails when locked or sleeping
+		return GetLastError();
 
 	POINT origin = {0};
 	CoordToScreen(origin, COORD_MODE_MOUSE);

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -1325,7 +1325,7 @@ VOID CALLBACK DerefTimeout(HWND hWnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime)
 bif_impl FResult MouseGetPos(int *aX, int *aY, ResultToken *aParent, ResultToken *aChild, optl<int> aFlag)
 {
 	POINT point;
-	if (GetCursorPos(&point))  // fails when locked or sleeping
+	if (!GetCursorPos(&point))  // fails when locked or sleeping
 		return FR_E_WIN32;
 
 	POINT origin = {0};

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -1326,7 +1326,7 @@ bif_impl FResult MouseGetPos(int *aX, int *aY, ResultToken *aParent, ResultToken
 {
 	POINT point;
 	if (GetCursorPos(&point))  // fails when locked or sleeping
-		return GetLastError();
+		return FR_E_WIN32;
 
 	POINT origin = {0};
 	CoordToScreen(origin, COORD_MODE_MOUSE);


### PR DESCRIPTION
GetCursorPos() can fail when locked or suspending.

For example, you will see a tooltip from the following script if you hit the sleep button on your keyboard (and resume).

```ahk
CoordMode("Mouse", "Screen")
Persistent(true)
registerpower()
return

registerpower() {
  failed := DllCall(
    "ole32\CLSIDFromString",
    ; https://learn.microsoft.com/windows/win32/power/power-setting-guids#GUID_CONSOLE_DISPLAY_STATE
    "WStr", "{6FE69556-704A-47A0-8F24-C28D936FDA47}",
    "Ptr", CLSID := Buffer(16),
    "UInt"
  )
  if (failed) {
    throw (Error("CLSIDFromString failed. Error: " . Format("{:#x}", failed)))
  }
  PSN := DllCall("RegisterPowerSettingNotification", "Ptr", A_ScriptHwnd, "Ptr", CLSID, "UInt", 0, "Ptr")
  if (!PSN) {
    throw (OSError(A_LastError, -1, "RegisterPowerSettingNotification"))
  }
  OnExit(unregister.Bind("PowerSetting", PSN))
  Sleep(1)
  OnMessage(0x218, _WM_POWERBROADCAST)
}

_WM_POWERBROADCAST(wParam, lParam, msg, hwnd) {
  static oldpower := 1
  static wins := Map()

  Critical(1000)
  if (wParam = 0x8013) { ; PBT_POWERSETTINGCHANGE
      newpower := NumGet(lParam, 20, "UChar") ; 1 (on) -> 2 (dim) -> 0 (off) -> 1 (on)
      if (oldpower and !newpower) {
        ; MouseGetPos(&mx, &my) returns (bogus big number, 0) in POWERSETTINGCHANGE just before APMSUSPEND
        ; because GetCursorPos() fails with ACCESS_DENIED but AutoHotkey ignores the failure
        if (!DllCall("GetCursorPos", "Ptr", lppoint := Buffer(8, 0))) {
          if(DllCall("GetLastError", "UInt") = 5) {
            ToolTip("GetCursorPos: Access Denied")
            return
          }
        }
      }
      oldpower := newpower
  }
  return true
}

unregister(kind, hPowerNotify, *) {
  DllCall("Unregister" . kind . "Notification", "Ptr", hPowerNotify)
  return 0
}
```

Maybe related to WinLogon desktop?
https://learn.microsoft.com/en-us/windows/win32/winstation/desktops