### PR TITLE
v2.1: Added A_ThreadId and a thread id parameter to Exit()

### DIFF
--- a/source/application.cpp
+++ b/source/application.cpp
@@ -1859,6 +1859,7 @@ void InitNewThread(int aPriority, bool aSkipUninterruptible, bool aIncrementThre
 	global_struct &g = *::g; // Must be done AFTER the ++g above. Reduces code size and may improve performance.
 	global_clear_state(g);
 	g.Priority = aPriority;
+	g.ThreadId = ((UINT)(++g_script.mTotalThreadCount) << 12) | g_nThreads;
 
 	// If the current quasi-thread is paused, the thread we're about to launch will not be, so the tray icon
 	// needs to be checked unless the caller said it wasn't needed.  In any case, if the tray icon is already

--- a/source/application.cpp
+++ b/source/application.cpp
@@ -1859,7 +1859,7 @@ void InitNewThread(int aPriority, bool aSkipUninterruptible, bool aIncrementThre
 	global_struct &g = *::g; // Must be done AFTER the ++g above. Reduces code size and may improve performance.
 	global_clear_state(g);
 	g.Priority = aPriority;
-	g.ThreadId = ((UINT)(++g_script.mTotalThreadCount) << 12) | g_nThreads;
+	g.ThreadId = ((__int64)(++g_script.mTotalThreadCount) << 16) | g_nThreads;
 
 	// If the current quasi-thread is paused, the thread we're about to launch will not be, so the tray icon
 	// needs to be checked unless the caller said it wasn't needed.  In any case, if the tray icon is already

--- a/source/defines.h
+++ b/source/defines.h
@@ -101,6 +101,8 @@ GNU General Public License for more details.
 #define GET_BIT(buf,n) (((buf) & (1 << (n))) >> (n))
 #define SET_BIT(buf,n,val) ((val) ? ((buf) |= (1<<(n))) : (buf &= ~(1<<(n))))
 
+#define THREADID_INDEX 0xFFF
+
 // FAIL = 0 to remind that FAIL should have the value zero instead of something arbitrary
 // because some callers may simply evaluate the return result as true or false
 // (and false is a failure):
@@ -910,7 +912,9 @@ struct ScriptThreadState
 	int UninterruptedLineCount; // Stored as a g-struct attribute in case OnExit func interrupts it while uninterruptible.
 	int UninterruptibleDuration; // Must be int to preserve negative values found in g_script.mUninterruptibleTime.
 	DWORD ThreadStartTime;
-	UINT ThreadId; // Lower 12 bits contain the 1-based index of the thread in g_array, higher 20 bits contain g_script.mTotalThreadCount at the time of creation (overflows after 1048576 threads).
+
+	UINT ThreadId; // Lower 12 bits contains the value of g_nThreads, higher 20 bits contain g_script.mTotalThreadCount at the time of creation (overflows after 1048576 threads).
+	bool IsMarkedEarlyExit; // Set by Exit() if a thread id is provided to terminate underlying threads
 
 	bool IsPaused;
 	bool MsgBoxTimedOut; // Meaningful only while a MsgBox call is in progress.

--- a/source/defines.h
+++ b/source/defines.h
@@ -1041,7 +1041,7 @@ inline void global_init(global_struct &g)
 {
 	global_clear_state(g);
 	global_set_defaults(g);
-	g.ThreadId = 1; // Set the auto-execute thread id to 1
+	g.ThreadId = (1 << 16) | 1; // Set the auto-execute thread id to 65537
 }
 
 

--- a/source/defines.h
+++ b/source/defines.h
@@ -910,6 +910,7 @@ struct ScriptThreadState
 	int UninterruptedLineCount; // Stored as a g-struct attribute in case OnExit func interrupts it while uninterruptible.
 	int UninterruptibleDuration; // Must be int to preserve negative values found in g_script.mUninterruptibleTime.
 	DWORD ThreadStartTime;
+	UINT ThreadId; // Lower 12 bits contain the 1-based index of the thread in g_array, higher 20 bits contain g_script.mTotalThreadCount at the time of creation (overflows after 1048576 threads).
 
 	bool IsPaused;
 	bool MsgBoxTimedOut; // Meaningful only while a MsgBox call is in progress.
@@ -1036,6 +1037,7 @@ inline void global_init(global_struct &g)
 {
 	global_clear_state(g);
 	global_set_defaults(g);
+	g.ThreadId = 1; // Set the auto-execute thread id to 1
 }
 
 

--- a/source/defines.h
+++ b/source/defines.h
@@ -101,7 +101,7 @@ GNU General Public License for more details.
 #define GET_BIT(buf,n) (((buf) & (1 << (n))) >> (n))
 #define SET_BIT(buf,n,val) ((val) ? ((buf) |= (1<<(n))) : (buf &= ~(1<<(n))))
 
-#define THREADID_INDEX 0xFFF
+#define THREADID_INDEX 0xFFFF
 
 // FAIL = 0 to remind that FAIL should have the value zero instead of something arbitrary
 // because some callers may simply evaluate the return result as true or false
@@ -913,7 +913,7 @@ struct ScriptThreadState
 	int UninterruptibleDuration; // Must be int to preserve negative values found in g_script.mUninterruptibleTime.
 	DWORD ThreadStartTime;
 
-	UINT ThreadId; // Lower 12 bits contains the value of g_nThreads, higher 20 bits contain g_script.mTotalThreadCount at the time of creation (overflows after 1048576 threads).
+	__int64 ThreadId; // Lower 16 bits contains the value of g_nThreads, higher 32 bits contain g_script.mTotalThreadCount at the time of the thread creation.
 	bool IsMarkedEarlyExit; // Set by Exit() if a thread id is provided to terminate underlying threads
 
 	bool IsPaused;

--- a/source/lib/CCallback.cpp
+++ b/source/lib/CCallback.cpp
@@ -147,6 +147,9 @@ UINT_PTR CALLBACK RegisterCallbackCStub(UINT_PTR *params, char *address) // Used
 	}
 	else
 	{
+		if (!g->ThreadId)
+			g->IsMarkedEarlyExit = 1;
+
 		if (g == g_array && !g_script.mAutoExecSectionIsRunning)
 			// If the function just called used thread #0 and the AutoExec section isn't running, that means
 			// the AutoExec section definitely didn't launch or control the callback (even if it is running,

--- a/source/lib/functions.h
+++ b/source/lib/functions.h
@@ -94,7 +94,7 @@ md_func(EditPaste, (In, String, Value), MD_CONTROL_ARGS)
 md_func(EnvGet, (In, String, VarName), (Ret, String, RetVal))
 md_func(EnvSet, (In, String, VarName), (In_Opt, String, Value))
 
-md_func_x(Exit, Exit, ResultType, (In_Opt, Int32, ExitCode))
+md_func(Exit, (In_Opt, Int32, ExitCode), (In_Opt, UInt32, ThreadId), (Ret, Variant, RetVal))
 md_func_x(ExitApp, ExitApp, ResultType, (In_Opt, Int32, ExitCode))
 
 md_func(FileAppend, (In, Variant, Value), (In_Opt, String, Path), (In_Opt, String, Options))

--- a/source/lib/functions.h
+++ b/source/lib/functions.h
@@ -94,7 +94,7 @@ md_func(EditPaste, (In, String, Value), MD_CONTROL_ARGS)
 md_func(EnvGet, (In, String, VarName), (Ret, String, RetVal))
 md_func(EnvSet, (In, String, VarName), (In_Opt, String, Value))
 
-md_func(Exit, (In_Opt, Int32, ExitCode), (In_Opt, UInt32, ThreadId), (Ret, Variant, RetVal))
+md_func(Exit, (In_Opt, Int32, ExitCode), (In_Opt, Int64, ThreadId), (Ret, Variant, RetVal))
 md_func_x(ExitApp, ExitApp, ResultType, (In_Opt, Int32, ExitCode))
 
 md_func(FileAppend, (In, Variant, Value), (In_Opt, String, Path), (In_Opt, String, Options))

--- a/source/lib/vars.cpp
+++ b/source/lib/vars.cpp
@@ -554,6 +554,11 @@ BIV_DECL_R(BIV_IsSuspended)
 }
 
 
+BIV_DECL_R(BIV_ThreadId)
+{
+	_f_return_i(g->ThreadId);
+}
+
 
 BIV_DECL_R(BIV_IsCompiled)
 {

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -268,6 +268,7 @@ VarEntry g_BIV_A[] =
 	A_(Temp), // Debatably should be A_TempDir, but brevity seemed more popular with users, perhaps for heavy uses of the temp folder.,
 	A_(ThisFunc),
 	A_(ThisHotkey),
+	A_(ThreadId),
 	A_(TickCount),
 	A_x(TimeIdle, BIV_TimeIdle),
 	A_x(TimeIdleKeyboard, BIV_TimeIdle),

--- a/source/script.cpp
+++ b/source/script.cpp
@@ -1185,9 +1185,9 @@ ResultType Script::Reload(bool aDisplayErrors)
 
 
 
-bif_impl FResult Exit(optl<int> aExitCode, optl<UINT> aThreadId, ResultToken& aResultToken)
+bif_impl FResult Exit(optl<int> aExitCode, optl<INT64> aThreadId, ResultToken& aResultToken)
 {
-	UINT uThreadId = aThreadId.value_or(g->ThreadId); // Default is the currently running thread
+	INT64 uThreadId = aThreadId.value_or(g->ThreadId); // Default is the currently running thread
 	int nCurrentThreadIndex = g->ThreadId & THREADID_INDEX;
 	int nTargetThreadIndex = uThreadId & THREADID_INDEX;
 	aResultToken.SetValue(0); // Default return value
@@ -1200,12 +1200,12 @@ bif_impl FResult Exit(optl<int> aExitCode, optl<UINT> aThreadId, ResultToken& aR
 	if (g_script.mAutoExecSectionIsRunning)
 		--nTargetThreadIndex; 
 
-	UINT uThreadIdAtIndex = g_array[nTargetThreadIndex].ThreadId;
+	INT64 uThreadIdAtIndex = g_array[nTargetThreadIndex].ThreadId;
 	if (!uThreadIdAtIndex || g_array[nTargetThreadIndex].IsMarkedEarlyExit)
 		return OK; // The target thread has already been marked to exit
 
 	// Return 0 if the thread id at the specified index isn't the target thread, and the target thread isn't a plain index
-	if ((uThreadIdAtIndex != uThreadId) && (uThreadId >> 12))
+	if ((uThreadIdAtIndex != uThreadId) && (uThreadId >> 16))
 		return OK;
 
 	aResultToken.SetValue(uThreadIdAtIndex);

--- a/source/script.h
+++ b/source/script.h
@@ -2240,6 +2240,7 @@ public:
 	MsgMonitorList mOnExit, mOnClipboardChange, mOnError; // Event handlers for OnExit(), OnClipboardChange() and OnError().
 	bool mOnClipboardChangeIsRunning;
 	int mPendingExitCode = 0;
+	DWORD mTotalThreadCount = 1;  // Counts the number of threads created in total during the execution of the script
 
 	ScriptTimer *mFirstTimer, *mLastTimer;  // The first and last script timers in the linked list.
 	UINT mTimerCount, mTimerEnabledCount;
@@ -2498,6 +2499,7 @@ BIV_DECL_RW(BIV_MenuMaskKey);
 BIV_DECL_R (BIV_IsPaused);
 BIV_DECL_R (BIV_IsCritical);
 BIV_DECL_R (BIV_IsSuspended);
+BIV_DECL_R (BIV_ThreadId);
 BIV_DECL_R (BIV_IsCompiled);
 BIV_DECL_RW(BIV_FileEncoding);
 BIV_DECL_RW(BIV_RegView);


### PR DESCRIPTION
### `A_ThreadId`

`A_ThreadId` returns a nearly unique id for the running pseudo-thread. It can be used to differentiate pseudo-threads (eg by using a Map object), or with `Exit()` to terminate a specific thread (see down below for explanations). The auto-execute section id is always 65537 (`(1 << 16) | 1`). 

Implementation: `A_ThreadId` is a 64-bit integer, where the lower 16 bits store the number of active threads, and the next 32 bits is the number of total threads created at the moment of the current pseudo-thread creation. Upmost 16 bits are reserved for future applications. 
64 bits was chosen over 32 bits because it drastically increases the chance that the id is unique: with 32 bits I would've split it into 20 and 12 bits, which would overflow after ~1 million pseudo-threads, a number which is feasibly reached. Additionally the bit arithmetic looked uglier: `A_ThisThread & 0xFFF` instead of `A_ThisThread & 0xFFFF`. Furthermore, as a 32-bit integer overflow is highly unlikely during the lifetime of a script, it can be used to differentiate newer threads from older ones. 


### `Exit [ExitCode, ThreadId]`

Additionally this PR modifies `Exit [ExitCode]` to `Exit [ExitCode, ThreadId]` and adds a return value to it. `ThreadId` may be either a specific thread id returned by `A_ThisThread`, or an index number in the current stack of pseudo-threads. For example, `Exit(, 1)` marks the first (oldest) pseudo-thread in the stack for termination; `Exit(, (A_ThisThread & 0xFFFF) - 1` marks the underlying thread; `Exit(, (1 << 16) | 1)` marks the auto-execute section. A thread marked for termination will exit once the stack unwinds to it, the thread resumes execution, and starts executing the next line. This means that if it was interrupted during a chained expression, then the last parts of the expression will still execute. Such behavior was chosen to limit the number of checks for whether to stop thread execution, and gives a bit more flexibility to the user: if some action should unconditionally be executed after another, then the user can chain it in an expression instead of a new line to prevent another thread from stopping it.
The behavior of `Exit [ExitCode]` is almost unchanged and causes the running thread to immediately exit, handling __delete and *finally* afterwards if needed. One exception is that calling `DllCall(CallbackCreate((*) => Exit(), "F"))` will now cause the thread which called `DllCall` to exit, because Fast mode doesn't create a new thread.

`Exit` returns the terminated thread id, or 0 if no thread was terminated. 

Some test cases:
1. 
```
try {
	Exit
} catch {
} finally {
    MsgBox "Reached"
}
MsgBox "Not reached, script terminates, exit code = 0"
```


2. 
```
Exit(1)
MsgBox "Not reached, script terminates, exit code = 1"
```

3. 
```
SetTimer((*) => Exit(1, 1), -1000) ; Auto-execute section is exited in 1 second, exit code = 1

Loop {
	ToolTip "Thread is running: " A_ThreadId
	Sleep 100
}
```

4.
```
SetTimer((*) { 
	__ := {}.DefineProp("__Delete", {call:(*) => MsgBox("Delete is called, script exits")})
	Exit()
}, -1000)
```

5. 
```
SetTimer((*) { 
	DllCall(CallbackCreate(MyExit))
	MsgBox "This thread is not exited"
}, -1000)

MyExit() => Exit()
```

6.
```
SetTimer((*) { 
	DllCall(CallbackCreate(MyExit, "F"))
	MsgBox "This is not reached, because F mode is used and the code is ran in the existing thread"
}, -1000)

MyExit() => Exit()
```

7. 
```
SetTimer((*) { 
	DllCall(CallbackCreate(MyExit, "F"))
	MsgBox "This is not reached even with multiple F mode threads"
}, -1000)

MyExit() => (DllCall(CallbackCreate(MyExit2, "F")), MsgBox("This is still evaluated, then the script exits"))
MyExit2() => Exit()
```

8. 
```
F1::{
	MsgBox "Press F1 first, then press F2"
	MsgBox "This is not reached"
}

F2::{
	MsgBox "This kills the underlying thread with id " Exit(, (A_ThreadId & 0xFFFF) - 1)
}
```