### PR TITLE
CallbackCreateSync

### DIFF
--- a/source/hook.h
+++ b/source/hook.h
@@ -41,6 +41,7 @@ enum UserMessages {AHK_HOOK_HOTKEY = WM_USER, AHK_HOTSTRING, AHK_USER_MENU, AHK_
 	, AHK_HOOK_SYNC // For WaitHookIdle().
 	, AHK_INPUT_END, AHK_INPUT_KEYDOWN, AHK_INPUT_CHAR, AHK_INPUT_KEYUP
 	, AHK_HOOK_SET_KEYHISTORY
+	, AHK_INVOKE
 };
 // NOTE: TRY NEVER TO CHANGE the specific numbers of the above messages, since some users might be
 // using the Post/SendMessage commands to automate AutoHotkey itself.  Here is the original order

--- a/source/script2.cpp
+++ b/source/script2.cpp
@@ -509,6 +509,13 @@ LRESULT CALLBACK MainWindowProc(HWND hWnd, UINT iMsg, WPARAM wParam, LPARAM lPar
 			}
 		}
 		break;
+	case AHK_INVOKE:
+		{
+			auto function = (LRESULT(*)(PVOID, PVOID))wParam;
+			PVOID *params = (PVOID *)lParam;
+			return function(params[0], params[1]);
+		}
+		break;
 
 #ifdef CONFIG_DEBUGGER
 	case AHK_CHECK_DEBUGGER:


### PR DESCRIPTION
CallbackCreate - add '$' option to create callback that is safe to pass to multithreaded APIs. If callback thread not equal to AHK thread execution will be synchronized via SendMessage invoke.