### PR TITLE
Experimental: added disableWindowFiltering to manifest

### DIFF
--- a/source/resources/AutoHotkey.exe.manifest
+++ b/source/resources/AutoHotkey.exe.manifest
@@ -63,4 +63,11 @@
     </v3:requestedPrivileges>
   </v3:security>
 </v3:trustInfo>
+<asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+	<asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+		<!-- This allows enumerating immersive (UWP / Microsoft Store) windows. 
+		     Additional reading: https://docs.microsoft.com/en-us/windows/desktop/sbscs/application-manifests#disableWindowFiltering -->
+		<disableWindowFiltering xmlns="http://schemas.microsoft.com/SMI/2011/WindowsSettings">true</disableWindowFiltering>
+	</asmv3:windowsSettings>
+</asmv3:application>
 </assembly>


### PR DESCRIPTION
EnumWindows by default skips over some UWP / Microsoft Store apps, making them very hard to detect with AutoHotkey. Example: [To Do app](https://www.autohotkey.com/boards/viewtopic.php?p=506799). FindWindowEx can be used as a work-around, but is very inconvenient to use.

Adding [disableWindowFiltering](https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests#disableWindowFiltering) to the package manifest disables the filtering implemented by Microsoft and allows EnumWindows to detect the previously undetectable top-level windows. 

The following example is for detecting the Notification Centre window in Windows 11 that appears when the time/date is clicked in the taskbar:
```
Loop {
	ToolTip WinExist("Notification Centre") ; if testing in Windows 10, replace with "Date and Time Information"
	Sleep 100
}
```

I have no idea what side effects this will cause, but certainly it would break some previous scripts. However, it seems like a *very* useful change.