### PR TITLE
Fix FileSetTime: use FILE_WRITE_ATTRIBUTES

### DIFF
--- a/source/lib/file.cpp
+++ b/source/lib/file.cpp
@@ -914,14 +914,11 @@ BOOL FileSetTimeCallback(LPCTSTR aFilename, WIN32_FIND_DATA &aFile, void *aCallb
 {
 	HANDLE hFile;
 	// Open existing file.
-	// FILE_FLAG_NO_BUFFERING might improve performance because all we're doing is
-	// changing one of the file's attributes.  FILE_FLAG_BACKUP_SEMANTICS must be
-	// used, otherwise changing the time of a directory under NT and beyond will
-	// not succeed.  Win95 (not sure about Win98/Me) does not support this, but it
-	// should be harmless to specify it even if the OS is Win95:
-	hFile = CreateFile(aFilename, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE
+	// FILE_WRITE_ATTRIBUTES is sufficient for SetFileTime().
+	// FILE_FLAG_BACKUP_SEMANTICS must be used, otherwise changing the time of a directory will fail.
+	hFile = CreateFile(aFilename, FILE_WRITE_ATTRIBUTES, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE
 		, (LPSECURITY_ATTRIBUTES)NULL, OPEN_EXISTING
-		, FILE_FLAG_NO_BUFFERING | FILE_FLAG_BACKUP_SEMANTICS, NULL);
+		, FILE_FLAG_BACKUP_SEMANTICS, NULL);
 	if (hFile == INVALID_HANDLE_VALUE)
 	{
 		g->LastError = GetLastError();


### PR DESCRIPTION
Problem
-------
FileSetTime opens the target with GENERIC_WRITE. On Windows this can fail with ERROR_ACCESS_DENIED (5) in cases where write-data is denied but updating timestamps is still allowed. This is also broader access than required.

Fix
---
Open the file/directory with FILE_WRITE_ATTRIBUTES (the access required by SetFileTime) instead of GENERIC_WRITE.
Also add FILE_SHARE_DELETE to reduce sharing-related failures, and remove FILE_FLAG_NO_BUFFERING since no I/O is performed.
Keep FILE_FLAG_BACKUP_SEMANTICS so directories continue to work.

Repro
-----
1) Create a file and make it read-only (or otherwise deny write-data access).
2) Call FileSetTime(...) on that file.
Before: may fail with (5) Access is denied.
After: succeeds.

Change
------
- source/lib/file.cpp: FileSetTimeCallback (CreateFile flags/access)