### PR TITLE
cscript //E:JScript (specify Engine for misconfigured `HKEY_CLASSES_ROOT\.js`)

### DIFF
--- a/AutoHotkeyx.vcxproj
+++ b/AutoHotkeyx.vcxproj
@@ -351,7 +351,7 @@
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="source\resources\AutoHotkey.exe.manifest">
-      <Command>cscript.exe //NoLogo "$(SolutionDir)source\scripts\minman.js" "%(FullPath)" "$(SolutionDir)temp\AutoHotkey.exe.manifest"</Command>
+      <Command>cscript.exe //E:JScript //NoLogo "$(SolutionDir)source\scripts\minman.js" "%(FullPath)" "$(SolutionDir)temp\AutoHotkey.exe.manifest"</Command>
       <Outputs>$(SolutionDir)temp\AutoHotkey.exe.manifest</Outputs>
       <SubType>Designer</SubType>
     </CustomBuild>


### PR DESCRIPTION
I had a misconfigured `HKEY_CLASSES_ROOT\.js` `(Default)` set to `JavaScript` instead of `JSFile`
specifying the Engine would allow compiling even with a misconfigured file assoc

for example: associating `.js` with `notepad++` would make it misconfigured

```
There is no script engine for file extension ".js"
```