### PR TITLE
Optimized DllCall with param count <= 4 for x64

### DIFF
--- a/source/lib/DllCall.cpp
+++ b/source/lib/DllCall.cpp
@@ -78,7 +78,7 @@ struct DYNAPARM
 
 #ifdef _WIN64
 // This function was borrowed from http://dyncall.org/
-extern "C" UINT_PTR PerformDynaCall(size_t stackArgsSize, DWORD_PTR* stackArgs, DWORD_PTR* regArgs, void* aFunction);
+extern "C" UINT_PTR PerformDynaCall(size_t stackArgsCount, DWORD_PTR* stackArgs, DWORD_PTR* regArgs, void* aFunction);
 
 // Retrieve a float or double return value.  These don't actually do anything, since the value we
 // want is already in the xmm0 register which is used to return float or double values.
@@ -215,7 +215,7 @@ void DynaCall(void *aFunction, DYNAPARM aParam[], int aParamCount, DWORD &aExcep
 	int params_left = aParamCount, i = 0, r = 0;
 	DWORD_PTR regArgs[4];
 	DWORD_PTR* stackArgs = NULL;
-	size_t stackArgsSize = 0;
+	size_t stackArgsCount = 0;
 
 	if (!register_return)
 	{
@@ -230,8 +230,8 @@ void DynaCall(void *aFunction, DYNAPARM aParam[], int aParamCount, DWORD &aExcep
 	// Copy the remaining parameters
 	if(params_left)
 	{
-		stackArgsSize = params_left * 8;
-		stackArgs = (DWORD_PTR*) _alloca(stackArgsSize);
+		stackArgsCount = params_left;
+		stackArgs = (DWORD_PTR*) _alloca(stackArgsCount*sizeof(DWORD_PTR));
 
 		for(int i = 0; i < params_left; i ++)
 			stackArgs[i] = DynaParamToElement(aParam[i+4]);
@@ -240,7 +240,7 @@ void DynaCall(void *aFunction, DYNAPARM aParam[], int aParamCount, DWORD &aExcep
 	// Call the function.
 	__try
 	{
-		Res.UIntPtr = PerformDynaCall(stackArgsSize, stackArgs, regArgs, aFunction);
+		Res.UIntPtr = PerformDynaCall(stackArgsCount, stackArgs, regArgs, aFunction);
 	}
 	__except(EXCEPTION_EXECUTE_HANDLER)
 	{

--- a/source/libx64call/x64call.asm
+++ b/source/libx64call/x64call.asm
@@ -44,6 +44,9 @@ PerformDynaCall proc frame
 	; r8:  pointer to arguments to be passed by registers
 	; r9:  target function pointer
 
+	test rcx, rcx
+	jz save_func_address
+
 	; Setup stack frame by subtracting the size of the arguments
 	sub rsp, rcx
 
@@ -54,13 +57,14 @@ PerformDynaCall proc frame
 	sub rsi, rax
 	sub rsp, rsi
 
-	; Save function address
-	mov rax, r9
-
 	; Copy the stack arguments
 	mov rsi, rdx ; let rsi point to the arguments.
 	mov rdi, rsp ; store pointer to beginning of stack arguments in rdi (for rep movsb).
 	rep movsb    ; @@@ should be optimized (e.g. movq)
+
+save_func_address:
+	; Save function address
+	mov rax, r9
 
 	; Copy the register arguments
 	mov rcx,  qword ptr[r8   ] ; copy first four arguments to rcx, rdx, r8, r9 and xmm0-xmm3.

--- a/source/libx64call/x64call.asm
+++ b/source/libx64call/x64call.asm
@@ -39,7 +39,7 @@ PerformDynaCall proc frame
 	.endprolog
 
 	; Arguments:
-	; rcx: size of arguments to be passed via stack
+	; rcx: number of QWORDs to be passed as arguments via stack
 	; rdx: pointer to arguments to be passed via stack
 	; r8:  pointer to arguments to be passed by registers
 	; r9:  target function pointer
@@ -47,20 +47,19 @@ PerformDynaCall proc frame
 	test rcx, rcx
 	jz save_func_address
 
-	; Setup stack frame by subtracting the size of the arguments
-	sub rsp, rcx
-
 	; Ensure the stack is 16-byte aligned
 	mov rax, rcx
-	and rax, 15
-	mov rsi, 16
-	sub rsi, rax
-	sub rsp, rsi
+	and rax, 1
+	add rax, rcx
+	shl rax, 3
+
+	; Setup stack frame by subtracting the size of the arguments
+	sub rsp, rax
 
 	; Copy the stack arguments
 	mov rsi, rdx ; let rsi point to the arguments.
 	mov rdi, rsp ; store pointer to beginning of stack arguments in rdi (for rep movsb).
-	rep movsb    ; @@@ should be optimized (e.g. movq)
+	rep movsq
 
 save_func_address:
 	; Save function address

--- a/source/libx64call/x64stub.asm
+++ b/source/libx64call/x64stub.asm
@@ -14,14 +14,14 @@ RegisterCallbackAsmStub proc frame
 .allocstack 8*5
 .endprolog
 
-	; For the 'mov' further below
-	add rsp, 8
+	; For the 'push' further below
+	add rsp, 8*5
 
 	; Save the parameters in the spill area for consistency
-	mov qword ptr[rsp+8*0], rcx
-	mov qword ptr[rsp+8*1], rdx
-	mov qword ptr[rsp+8*2], r8
-	mov qword ptr[rsp+8*3], r9
+	push r9
+	push r8
+	push rdx
+	push rcx
 
 	; Set parameters for the upcoming function call
 	mov rcx, rsp ; UINT_PTR* aParams


### PR DESCRIPTION
If there is no stack arguments we can jump over ineffective code that copying stack arguments.
Tested on:
```
DllCall(CallbackCreate(TestFunc1,, 5), "Ptr",228, "Str","Test string", "Ptr",1, "Ptr",1, "Ptr",1337)

DllCall(CallbackCreate(TestFunc2,, 2), "Ptr",228, "Str","Test string")


TestFunc1(param1, param2, param3, param4, param5) {

	MsgBox('param1`t=`t' param1 '`nparam2`t=`t"' StrGet(param2) '"`nparam5`t=`t' param5 )
}

TestFunc2(param1, param2) {

	MsgBox('param1`t=`t' param1 '`nparam2`t=`t"' StrGet(param2))
}
```