### PR TITLE
Gui.Move fix for owned windows

### DIFF
--- a/source/script_gui.cpp
+++ b/source/script_gui.cpp
@@ -520,8 +520,8 @@ FResult GuiType::Move(optl<int> aX, optl<int> aY, optl<int> aWidth, optl<int> aH
 	GetWindowRect(mHwnd, &rect);
 	rect.right -= rect.left; // Convert to width.
 	rect.bottom -= rect.top; // Convert to height.
-	if (HWND parent = GetParent(mHwnd)) // Allow for +Parent.
-		ScreenToClient(parent, (LPPOINT)&rect); // Must do this before the loop, as coord[] already contains client coords.
+	if (GetWindowLong(mHwnd, GWL_STYLE) & WS_CHILD) // Allow for +Parent.
+		ScreenToClient(GetParent(mHwnd), (LPPOINT)&rect); // Must do this before the loop, as coord[] already contains client coords.
 	if (aX.has_value())			rect.left = Scale(aX.value());
 	if (aY.has_value())			rect.top = Scale(aY.value());
 	if (aWidth.has_value())		rect.right = Scale(aWidth.value());


### PR DESCRIPTION
The following script demonstrated the problem being solved by this pull request:

```
#Requires AutoHotkey v2.0
MyGui := Gui('+Owner')
MyGui.Show('w300 h300')
Sleep 1000
MyGui.Move()
```

When the above is run, the Gui is first shown in the middle of the primary screen. A second later, the Gui is moved to another location on the screen. The move is unexpected.

The reason for this is that the source code tests for the existence of a parent window using the `GetParent` function. If one exists, the screen coordinates of the window are transformed to client coordinates and the window is moved using the new client coordinates. This works well for windows that have a parent. For owned windows, such as in the above example, this leads to the observed anomalous behavior.

The reason why it doesn't work for owned windows is that the `GetParent` function returns a non-zero value for owned windows. A more discriminating way to determine if a window has a parent (but not an owner) is to test whether the window has the `WS_CHILD` style. If the window has that style, transform the coordinates. Othwerwise, do not.
