### PR TITLE
Update Gui.ListView.cpp

### DIFF
--- a/source/lib/Gui.ListView.cpp
+++ b/source/lib/Gui.ListView.cpp
@@ -751,11 +751,10 @@ FResult GuiControlType::LV_SetImageList(UINT_PTR aImageListID, optl<int> aIconTy
 	int list_type;
 	if (aIconType.has_value())
 		list_type = aIconType.value();
-	else // Auto-detect large vs. small icons based on the actual icon size in the image list.
+	else // Auto-detect the list type based on the view mode.
 	{
-		int cx, cy;
-		ImageList_GetIconSize(himl, &cx, &cy);
-		list_type = (cx > GetSystemMetrics(SM_CXSMICON)) ? LVSIL_NORMAL : LVSIL_SMALL;
+		DWORD view_mode = ListView_GetView(hwnd);
+		list_type = ((view_mode == LV_VIEW_ICON) || (view_mode == LV_VIEW_TILE)) ? LVSIL_NORMAL : LVSIL_SMALL;
 	}
 	aRetVal = (UINT_PTR)ListView_SetImageList(hwnd, himl, list_type);
 	return OK;


### PR DESCRIPTION
Fix to a counter-intuitive issue where a user has to create a large-icon image list and assign it explicitly as small-icon image list in order for the ListView to show large icons. See [this post](https://www.autohotkey.com/boards/viewtopic.php?f=82&t=140179) for more details on the topic.